### PR TITLE
docs(research): WOTS+ post-quantum signature feasibility study

### DIFF
--- a/docs/specs/WOTS-SIGNATURE-RESEARCH.md
+++ b/docs/specs/WOTS-SIGNATURE-RESEARCH.md
@@ -18,7 +18,7 @@ This document evaluates adding WOTS+ (Winternitz One-Time Signature Plus) suppor
 | Criterion | Finding | Verdict |
 |-----------|---------|---------|
 | Technical Feasibility | WOTS+ signature (2,144 bytes) exceeds Solana tx limit (1,232 bytes) | ❌ Blocked |
-| Compute Cost | ~5,700 CU for verification (acceptable) | ✅ OK |
+| Compute Cost | ~62,700 CU for verification (acceptable) | ✅ OK |
 | Library Availability | Limited standalone libraries, mostly SPHINCS+ wrappers | ⚠️ Partial |
 | User Demand | Marketing-driven, no urgent security need | ⚠️ Low |
 | Alternative | Winternitz Vault (SIP-10) already provides quantum resistance | ✅ Better |


### PR DESCRIPTION
## Summary

Comprehensive research on adding WOTS+ (Winternitz One-Time Signature Plus) for post-quantum resistant stealth address claims.

## Key Findings

| Finding | Impact |
|---------|--------|
| WOTS+ signature size: **2,144 bytes** | Exceeds Solana tx limit |
| Solana tx limit: **1,232 bytes** | Fundamental blocker |
| Compute cost: **~60K CU** | Acceptable (not the issue) |
| Alternative exists | Winternitz Vault (SIP-10) |

## Conclusion

**NOT RECOMMENDED** — Direct WOTS+ signatures are blocked by Solana's transaction size limit.

The existing [Winternitz Vault integration (SIP-10)](docs/specs/QUANTUM-RESISTANT-STORAGE.md) provides a better solution by handling WOTS+ internally within the vault program.

## Recommendations

1. Close issue #491 with "won't implement"
2. Prioritize Winternitz Vault (SIP-10) for M17/M20
3. Update marketing to emphasize vault-based quantum resistance
4. Revisit if Solana increases transaction size limits

## Research Sources

- [RFC 8391 - XMSS/WOTS+](https://datatracker.ietf.org/doc/html/rfc8391)
- [NIST FIPS 205 - SLH-DSA](https://csrc.nist.gov/pubs/fips/205/final)
- [@noble/post-quantum](https://github.com/paulmillr/noble-post-quantum)
- [Solana Transaction Docs](https://solana.com/docs/core/transactions)

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)