### PR TITLE
feat(sdk): add Triton RPC provider with Dragon's Mouth gRPC subscriptions

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -58,10 +58,11 @@
     "@noir-lang/types": "1.0.0-beta.15",
     "@scure/base": "^2.0.0",
     "@sip-protocol/types": "^0.2.1",
-    "@solana/web3.js": "^1.95.0",
-    "@solana/spl-token": "^0.4.0"
+    "@solana/spl-token": "^0.4.0",
+    "@solana/web3.js": "^1.95.0"
   },
   "devDependencies": {
+    "@triton-one/yellowstone-grpc": "^5.0.1",
     "@vitest/coverage-v8": "1.6.1",
     "fast-check": "^4.3.0",
     "tsup": "^8.0.0",

--- a/packages/sdk/src/chains/solana/providers/index.ts
+++ b/packages/sdk/src/chains/solana/providers/index.ts
@@ -41,6 +41,7 @@ export {
 // Provider implementations
 export { HeliusProvider, type HeliusProviderConfig } from './helius'
 export { GenericProvider } from './generic'
+export { TritonProvider, type TritonProviderConfig } from './triton'
 
 // Webhook handler for real-time scanning
 export {

--- a/packages/sdk/src/chains/solana/providers/interface.ts
+++ b/packages/sdk/src/chains/solana/providers/interface.ts
@@ -27,6 +27,7 @@
 
 import { HeliusProvider, type HeliusProviderConfig } from './helius'
 import { GenericProvider } from './generic'
+import { TritonProvider, type TritonProviderConfig } from './triton'
 
 /**
  * Token asset information returned by providers
@@ -153,24 +154,29 @@ export function createProvider(
   config: GenericProviderConfig
 ): SolanaRPCProvider
 export function createProvider(
-  type: ProviderType,
-  config: ProviderConfig | GenericProviderConfig
+  type: 'triton',
+  config: TritonProviderConfig
 ): SolanaRPCProvider
 export function createProvider(
   type: ProviderType,
-  config: ProviderConfig | GenericProviderConfig
+  config: ProviderConfig | GenericProviderConfig | TritonProviderConfig
+): SolanaRPCProvider
+export function createProvider(
+  type: ProviderType,
+  config: ProviderConfig | GenericProviderConfig | TritonProviderConfig
 ): SolanaRPCProvider {
   switch (type) {
     case 'helius':
       return new HeliusProvider(config as HeliusProviderConfig)
     case 'generic':
       return new GenericProvider(config as GenericProviderConfig)
-    case 'quicknode':
     case 'triton':
+      return new TritonProvider(config as TritonProviderConfig)
+    case 'quicknode':
       throw new Error(
-        `Provider '${type}' is not yet implemented. ` +
-        `Use 'helius' or 'generic' for now. ` +
-        `See https://github.com/sip-protocol/sip-protocol/issues/${type === 'quicknode' ? '494' : '495'}`
+        `Provider 'quicknode' is not yet implemented. ` +
+        `Use 'helius', 'triton', or 'generic' for now. ` +
+        `See https://github.com/sip-protocol/sip-protocol/issues/494`
       )
     default:
       throw new Error(`Unknown provider type: ${type}`)

--- a/packages/sdk/src/chains/solana/providers/triton.ts
+++ b/packages/sdk/src/chains/solana/providers/triton.ts
@@ -1,0 +1,434 @@
+/**
+ * Triton RPC Provider
+ *
+ * Leverages Triton's Dragon's Mouth gRPC (Yellowstone) for real-time
+ * subscriptions with up to 400ms latency advantage over standard RPC.
+ *
+ * ## Key Features
+ *
+ * - **gRPC Subscriptions**: Real-time account updates via Yellowstone
+ * - **Standard RPC Compatible**: Full Solana JSON-RPC support
+ * - **High Throughput**: Built for heavy indexing workloads
+ *
+ * @see https://docs.triton.one/chains/solana
+ * @see https://docs.triton.one/project-yellowstone/dragons-mouth-grpc-subscriptions
+ *
+ * @example
+ * ```typescript
+ * import { TritonProvider } from '@sip-protocol/sdk'
+ *
+ * const triton = new TritonProvider({
+ *   endpoint: 'https://sip-XXX.mainnet.rpcpool.com',
+ *   xToken: process.env.TRITON_X_TOKEN,
+ * })
+ *
+ * // Standard queries
+ * const assets = await triton.getAssetsByOwner('7xK9...')
+ *
+ * // Real-time subscriptions (Triton's moat!)
+ * const unsubscribe = await triton.subscribeToTransfers('7xK9...', (asset) => {
+ *   console.log('New transfer:', asset)
+ * })
+ * ```
+ */
+
+import { Connection, PublicKey } from '@solana/web3.js'
+import { getAssociatedTokenAddress, getAccount, TokenAccountNotFoundError } from '@solana/spl-token'
+import type { SolanaRPCProvider, TokenAsset, ProviderConfig } from './interface'
+
+/**
+ * Triton provider configuration
+ */
+export interface TritonProviderConfig extends ProviderConfig {
+  /**
+   * Triton RPC endpoint
+   * @example 'https://sip-protocol-XXX.mainnet.rpcpool.com'
+   */
+  endpoint: string
+  /**
+   * X-Token for authentication (optional for public endpoints)
+   */
+  xToken?: string
+  /**
+   * gRPC endpoint for Dragon's Mouth subscriptions
+   * If not provided, derived from RPC endpoint
+   * @example 'https://sip-protocol-XXX.mainnet.rpcpool.com'
+   */
+  grpcEndpoint?: string
+  /**
+   * Solana cluster (for endpoint validation)
+   * @default 'mainnet-beta'
+   */
+  cluster?: 'mainnet-beta' | 'devnet' | 'testnet'
+}
+
+/**
+ * gRPC subscription state
+ */
+interface SubscriptionState {
+  /** Active stream */
+  stream: AsyncIterable<unknown> | null
+  /** Abort controller for cleanup */
+  abortController: AbortController
+  /** Whether subscription is active */
+  active: boolean
+}
+
+/**
+ * Triton RPC Provider implementation
+ *
+ * Uses standard Solana RPC for queries and Dragon's Mouth gRPC
+ * for real-time subscriptions.
+ */
+export class TritonProvider implements SolanaRPCProvider {
+  readonly name = 'triton'
+  private connection: Connection
+  private endpoint: string
+  private grpcEndpoint: string
+  private xToken?: string
+  private subscriptions: Map<string, SubscriptionState> = new Map()
+  private grpcClient: unknown | null = null
+
+  constructor(config: TritonProviderConfig) {
+    if (!config.endpoint) {
+      throw new Error(
+        'Triton endpoint is required. Get one at https://triton.one'
+      )
+    }
+
+    this.endpoint = config.endpoint
+    this.xToken = config.xToken
+    this.grpcEndpoint = config.grpcEndpoint ?? config.endpoint
+
+    // Create connection with optional auth header
+    const connectionConfig = this.xToken
+      ? {
+          httpHeaders: { 'x-token': this.xToken },
+          commitment: 'confirmed' as const,
+        }
+      : { commitment: 'confirmed' as const }
+
+    this.connection = new Connection(this.endpoint, connectionConfig)
+  }
+
+  /**
+   * Get all token assets owned by an address
+   *
+   * Uses standard Solana RPC for compatibility.
+   * For enhanced metadata, consider using Triton's DAS API separately.
+   */
+  async getAssetsByOwner(owner: string): Promise<TokenAsset[]> {
+    const ownerPubkey = this.validateAddress(owner, 'owner')
+
+    const tokenAccounts = await this.connection.getParsedTokenAccountsByOwner(
+      ownerPubkey,
+      { programId: new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA') }
+    )
+
+    const assets: TokenAsset[] = []
+
+    for (const { account } of tokenAccounts.value) {
+      const parsed = account.data.parsed
+      if (parsed?.type !== 'account') continue
+
+      const info = parsed.info
+      const amount = BigInt(info.tokenAmount?.amount ?? '0')
+
+      // Skip zero balances
+      if (amount === 0n) continue
+
+      assets.push({
+        mint: info.mint,
+        amount,
+        decimals: info.tokenAmount?.decimals ?? 0,
+        // Note: Symbol/name/logo require separate metadata lookup
+      })
+    }
+
+    return assets
+  }
+
+  /**
+   * Get token balance for a specific mint
+   */
+  async getTokenBalance(owner: string, mint: string): Promise<bigint> {
+    const ownerPubkey = this.validateAddress(owner, 'owner')
+    const mintPubkey = this.validateAddress(mint, 'mint')
+
+    try {
+      const ata = await getAssociatedTokenAddress(mintPubkey, ownerPubkey)
+      const account = await getAccount(this.connection, ata)
+      return account.amount
+    } catch (error) {
+      // Check by error name for better compatibility with mocks and different module versions
+      if (
+        error instanceof TokenAccountNotFoundError ||
+        (error instanceof Error && error.name === 'TokenAccountNotFoundError')
+      ) {
+        return 0n
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Check if provider supports real-time subscriptions
+   *
+   * Triton supports gRPC subscriptions via Dragon's Mouth - this is
+   * the key differentiator from other providers.
+   */
+  supportsSubscriptions(): boolean {
+    return true
+  }
+
+  /**
+   * Subscribe to token transfers for an address
+   *
+   * Uses Dragon's Mouth gRPC for real-time updates with up to
+   * 400ms latency advantage over standard WebSocket.
+   *
+   * @param address - Solana address to watch
+   * @param callback - Called when a transfer is detected
+   * @returns Unsubscribe function
+   */
+  async subscribeToTransfers(
+    address: string,
+    callback: (asset: TokenAsset) => void
+  ): Promise<() => void> {
+    const addressPubkey = this.validateAddress(address, 'address')
+    const subscriptionId = `transfer-${address}-${Date.now()}`
+
+    // Initialize gRPC client if needed
+    await this.ensureGrpcClient()
+
+    const abortController = new AbortController()
+    const state: SubscriptionState = {
+      stream: null,
+      abortController,
+      active: true,
+    }
+    this.subscriptions.set(subscriptionId, state)
+
+    // Start subscription in background
+    this.startSubscription(addressPubkey, callback, state).catch((error) => {
+      if (state.active) {
+        console.error('[TritonProvider] Subscription error:', error)
+      }
+    })
+
+    // Return unsubscribe function
+    return () => {
+      state.active = false
+      state.abortController.abort()
+      this.subscriptions.delete(subscriptionId)
+    }
+  }
+
+  /**
+   * Initialize gRPC client lazily
+   */
+  private async ensureGrpcClient(): Promise<void> {
+    if (this.grpcClient) return
+
+    try {
+      // Dynamic import to avoid bundling gRPC when not used
+      const { default: Client } = await import('@triton-one/yellowstone-grpc')
+
+      // Initialize with endpoint, optional auth token, and undefined channel options
+      this.grpcClient = new Client(this.grpcEndpoint, this.xToken, undefined)
+    } catch (error) {
+      throw new Error(
+        `Failed to initialize Triton gRPC client. ` +
+        `Ensure @triton-one/yellowstone-grpc is installed: ${error}`
+      )
+    }
+  }
+
+  /**
+   * Start gRPC subscription for account updates
+   */
+  private async startSubscription(
+    address: PublicKey,
+    callback: (asset: TokenAsset) => void,
+    state: SubscriptionState
+  ): Promise<void> {
+    if (!this.grpcClient) {
+      throw new Error('gRPC client not initialized')
+    }
+
+    // Type assertion for the client
+    const client = this.grpcClient as {
+      subscribe(): {
+        on(event: 'data', handler: (data: GrpcAccountUpdate) => void): void
+        on(event: 'error', handler: (error: Error) => void): void
+        on(event: 'end', handler: () => void): void
+        write(request: GrpcSubscribeRequest): void
+        end(): void
+      }
+    }
+
+    const stream = client.subscribe()
+    state.stream = stream as unknown as AsyncIterable<unknown>
+
+    // Set up event handlers
+    stream.on('data', (data: GrpcAccountUpdate) => {
+      if (!state.active) return
+
+      // Process account update
+      const asset = this.parseAccountUpdate(data, address.toBase58())
+      if (asset) {
+        callback(asset)
+      }
+    })
+
+    stream.on('error', (error: Error) => {
+      if (state.active) {
+        console.error('[TritonProvider] gRPC stream error:', error)
+      }
+    })
+
+    stream.on('end', () => {
+      state.active = false
+    })
+
+    // Send subscription request
+    const request: GrpcSubscribeRequest = {
+      accounts: {
+        tokenTransfers: {
+          owner: [address.toBase58()],
+          account: [],
+          filters: [],
+        },
+      },
+      commitment: 2, // CONFIRMED
+      accountsDataSlice: [],
+      ping: { id: 1 },
+    }
+
+    stream.write(request)
+
+    // Handle abort
+    state.abortController.signal.addEventListener('abort', () => {
+      stream.end()
+    })
+  }
+
+  /**
+   * Parse gRPC account update into TokenAsset
+   */
+  private parseAccountUpdate(
+    data: GrpcAccountUpdate,
+    _watchedAddress: string
+  ): TokenAsset | null {
+    // Check if this is an account update
+    if (!data.account?.account) {
+      return null
+    }
+
+    const accountData = data.account.account
+
+    // Parse token account data
+    try {
+      // Token account data layout: mint (32) + owner (32) + amount (8) + ...
+      const dataBuffer = Buffer.from(accountData.data)
+      if (dataBuffer.length < 72) return null
+
+      const mint = new PublicKey(dataBuffer.subarray(0, 32)).toBase58()
+      const amount = dataBuffer.readBigUInt64LE(64)
+
+      return {
+        mint,
+        amount,
+        decimals: 0, // Would need metadata lookup for decimals
+      }
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Validate Solana address
+   */
+  private validateAddress(address: string, paramName: string): PublicKey {
+    try {
+      return new PublicKey(address)
+    } catch {
+      throw new Error(`Invalid Solana address for ${paramName}: ${address}`)
+    }
+  }
+
+  /**
+   * Get the underlying Connection for advanced use cases
+   */
+  getConnection(): Connection {
+    return this.connection
+  }
+
+  /**
+   * Check if gRPC client is initialized
+   */
+  isGrpcReady(): boolean {
+    return this.grpcClient !== null
+  }
+
+  /**
+   * Clean up all subscriptions
+   */
+  async dispose(): Promise<void> {
+    for (const [id, state] of this.subscriptions) {
+      state.active = false
+      state.abortController.abort()
+      this.subscriptions.delete(id)
+    }
+    this.grpcClient = null
+  }
+}
+
+// ─── gRPC Types ─────────────────────────────────────────────────────────────
+
+/**
+ * gRPC subscription request
+ */
+interface GrpcSubscribeRequest {
+  accounts?: {
+    [key: string]: {
+      owner?: string[]
+      account?: string[]
+      filters?: Array<{
+        memcmp?: { offset: number; data: { bytes: string } }
+        datasize?: number
+      }>
+    }
+  }
+  commitment?: number
+  accountsDataSlice?: Array<{ offset: number; length: number }>
+  ping?: { id: number }
+}
+
+/**
+ * gRPC account update message
+ */
+interface GrpcAccountUpdate {
+  account?: {
+    account?: {
+      pubkey: Uint8Array
+      lamports: bigint
+      owner: Uint8Array
+      executable: boolean
+      rentEpoch: bigint
+      data: Uint8Array
+      writeVersion: bigint
+      slot: bigint
+    }
+    slot: bigint
+    isStartup: boolean
+  }
+  slot?: {
+    slot: bigint
+    parent?: bigint
+    status: number
+  }
+  ping?: {
+    id: number
+  }
+}

--- a/packages/sdk/tests/chains/solana/providers.test.ts
+++ b/packages/sdk/tests/chains/solana/providers.test.ts
@@ -13,6 +13,7 @@ import {
   createProvider,
   HeliusProvider,
   GenericProvider,
+  TritonProvider,
 } from '../../../src/chains/solana/providers'
 import type {
   SolanaRPCProvider,
@@ -51,13 +52,12 @@ describe('Solana RPC Providers', () => {
       ).toThrow(/issues\/494/)
     })
 
-    it('should throw helpful error for triton (not yet implemented)', () => {
-      expect(() =>
-        createProvider('triton', { apiKey: 'test' })
-      ).toThrow(/Provider 'triton' is not yet implemented/)
-      expect(() =>
-        createProvider('triton', { apiKey: 'test' })
-      ).toThrow(/issues\/495/)
+    it('should create TritonProvider with triton type', () => {
+      const provider = createProvider('triton', {
+        endpoint: 'https://sip-protocol.mainnet.rpcpool.com',
+      })
+      expect(provider).toBeInstanceOf(TritonProvider)
+      expect(provider.name).toBe('triton')
     })
   })
 

--- a/packages/sdk/tests/chains/solana/providers/triton.test.ts
+++ b/packages/sdk/tests/chains/solana/providers/triton.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Triton Provider Tests
+ *
+ * Tests for TritonProvider implementation including gRPC subscriptions.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { TritonProvider } from '../../../../src/chains/solana/providers/triton'
+import { createProvider } from '../../../../src/chains/solana/providers/interface'
+
+describe('TritonProvider', () => {
+  const validConfig = {
+    endpoint: 'https://sip-protocol.mainnet.rpcpool.com',
+    xToken: 'test-token',
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('constructor', () => {
+    it('should create provider with valid config', () => {
+      const provider = new TritonProvider(validConfig)
+      expect(provider.name).toBe('triton')
+    })
+
+    it('should throw error without endpoint', () => {
+      expect(() => {
+        new TritonProvider({ endpoint: '' })
+      }).toThrow('Triton endpoint is required')
+    })
+
+    it('should use endpoint as grpcEndpoint if not specified', () => {
+      const provider = new TritonProvider({
+        endpoint: 'https://test.rpcpool.com',
+      })
+      expect(provider.name).toBe('triton')
+    })
+
+    it('should accept custom grpcEndpoint', () => {
+      const provider = new TritonProvider({
+        endpoint: 'https://rpc.rpcpool.com',
+        grpcEndpoint: 'https://grpc.rpcpool.com',
+      })
+      expect(provider.name).toBe('triton')
+    })
+
+    it('should work without xToken (public endpoints)', () => {
+      const provider = new TritonProvider({
+        endpoint: 'https://public.rpcpool.com',
+      })
+      expect(provider.name).toBe('triton')
+    })
+  })
+
+  describe('getAssetsByOwner validation', () => {
+    it('should throw error for invalid address', async () => {
+      const provider = new TritonProvider(validConfig)
+      await expect(provider.getAssetsByOwner('invalid')).rejects.toThrow(
+        'Invalid Solana address for owner'
+      )
+    })
+
+    it('should throw error for empty address', async () => {
+      const provider = new TritonProvider(validConfig)
+      await expect(provider.getAssetsByOwner('')).rejects.toThrow(
+        'Invalid Solana address for owner'
+      )
+    })
+  })
+
+  describe('getTokenBalance validation', () => {
+    it('should throw error for invalid owner address', async () => {
+      const provider = new TritonProvider(validConfig)
+      await expect(
+        provider.getTokenBalance('invalid', 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')
+      ).rejects.toThrow('Invalid Solana address for owner')
+    })
+
+    it('should throw error for invalid mint address', async () => {
+      const provider = new TritonProvider(validConfig)
+      await expect(
+        provider.getTokenBalance('7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU', 'invalid')
+      ).rejects.toThrow('Invalid Solana address for mint')
+    })
+  })
+
+  describe('supportsSubscriptions', () => {
+    it('should return true (Triton supports gRPC subscriptions)', () => {
+      const provider = new TritonProvider(validConfig)
+      expect(provider.supportsSubscriptions()).toBe(true)
+    })
+  })
+
+  describe('subscribeToTransfers validation', () => {
+    it('should throw for invalid address', async () => {
+      const provider = new TritonProvider(validConfig)
+      await expect(
+        provider.subscribeToTransfers('invalid', vi.fn())
+      ).rejects.toThrow('Invalid Solana address')
+    })
+  })
+
+  describe('getConnection', () => {
+    it('should return the underlying Connection', () => {
+      const provider = new TritonProvider(validConfig)
+      const connection = provider.getConnection()
+      expect(connection).toBeDefined()
+      expect(connection.rpcEndpoint).toBe(validConfig.endpoint)
+    })
+  })
+
+  describe('isGrpcReady', () => {
+    it('should return false before subscription', () => {
+      const provider = new TritonProvider(validConfig)
+      expect(provider.isGrpcReady()).toBe(false)
+    })
+  })
+
+  describe('dispose', () => {
+    it('should not throw when called on fresh provider', async () => {
+      const provider = new TritonProvider(validConfig)
+      await expect(provider.dispose()).resolves.toBeUndefined()
+    })
+
+    it('should reset gRPC ready state', async () => {
+      const provider = new TritonProvider(validConfig)
+      await provider.dispose()
+      expect(provider.isGrpcReady()).toBe(false)
+    })
+  })
+})
+
+describe('createProvider with triton', () => {
+  it('should create TritonProvider via factory', () => {
+    const provider = createProvider('triton', {
+      endpoint: 'https://test.rpcpool.com',
+    })
+
+    expect(provider).toBeInstanceOf(TritonProvider)
+    expect(provider.name).toBe('triton')
+  })
+
+  it('should pass xToken to provider', () => {
+    const provider = createProvider('triton', {
+      endpoint: 'https://test.rpcpool.com',
+      xToken: 'my-secret-token',
+    })
+
+    expect(provider).toBeInstanceOf(TritonProvider)
+  })
+
+  it('should throw for missing endpoint', () => {
+    expect(() => {
+      createProvider('triton', { endpoint: '' })
+    }).toThrow('Triton endpoint is required')
+  })
+})
+
+describe('TritonProvider integration scenarios', () => {
+  it('should work with mainnet configuration', () => {
+    const provider = new TritonProvider({
+      endpoint: 'https://sip-protocol.mainnet.rpcpool.com',
+      xToken: 'prod-token',
+      cluster: 'mainnet-beta',
+    })
+
+    expect(provider.name).toBe('triton')
+    expect(provider.supportsSubscriptions()).toBe(true)
+  })
+
+  it('should work with devnet configuration', () => {
+    const provider = new TritonProvider({
+      endpoint: 'https://sip-protocol.devnet.rpcpool.com',
+      cluster: 'devnet',
+    })
+
+    expect(provider.name).toBe('triton')
+  })
+
+  it('should expose connection with correct endpoint', () => {
+    const endpoint = 'https://custom.rpcpool.com'
+    const provider = new TritonProvider({ endpoint })
+    const connection = provider.getConnection()
+
+    expect(connection.rpcEndpoint).toBe(endpoint)
+  })
+})
+
+describe('TritonProvider interface contract', () => {
+  let provider: TritonProvider
+
+  beforeEach(() => {
+    provider = new TritonProvider({
+      endpoint: 'https://test.rpcpool.com',
+    })
+  })
+
+  it('should have a name property', () => {
+    expect(typeof provider.name).toBe('string')
+    expect(provider.name).toBe('triton')
+  })
+
+  it('should have getAssetsByOwner method', () => {
+    expect(typeof provider.getAssetsByOwner).toBe('function')
+  })
+
+  it('should have getTokenBalance method', () => {
+    expect(typeof provider.getTokenBalance).toBe('function')
+  })
+
+  it('should have supportsSubscriptions method returning true', () => {
+    expect(typeof provider.supportsSubscriptions).toBe('function')
+    expect(provider.supportsSubscriptions()).toBe(true)
+  })
+
+  it('should have subscribeToTransfers method', () => {
+    expect(typeof provider.subscribeToTransfers).toBe('function')
+  })
+
+  it('should have getConnection method', () => {
+    expect(typeof provider.getConnection).toBe('function')
+  })
+
+  it('should have isGrpcReady method', () => {
+    expect(typeof provider.isGrpcReady).toBe('function')
+  })
+
+  it('should have dispose method', () => {
+    expect(typeof provider.dispose).toBe('function')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,9 @@ importers:
         specifier: ^1.95.0
         version: 1.98.4(typescript@5.9.3)
     devDependencies:
+      '@triton-one/yellowstone-grpc':
+        specifier: ^5.0.1
+        version: 5.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: 1.6.1
         version: 1.6.1(vitest@1.6.1)
@@ -401,6 +404,11 @@ packages:
 
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+    dev: true
+
+  /@bufbuild/protobuf@2.10.2:
+    resolution: {integrity: sha512-uFsRXwIGyu+r6AMdz+XijIIZJYpoWeYzILt5yZ2d3mCjQrWUTVpVD9WL/jZAbvp+Ed04rOhrsk7FiTcEDseB5A==}
+    requiresBuild: true
     dev: true
 
   /@changesets/apply-release-plan@7.0.14:
@@ -1882,6 +1890,34 @@ packages:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
+  /@solana/addresses@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3):
+    resolution: {integrity: sha512-X84qSZLgve9YeYsyxGI49WnfEre53tdFu4x9/4oULBgoj8d0A+P9VGLYzmRJ0YFYKRcZG7U4u3MQpI5uLZ1AsQ==}
+    engines: {node: '>=20.18.0'}
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+    dependencies:
+      '@solana/assertions': 5.1.0(typescript@5.9.3)
+      '@solana/codecs-core': 5.1.0(typescript@5.9.3)
+      '@solana/codecs-strings': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 5.1.0(typescript@5.9.3)
+      '@solana/nominal-types': 5.1.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    dev: true
+
+  /@solana/assertions@5.1.0(typescript@5.9.3):
+    resolution: {integrity: sha512-5But2wyxuvGXMIOnD0jBMQ9yq1QQF2LSK3IbIRSkAkXbD3DS6O2tRvKUHNhogd+BpkPyCGOQHBycezgnxmStlg==}
+    engines: {node: '>=20.18.0'}
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+    dependencies:
+      '@solana/errors': 5.1.0(typescript@5.9.3)
+      typescript: 5.9.3
+    dev: true
+
   /@solana/buffer-layout-utils@0.2.0(typescript@5.9.3):
     resolution: {integrity: sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==}
     engines: {node: '>= 10'}
@@ -1923,6 +1959,17 @@ packages:
       typescript: 5.9.3
     dev: false
 
+  /@solana/codecs-core@5.1.0(typescript@5.9.3):
+    resolution: {integrity: sha512-vDwi03mxWeWCS5Il6BCdNdifYdOoHVz97YOmbWGIt45b77Ivu5NUYeSD2+ccl6fSw8eYQ6QaqqKXMjbSfsXv4g==}
+    engines: {node: '>=20.18.0'}
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+    dependencies:
+      '@solana/errors': 5.1.0(typescript@5.9.3)
+      typescript: 5.9.3
+    dev: true
+
   /@solana/codecs-data-structures@2.0.0-rc.1(typescript@5.9.3):
     resolution: {integrity: sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==}
     peerDependencies:
@@ -1933,6 +1980,19 @@ packages:
       '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
       typescript: 5.9.3
     dev: false
+
+  /@solana/codecs-data-structures@5.1.0(typescript@5.9.3):
+    resolution: {integrity: sha512-ftAwL/jsurFrk9kFVhkTLdQ8fGZ8I0PcbVH+V1a0dIP2aKDofGePvK0XbwZE/ohizC9gEIZxyBX5IgRKk5PXyg==}
+    engines: {node: '>=20.18.0'}
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+    dependencies:
+      '@solana/codecs-core': 5.1.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.1.0(typescript@5.9.3)
+      '@solana/errors': 5.1.0(typescript@5.9.3)
+      typescript: 5.9.3
+    dev: true
 
   /@solana/codecs-numbers@2.0.0-rc.1(typescript@5.9.3):
     resolution: {integrity: sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==}
@@ -1955,6 +2015,18 @@ packages:
       typescript: 5.9.3
     dev: false
 
+  /@solana/codecs-numbers@5.1.0(typescript@5.9.3):
+    resolution: {integrity: sha512-Ea5/9yjDNOrDZcI40UGzzi6Aq1JNsmzM4m5pOk6Xb3JRZ0YdKOv/MwuCqb6jRgzZ7SQjHhkfGL43kHLJA++bOw==}
+    engines: {node: '>=20.18.0'}
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+    dependencies:
+      '@solana/codecs-core': 5.1.0(typescript@5.9.3)
+      '@solana/errors': 5.1.0(typescript@5.9.3)
+      typescript: 5.9.3
+    dev: true
+
   /@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3):
     resolution: {integrity: sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==}
     peerDependencies:
@@ -1967,6 +2039,24 @@ packages:
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.9.3
     dev: false
+
+  /@solana/codecs-strings@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3):
+    resolution: {integrity: sha512-014xwl5T/3VnGW0gceizF47DUs5EURRtgGmbWIR5+Z32yxgQ6hT9Zl0atZbL268RHbUQ03/J8Ush1StQgy7sfQ==}
+    engines: {node: '>=20.18.0'}
+    requiresBuild: true
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5.3.3'
+    peerDependenciesMeta:
+      fastestsmallesttextencoderdecoder:
+        optional: true
+    dependencies:
+      '@solana/codecs-core': 5.1.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.1.0(typescript@5.9.3)
+      '@solana/errors': 5.1.0(typescript@5.9.3)
+      fastestsmallesttextencoderdecoder: 1.0.22
+      typescript: 5.9.3
+    dev: true
 
   /@solana/codecs@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3):
     resolution: {integrity: sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==}
@@ -2006,6 +2096,68 @@ packages:
       typescript: 5.9.3
     dev: false
 
+  /@solana/errors@5.1.0(typescript@5.9.3):
+    resolution: {integrity: sha512-JlTyekErWa6Fdcwu1Hrh+jZxjM4YxyorGCFDRVZlmHZFkp5N00DWKcYnSGZrTF8E6ZZEP9pfS2XwM8y7p7HPww==}
+    engines: {node: '>=20.18.0'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+    dependencies:
+      chalk: 5.6.2
+      commander: 14.0.2
+      typescript: 5.9.3
+    dev: true
+
+  /@solana/functional@5.1.0(typescript@5.9.3):
+    resolution: {integrity: sha512-R6jacWU0Gr+j49lTDp+FSECBolqw2Gq7JlC22rI0JkcxJiiAlp3G80v6zAYq0FkHzxZbjyR6//JYUXSwliem5g==}
+    engines: {node: '>=20.18.0'}
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+    dependencies:
+      typescript: 5.9.3
+    dev: true
+
+  /@solana/instructions@5.1.0(typescript@5.9.3):
+    resolution: {integrity: sha512-fkwpUwwqk5K14T/kZDnCrfeR0kww49HBx+BK8xdSeJx+bt4QTwAHa9YeOkGhGrHEFVEJEUf8FKoxxTzZzJZtKQ==}
+    engines: {node: '>=20.18.0'}
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+    dependencies:
+      '@solana/codecs-core': 5.1.0(typescript@5.9.3)
+      '@solana/errors': 5.1.0(typescript@5.9.3)
+      typescript: 5.9.3
+    dev: true
+
+  /@solana/keys@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3):
+    resolution: {integrity: sha512-ma4zTTuSOmtTCvATHMfUGNTw0Vqah/6XPe1VmLc66ohwXMI3yqatX1FQPXgDZozr15SvLAesfs7/bgl2TRoe9w==}
+    engines: {node: '>=20.18.0'}
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+    dependencies:
+      '@solana/assertions': 5.1.0(typescript@5.9.3)
+      '@solana/codecs-core': 5.1.0(typescript@5.9.3)
+      '@solana/codecs-strings': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 5.1.0(typescript@5.9.3)
+      '@solana/nominal-types': 5.1.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    dev: true
+
+  /@solana/nominal-types@5.1.0(typescript@5.9.3):
+    resolution: {integrity: sha512-+4Cm+SpK+D811i9giqv4Up93ZlmUcZfLDHkSH24F4in61+Y2TKA+XKuRtKhNytQMmqCfbvJZ9MHFaIeZw5g+Bg==}
+    engines: {node: '>=20.18.0'}
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+    dependencies:
+      typescript: 5.9.3
+    dev: true
+
   /@solana/options@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3):
     resolution: {integrity: sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==}
     peerDependencies:
@@ -2020,6 +2172,96 @@ packages:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
     dev: false
+
+  /@solana/rpc-api@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3):
+    resolution: {integrity: sha512-eI1tY0i3gmih1C65gFECYbfPRpHEYqFp+9IKjpknZtYpQIe9BqBKSpfYpGiCAbKdN/TMadBNPOzdK15ewhkkvQ==}
+    engines: {node: '>=20.18.0'}
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+    dependencies:
+      '@solana/addresses': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 5.1.0(typescript@5.9.3)
+      '@solana/codecs-strings': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 5.1.0(typescript@5.9.3)
+      '@solana/keys': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 5.1.0(typescript@5.9.3)
+      '@solana/rpc-spec': 5.1.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    dev: true
+
+  /@solana/rpc-parsed-types@5.1.0(typescript@5.9.3):
+    resolution: {integrity: sha512-ZJoXHNItALMNa1zmGrNnIh96RBlc9GpIqoaZkdE14mAQ7gWe7Oc0ejYavUeSCmcL0wZcvIFh50AsfVxrHr4+2Q==}
+    engines: {node: '>=20.18.0'}
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+    dependencies:
+      typescript: 5.9.3
+    dev: true
+
+  /@solana/rpc-spec-types@5.1.0(typescript@5.9.3):
+    resolution: {integrity: sha512-B8/WyjmHpC34vXtAmTpZyPwRCm7WwoSkmjBcBouaaY1uilJ9+Wp2nptbq2cJyWairOoMSoI7v5kvvnrJuquq4Q==}
+    engines: {node: '>=20.18.0'}
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+    dependencies:
+      typescript: 5.9.3
+    dev: true
+
+  /@solana/rpc-spec@5.1.0(typescript@5.9.3):
+    resolution: {integrity: sha512-y8B6fUWA1EBKXUsNo6b9EiFcQPsaJREPLlcIDbo4b6TucQNwvl7FHfpf1VHJL64SkI/WE69i2WEkiOJYjmLO0A==}
+    engines: {node: '>=20.18.0'}
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+    dependencies:
+      '@solana/errors': 5.1.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 5.1.0(typescript@5.9.3)
+      typescript: 5.9.3
+    dev: true
+
+  /@solana/rpc-transformers@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3):
+    resolution: {integrity: sha512-6v93xi/ewGS/xEiSktNQ0bh0Uiv1/q9nR5oiFMn3BiAJRC+FdMRMxCjp6H+/Tua7wdhpClaPKrZYBQHoIp59tw==}
+    engines: {node: '>=20.18.0'}
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+    dependencies:
+      '@solana/errors': 5.1.0(typescript@5.9.3)
+      '@solana/functional': 5.1.0(typescript@5.9.3)
+      '@solana/nominal-types': 5.1.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 5.1.0(typescript@5.9.3)
+      '@solana/rpc-types': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    dev: true
+
+  /@solana/rpc-types@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3):
+    resolution: {integrity: sha512-Rnpt5BuHQvnULPNXUC/yRqB+7iPbon95CSCeyRvPj5tJ4fx2JibvX3s/UEoud5vC+kRjPi/R0BGJ8XFvd3eDWg==}
+    engines: {node: '>=20.18.0'}
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+    dependencies:
+      '@solana/addresses': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 5.1.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.1.0(typescript@5.9.3)
+      '@solana/codecs-strings': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 5.1.0(typescript@5.9.3)
+      '@solana/nominal-types': 5.1.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    dev: true
 
   /@solana/spl-token-group@0.0.7(@solana/web3.js@1.98.4)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3):
     resolution: {integrity: sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==}
@@ -2066,6 +2308,51 @@ packages:
       - typescript
       - utf-8-validate
     dev: false
+
+  /@solana/transaction-messages@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3):
+    resolution: {integrity: sha512-9rNV2YJhd85WIMvnwa/vUY4xUw3ZTU17jP1KDo/fFZWk55a0ov0ATJJPyC5HAR1i6hT1cmJzGH/UHhnD9m/Q3w==}
+    engines: {node: '>=20.18.0'}
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+    dependencies:
+      '@solana/addresses': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 5.1.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 5.1.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.1.0(typescript@5.9.3)
+      '@solana/errors': 5.1.0(typescript@5.9.3)
+      '@solana/functional': 5.1.0(typescript@5.9.3)
+      '@solana/instructions': 5.1.0(typescript@5.9.3)
+      '@solana/nominal-types': 5.1.0(typescript@5.9.3)
+      '@solana/rpc-types': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    dev: true
+
+  /@solana/transactions@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3):
+    resolution: {integrity: sha512-06JwSPtz+38ozNgpysAXS2eTMPQCufIisXB6K88X8J4GF8ziqs4nkq0BpXAXn+MpZTkuMt+JeW2RxP3HKhXe5g==}
+    engines: {node: '>=20.18.0'}
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+    dependencies:
+      '@solana/addresses': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 5.1.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 5.1.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.1.0(typescript@5.9.3)
+      '@solana/codecs-strings': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 5.1.0(typescript@5.9.3)
+      '@solana/functional': 5.1.0(typescript@5.9.3)
+      '@solana/instructions': 5.1.0(typescript@5.9.3)
+      '@solana/keys': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/nominal-types': 5.1.0(typescript@5.9.3)
+      '@solana/rpc-types': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    dev: true
 
   /@solana/web3.js@1.98.4(typescript@5.9.3):
     resolution: {integrity: sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==}
@@ -2156,6 +2443,57 @@ packages:
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    dev: true
+
+  /@triton-one/yellowstone-grpc-napi-darwin-arm64@0.0.5:
+    resolution: {integrity: sha512-UyxNkkBvLMOiR77s96q8OIi51mPE0YwSQT5wxPhOTvptFcfX8qbZbsqAWOnphUBtW8CoTQsAHrMz51PdCOqgEw==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@triton-one/yellowstone-grpc-napi-darwin-x64@0.0.5:
+    resolution: {integrity: sha512-Lj5rR0T9wB3xeq76VtaJUHyaNstu0Mc2kwieAtHOigGfaCUvGwc5XgpbYcx5aVrUq4R8gGF9kM/9+n+GcqXxig==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@triton-one/yellowstone-grpc-napi-linux-x64-gnu@0.0.5:
+    resolution: {integrity: sha512-Cx6ifzYSyaGn5uF0wN5dwwWS/wj6sDWIqZa8YRTuF6pP5pkjM78neoHNMr9taOrH5LRtwC1JSaSYyQw+inGq4g==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@triton-one/yellowstone-grpc-napi-linux-x64-musl@0.0.5:
+    resolution: {integrity: sha512-lLb5sBVAoELgjrX57qcxe0FtJTtDaBxo4KOCQfuqqYgeEd1ooOhGeuYx2KO+zMbBXa8+8OD4mt4ZHcW5b/n9tg==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@triton-one/yellowstone-grpc@5.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3):
+    resolution: {integrity: sha512-8HADdlWlHPlNday+Ii54CmHjyUxX6DN6LvYUf9zOQv2EqomQPaiqkEQ9hW9MCMqGO0ZoEtt/59Ef6mBXptag1A==}
+    engines: {node: '>=20.18.0'}
+    requiresBuild: true
+    dependencies:
+      '@bufbuild/protobuf': 2.10.2
+      '@solana/addresses': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-api': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      '@triton-one/yellowstone-grpc-napi-darwin-arm64': 0.0.5
+      '@triton-one/yellowstone-grpc-napi-darwin-x64': 0.0.5
+      '@triton-one/yellowstone-grpc-napi-linux-x64-gnu': 0.0.5
+      '@triton-one/yellowstone-grpc-napi-linux-x64-musl': 0.0.5
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - typescript
     dev: true
 
   /@types/aria-query@5.0.4:
@@ -2925,7 +3263,6 @@ packages:
   /chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-    dev: false
 
   /chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -3002,7 +3339,6 @@ packages:
   /commander@14.0.2:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
     engines: {node: '>=20'}
-    dev: false
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -3651,7 +3987,6 @@ packages:
 
   /fastestsmallesttextencoderdecoder@1.0.22:
     resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
-    dev: false
 
   /fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}


### PR DESCRIPTION
## Summary

- Adds `TritonProvider` implementing `SolanaRPCProvider` interface
- Leverages Dragon's Mouth gRPC (Yellowstone) for real-time subscriptions with up to 400ms latency advantage
- Standard RPC fallback for `getAssetsByOwner` and `getTokenBalance`
- Lazy gRPC client initialization to avoid bundling when unused
- `supportsSubscriptions()` returns `true` (Triton's key differentiator vs Helius)

## Changes

- `packages/sdk/src/chains/solana/providers/triton.ts` - New TritonProvider implementation
- `packages/sdk/src/chains/solana/providers/interface.ts` - Updated factory to support 'triton' type
- `packages/sdk/src/chains/solana/providers/index.ts` - Export TritonProvider
- `packages/sdk/package.json` - Added @triton-one/yellowstone-grpc as devDependency
- `packages/sdk/tests/chains/solana/providers/triton.test.ts` - 29 comprehensive tests

## Usage

```typescript
import { createProvider } from '@sip-protocol/sdk'

// Create Triton provider with gRPC subscriptions
const triton = createProvider('triton', {
  endpoint: 'https://sip-protocol.mainnet.rpcpool.com',
  xToken: process.env.TRITON_X_TOKEN,
})

// Standard queries
const assets = await triton.getAssetsByOwner('7xK9...')

// Real-time subscriptions (Triton's moat!)
const unsubscribe = await triton.subscribeToTransfers('7xK9...', (asset) => {
  console.log('New transfer:', asset)
})
```

## Test plan

- [x] Constructor tests (5 tests)
- [x] Address validation tests (4 tests)
- [x] supportsSubscriptions returns true (1 test)
- [x] getConnection exposes Connection (1 test)
- [x] isGrpcReady state management (1 test)
- [x] dispose cleanup (2 tests)
- [x] Factory integration tests (3 tests)
- [x] Integration scenarios (3 tests)
- [x] Interface contract tests (8 tests)

All 98 Solana provider tests passing.

Closes #495

🤖 Generated with [Claude Code](https://claude.ai/code)