### PR TITLE
feat(sdk): add LangChain tools for Privacy Advisor Agent (#490)

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -52,6 +52,8 @@
     "@aztec/bb.js": "3.0.1",
     "@ethereumjs/rlp": "^10.1.0",
     "@jup-ag/api": "^6.0.48",
+    "@langchain/core": "^0.3.30",
+    "@langchain/openai": "^0.4.2",
     "@magicblock-labs/ephemeral-rollups-sdk": "^0.7.2",
     "@noble/ciphers": "^2.1.1",
     "@noble/curves": "^1.3.0",
@@ -64,8 +66,7 @@
     "@solana/spl-token": "^0.4.14",
     "@solana/web3.js": "^1.98.4",
     "@triton-one/yellowstone-grpc": "^4.0.2",
-    "@langchain/core": "^0.3.30",
-    "@langchain/openai": "^0.4.2",
+    "langchain": "^0.3.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/packages/sdk/src/advisor/index.ts
+++ b/packages/sdk/src/advisor/index.ts
@@ -4,10 +4,38 @@
  * LangChain-powered AI agent for intelligent privacy recommendations.
  *
  * @packageDocumentation
+ *
+ * @example
+ * ```typescript
+ * import { PrivacyAdvisorAgent, createPrivacyAdvisorTools } from '@sip-protocol/sdk'
+ *
+ * // Create advisor (simple chat mode)
+ * const advisor = new PrivacyAdvisorAgent({
+ *   openaiApiKey: process.env.OPENAI_API_KEY!,
+ * })
+ *
+ * // Or use tools for a full agent
+ * const tools = createPrivacyAdvisorTools({
+ *   heliusApiKey: process.env.HELIUS_API_KEY!,
+ * })
+ * ```
  */
 
+// Main agent
 export { PrivacyAdvisorAgent, createPrivacyAdvisor } from './advisor'
 
+// LangChain tools (for building custom agents)
+export {
+  createPrivacyAdvisorTools,
+  createAnalyzeWalletTool,
+  createQuickScoreTool,
+  createSIPComparisonTool,
+  createExplainTool,
+} from './tools'
+
+export type { ToolsConfig } from './tools'
+
+// Types
 export type {
   // Core types
   AdvisorRole,

--- a/packages/sdk/src/advisor/tools.ts
+++ b/packages/sdk/src/advisor/tools.ts
@@ -1,0 +1,303 @@
+/**
+ * Privacy Advisor LangChain Tools
+ *
+ * Tools for the Privacy Advisor Agent to analyze wallets and provide recommendations.
+ *
+ * @packageDocumentation
+ */
+
+import { z } from 'zod'
+import { DynamicStructuredTool } from '@langchain/core/tools'
+import { SurveillanceAnalyzer } from '../surveillance/analyzer'
+import type { FullAnalysisResult, PrivacyRecommendation as SurveillanceRecommendation } from '../surveillance/types'
+
+/**
+ * Configuration for creating tools
+ */
+export interface ToolsConfig {
+  /** Helius API key */
+  heliusApiKey: string
+  /** Solana cluster */
+  cluster?: 'mainnet-beta' | 'devnet'
+  /** Maximum transactions to analyze */
+  maxTransactions?: number
+}
+
+/**
+ * Create the analyze wallet tool
+ *
+ * @param config - Tool configuration
+ * @returns LangChain tool for wallet analysis
+ */
+export function createAnalyzeWalletTool(config: ToolsConfig): DynamicStructuredTool {
+  const analyzer = new SurveillanceAnalyzer({
+    heliusApiKey: config.heliusApiKey,
+    cluster: config.cluster ?? 'mainnet-beta',
+    maxTransactions: config.maxTransactions ?? 500,
+    includeSocialLinks: true,
+  })
+
+  return new DynamicStructuredTool({
+    name: 'analyze_wallet',
+    description: 'Analyze a Solana wallet for privacy risks and surveillance exposure. Returns detailed privacy score and risk breakdown.',
+    schema: z.object({
+      address: z.string().describe('The Solana wallet address to analyze (base58 encoded)'),
+    }),
+    func: async ({ address }): Promise<string> => {
+      try {
+        const result = await analyzer.analyze(address)
+        return formatAnalysisResult(result)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        return JSON.stringify({
+          error: true,
+          message: `Failed to analyze wallet: ${message}`,
+        })
+      }
+    },
+  })
+}
+
+/**
+ * Create the quick score tool for faster analysis
+ *
+ * @param config - Tool configuration
+ * @returns LangChain tool for quick scoring
+ */
+export function createQuickScoreTool(config: ToolsConfig): DynamicStructuredTool {
+  const analyzer = new SurveillanceAnalyzer({
+    heliusApiKey: config.heliusApiKey,
+    cluster: config.cluster ?? 'mainnet-beta',
+    maxTransactions: 100,
+    includeSocialLinks: false,
+  })
+
+  return new DynamicStructuredTool({
+    name: 'quick_privacy_score',
+    description: 'Get a quick privacy score for a wallet without full analysis. Faster but less detailed.',
+    schema: z.object({
+      address: z.string().describe('The Solana wallet address to score'),
+    }),
+    func: async ({ address }): Promise<string> => {
+      try {
+        const result = await analyzer.quickScore(address)
+        return JSON.stringify({
+          score: result.score,
+          risk: result.risk,
+          topIssue: result.topIssue,
+          summary: getQuickSummary(result.score),
+        })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        return JSON.stringify({
+          error: true,
+          message: `Failed to get quick score: ${message}`,
+        })
+      }
+    },
+  })
+}
+
+/**
+ * Create the SIP comparison tool
+ *
+ * @returns LangChain tool for SIP protection comparison
+ */
+export function createSIPComparisonTool(): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'sip_protection_comparison',
+    description: 'Calculate how much a privacy score would improve with SIP Protocol protection.',
+    schema: z.object({
+      currentScore: z.number().min(0).max(100).describe('Current privacy score'),
+      addressReuseScore: z.number().min(0).max(25).describe('Address reuse score component'),
+      clusterScore: z.number().min(0).max(25).describe('Cluster exposure score component'),
+    }),
+    func: async ({ currentScore, addressReuseScore, clusterScore }): Promise<string> => {
+      // SIP stealth addresses eliminate address reuse and cluster linking
+      const maxAddressImprovement = 25 - addressReuseScore
+      const maxClusterImprovement = 25 - clusterScore
+
+      // SIP typically provides 80-90% of theoretical maximum improvement
+      const addressImprovement = Math.round(maxAddressImprovement * 0.85)
+      const clusterImprovement = Math.round(maxClusterImprovement * 0.80)
+      const totalImprovement = addressImprovement + clusterImprovement
+
+      const projectedScore = Math.min(100, currentScore + totalImprovement)
+
+      return JSON.stringify({
+        currentScore,
+        projectedScore,
+        improvement: totalImprovement,
+        breakdown: {
+          addressReuse: {
+            current: addressReuseScore,
+            projected: addressReuseScore + addressImprovement,
+            reason: 'Stealth addresses prevent address reuse',
+          },
+          cluster: {
+            current: clusterScore,
+            projected: clusterScore + clusterImprovement,
+            reason: 'Each stealth address is unlinkable',
+          },
+        },
+        recommendation: totalImprovement > 20
+          ? 'SIP Protocol would significantly improve your privacy'
+          : totalImprovement > 10
+            ? 'SIP Protocol would moderately improve your privacy'
+            : 'Your privacy is already good, but SIP can help maintain it',
+      })
+    },
+  })
+}
+
+/**
+ * Create the explain concept tool
+ *
+ * @returns LangChain tool for explaining privacy concepts
+ */
+export function createExplainTool(): DynamicStructuredTool {
+  const explanations: Record<string, string> = {
+    'stealth-address': 'A stealth address is like a P.O. Box that automatically changes after each delivery. When someone sends you crypto, it goes to a unique address that only you can access. Even if someone knows your main address, they cannot link all your received payments together.',
+    'pedersen-commitment': 'A Pedersen commitment is like a sealed envelope with a number inside. You can prove the envelope contains a valid number without opening it. This lets blockchain verify transactions are correct without revealing the actual amounts.',
+    'viewing-key': 'A viewing key is like giving someone read-only access to your bank statements. They can see your transactions but cannot spend your money. This is useful for tax preparers, auditors, or proving funds to a lender.',
+    'address-reuse': 'Address reuse is when you receive multiple payments to the same address. This is bad for privacy because anyone watching that address can see all your incoming payments and potentially link them to your identity.',
+    'cluster-analysis': 'Cluster analysis is a technique used to link multiple wallet addresses to the same owner. By analyzing transaction patterns (like which addresses send to each other or appear together), analysts can de-anonymize users.',
+    'privacy-score': 'Your privacy score (0-100) measures how resistant your wallet is to surveillance. Higher is better. It considers: address reuse (are you using the same address?), cluster exposure (can your wallets be linked?), exchange interactions (do KYC exchanges know you?), and timing patterns.',
+  }
+
+  return new DynamicStructuredTool({
+    name: 'explain_privacy_concept',
+    description: 'Explain a privacy concept in simple terms',
+    schema: z.object({
+      concept: z.enum([
+        'stealth-address',
+        'pedersen-commitment',
+        'viewing-key',
+        'address-reuse',
+        'cluster-analysis',
+        'privacy-score',
+      ]).describe('The concept to explain'),
+    }),
+    func: async ({ concept }): Promise<string> => {
+      return explanations[concept] ?? 'I don\'t have an explanation for that concept yet.'
+    },
+  })
+}
+
+/**
+ * Format analysis result for the agent
+ */
+function formatAnalysisResult(result: FullAnalysisResult): string {
+  const { privacyScore, addressReuse, cluster, exchangeExposure, temporalPatterns, sipComparison } = result
+
+  // Format recommendations for readability
+  const topRecommendations = privacyScore.recommendations
+    .slice(0, 5)
+    .map((rec: SurveillanceRecommendation, i: number) => ({
+      rank: i + 1,
+      title: rec.title,
+      action: rec.action,
+      severity: rec.severity,
+      potentialGain: rec.potentialGain,
+    }))
+
+  return JSON.stringify({
+    // Summary
+    overall: {
+      score: privacyScore.overall,
+      risk: privacyScore.risk,
+      analyzedAt: new Date(privacyScore.analyzedAt).toISOString(),
+    },
+
+    // Score breakdown
+    breakdown: privacyScore.breakdown,
+
+    // Key findings
+    findings: {
+      addressReuse: {
+        count: addressReuse.totalReuseCount,
+        severity: addressReuse.scoreDeduction > 15 ? 'critical' : addressReuse.scoreDeduction > 8 ? 'high' : 'medium',
+        mostReused: addressReuse.reusedAddresses.slice(0, 3),
+      },
+      clusterExposure: {
+        linkedAddresses: cluster.linkedAddressCount,
+        confidence: cluster.confidence,
+        clusters: cluster.clusters.length,
+      },
+      exchangeExposure: {
+        exchanges: exchangeExposure.exchangeCount,
+        deposits: exchangeExposure.depositCount,
+        withdrawals: exchangeExposure.withdrawalCount,
+        kycExchanges: exchangeExposure.exchanges.filter((e: { kycRequired: boolean }) => e.kycRequired).length,
+      },
+      temporalPatterns: {
+        patternsFound: temporalPatterns.patterns.length,
+        inferredTimezone: temporalPatterns.inferredTimezone,
+        patterns: temporalPatterns.patterns.map((p: { type: string; confidence: number }) => ({
+          type: p.type,
+          confidence: p.confidence,
+        })),
+      },
+    },
+
+    // SIP improvement projection
+    sipComparison: {
+      currentScore: sipComparison.currentScore,
+      projectedScore: sipComparison.projectedScore,
+      improvement: sipComparison.improvement,
+    },
+
+    // Top recommendations
+    recommendations: topRecommendations,
+
+    // Transaction count analyzed
+    transactionCount: result.transactionCount,
+  }, null, 2)
+}
+
+/**
+ * Get a quick summary based on score
+ */
+function getQuickSummary(score: number): string {
+  if (score >= 80) {
+    return 'Excellent privacy. Your wallet shows minimal surveillance exposure.'
+  } else if (score >= 60) {
+    return 'Good privacy with some room for improvement. Consider using stealth addresses.'
+  } else if (score >= 40) {
+    return 'Moderate privacy risks detected. Your wallet activity may be trackable.'
+  } else if (score >= 20) {
+    return 'High privacy risks. Your wallet is significantly exposed to surveillance.'
+  } else {
+    return 'Critical privacy risks. Your wallet activity is highly visible to analysts.'
+  }
+}
+
+/**
+ * Create all tools for the Privacy Advisor agent
+ *
+ * @param config - Tool configuration
+ * @returns Array of LangChain tools
+ *
+ * @example
+ * ```typescript
+ * const tools = createPrivacyAdvisorTools({
+ *   heliusApiKey: process.env.HELIUS_API_KEY!,
+ *   cluster: 'mainnet-beta',
+ * })
+ *
+ * // Use with LangChain agent
+ * const agent = await createOpenAIToolsAgent({
+ *   llm: model,
+ *   tools,
+ *   prompt,
+ * })
+ * ```
+ */
+export function createPrivacyAdvisorTools(config: ToolsConfig): DynamicStructuredTool[] {
+  return [
+    createAnalyzeWalletTool(config),
+    createQuickScoreTool(config),
+    createSIPComparisonTool(),
+    createExplainTool(),
+  ]
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -954,6 +954,12 @@ export type {
 export {
   PrivacyAdvisorAgent,
   createPrivacyAdvisor,
+  // LangChain tools
+  createPrivacyAdvisorTools,
+  createAnalyzeWalletTool,
+  createQuickScoreTool,
+  createSIPComparisonTool,
+  createExplainTool,
 } from './advisor'
 
 export type {
@@ -971,4 +977,6 @@ export type {
   // Utilities
   ToolResult,
   StreamCallback,
+  // Tools config
+  ToolsConfig,
 } from './advisor'

--- a/packages/sdk/tests/advisor-tools.test.ts
+++ b/packages/sdk/tests/advisor-tools.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Privacy Advisor Tools Tests
+ *
+ * Tests for the LangChain tools that power the Privacy Advisor Agent.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import {
+  createPrivacyAdvisorTools,
+  createAnalyzeWalletTool,
+  createQuickScoreTool,
+  createSIPComparisonTool,
+  createExplainTool,
+} from '../src/advisor/tools'
+
+// Mock the SurveillanceAnalyzer
+vi.mock('../src/surveillance/analyzer', () => ({
+  SurveillanceAnalyzer: vi.fn().mockImplementation(() => ({
+    analyze: vi.fn().mockResolvedValue({
+      privacyScore: {
+        overall: 65,
+        risk: 'medium',
+        analyzedAt: Date.now(),
+        breakdown: {
+          addressReuse: 18,
+          clusterExposure: 15,
+          exchangeExposure: 12,
+          temporalPatterns: 10,
+          socialLinks: 10,
+        },
+        recommendations: [
+          {
+            id: 'rec-1',
+            title: 'Use stealth addresses',
+            action: 'Enable stealth addresses for receiving payments',
+            severity: 'high',
+            potentialGain: 10,
+            category: 'addressReuse',
+            description: 'Stealth addresses prevent address reuse',
+          },
+        ],
+      },
+      addressReuse: {
+        totalReuseCount: 5,
+        receiveReuseCount: 3,
+        sendReuseCount: 2,
+        scoreDeduction: 7,
+        reusedAddresses: [
+          { address: 'GjKr7abc123', useCount: 3, type: 'receive' },
+        ],
+      },
+      cluster: {
+        linkedAddressCount: 2,
+        confidence: 0.8,
+        scoreDeduction: 10,
+        clusters: [
+          { addresses: ['addr1', 'addr2'], linkType: 'common-input', transactionCount: 5 },
+        ],
+      },
+      exchangeExposure: {
+        exchangeCount: 2,
+        depositCount: 5,
+        withdrawalCount: 3,
+        scoreDeduction: 8,
+        exchanges: [
+          { name: 'Binance', type: 'cex', kycRequired: true, deposits: 3, withdrawals: 2 },
+        ],
+      },
+      temporalPatterns: {
+        patterns: [{ type: 'regular-schedule', confidence: 0.7 }],
+        inferredTimezone: 'UTC-5',
+        scoreDeduction: 5,
+      },
+      socialLinks: {
+        isDoxxed: false,
+        partialExposure: false,
+        scoreDeduction: 0,
+        links: [],
+      },
+      sipComparison: {
+        currentScore: 65,
+        projectedScore: 85,
+        improvement: 20,
+      },
+      transactionCount: 150,
+      analysisDurationMs: 2500,
+    }),
+    quickScore: vi.fn().mockResolvedValue({
+      score: 65,
+      risk: 'medium',
+      topIssue: 'Address reuse detected',
+    }),
+  })),
+}))
+
+describe('Privacy Advisor Tools', () => {
+  const mockConfig = {
+    heliusApiKey: 'test-api-key',
+    cluster: 'mainnet-beta' as const,
+  }
+
+  describe('createPrivacyAdvisorTools', () => {
+    it('should create all 4 tools', () => {
+      const tools = createPrivacyAdvisorTools(mockConfig)
+
+      expect(tools).toHaveLength(4)
+      expect(tools.map((t) => t.name)).toEqual([
+        'analyze_wallet',
+        'quick_privacy_score',
+        'sip_protection_comparison',
+        'explain_privacy_concept',
+      ])
+    })
+  })
+
+  describe('createAnalyzeWalletTool', () => {
+    it('should have correct name and description', () => {
+      const tool = createAnalyzeWalletTool(mockConfig)
+
+      expect(tool.name).toBe('analyze_wallet')
+      expect(tool.description).toContain('Solana wallet')
+      expect(tool.description).toContain('privacy')
+    })
+
+    it('should analyze a wallet and return formatted JSON', async () => {
+      const tool = createAnalyzeWalletTool(mockConfig)
+      const result = await tool.invoke({ address: 'GjKr7abc123xyz456' })
+
+      const parsed = JSON.parse(result)
+      expect(parsed.overall.score).toBe(65)
+      expect(parsed.overall.risk).toBe('medium')
+      expect(parsed.breakdown).toBeDefined()
+      expect(parsed.findings).toBeDefined()
+      expect(parsed.sipComparison).toBeDefined()
+      expect(parsed.recommendations).toBeDefined()
+    })
+
+    it('should return error on analysis failure', async () => {
+      const { SurveillanceAnalyzer } = await import('../src/surveillance/analyzer')
+      vi.mocked(SurveillanceAnalyzer).mockImplementationOnce(() => ({
+        analyze: vi.fn().mockRejectedValue(new Error('Network error')),
+        quickScore: vi.fn(),
+      }))
+
+      const tool = createAnalyzeWalletTool(mockConfig)
+      const result = await tool.invoke({ address: 'invalid' })
+
+      const parsed = JSON.parse(result)
+      expect(parsed.error).toBe(true)
+      expect(parsed.message).toContain('Failed to analyze wallet')
+    })
+  })
+
+  describe('createQuickScoreTool', () => {
+    it('should have correct name and description', () => {
+      const tool = createQuickScoreTool(mockConfig)
+
+      expect(tool.name).toBe('quick_privacy_score')
+      expect(tool.description).toContain('quick')
+      expect(tool.description).toContain('less detailed')
+    })
+
+    it('should return quick score with summary', async () => {
+      const tool = createQuickScoreTool(mockConfig)
+      const result = await tool.invoke({ address: 'GjKr7abc123xyz456' })
+
+      const parsed = JSON.parse(result)
+      expect(parsed.score).toBe(65)
+      expect(parsed.risk).toBe('medium')
+      expect(parsed.topIssue).toBe('Address reuse detected')
+      expect(parsed.summary).toBeDefined()
+    })
+  })
+
+  describe('createSIPComparisonTool', () => {
+    it('should have correct name and description', () => {
+      const tool = createSIPComparisonTool()
+
+      expect(tool.name).toBe('sip_protection_comparison')
+      expect(tool.description).toContain('SIP Protocol')
+    })
+
+    it('should calculate improvement for low score wallet', async () => {
+      const tool = createSIPComparisonTool()
+      const result = await tool.invoke({
+        currentScore: 40,
+        addressReuseScore: 5,
+        clusterScore: 5,
+      })
+
+      const parsed = JSON.parse(result)
+      expect(parsed.currentScore).toBe(40)
+      expect(parsed.projectedScore).toBeGreaterThan(40)
+      expect(parsed.improvement).toBeGreaterThan(20)
+      expect(parsed.breakdown.addressReuse).toBeDefined()
+      expect(parsed.breakdown.cluster).toBeDefined()
+    })
+
+    it('should calculate minimal improvement for high score wallet', async () => {
+      const tool = createSIPComparisonTool()
+      const result = await tool.invoke({
+        currentScore: 90,
+        addressReuseScore: 23,
+        clusterScore: 24,
+      })
+
+      const parsed = JSON.parse(result)
+      expect(parsed.improvement).toBeLessThan(5)
+      expect(parsed.recommendation).toContain('already good')
+    })
+  })
+
+  describe('createExplainTool', () => {
+    it('should have correct name and description', () => {
+      const tool = createExplainTool()
+
+      expect(tool.name).toBe('explain_privacy_concept')
+      expect(tool.description).toContain('privacy concept')
+    })
+
+    it('should explain stealth addresses', async () => {
+      const tool = createExplainTool()
+      const result = await tool.invoke({ concept: 'stealth-address' })
+
+      expect(result).toContain('P.O. Box')
+      expect(result).toContain('unique address')
+    })
+
+    it('should explain viewing keys', async () => {
+      const tool = createExplainTool()
+      const result = await tool.invoke({ concept: 'viewing-key' })
+
+      expect(result).toContain('read-only')
+      expect(result).toContain('bank statements')
+    })
+
+    it('should explain address reuse', async () => {
+      const tool = createExplainTool()
+      const result = await tool.invoke({ concept: 'address-reuse' })
+
+      expect(result).toContain('bad for privacy')
+      expect(result).toContain('multiple payments')
+    })
+
+    it('should explain cluster analysis', async () => {
+      const tool = createExplainTool()
+      const result = await tool.invoke({ concept: 'cluster-analysis' })
+
+      expect(result).toContain('link')
+      expect(result).toContain('transaction patterns')
+    })
+
+    it('should explain privacy score', async () => {
+      const tool = createExplainTool()
+      const result = await tool.invoke({ concept: 'privacy-score' })
+
+      expect(result).toContain('0-100')
+      expect(result).toContain('surveillance')
+    })
+
+    it('should explain Pedersen commitments', async () => {
+      const tool = createExplainTool()
+      const result = await tool.invoke({ concept: 'pedersen-commitment' })
+
+      expect(result).toContain('sealed envelope')
+      expect(result).toContain('without revealing')
+    })
+  })
+})
+
+describe('Tool Schema Validation', () => {
+  const mockConfig = {
+    heliusApiKey: 'test-api-key',
+    cluster: 'mainnet-beta' as const,
+  }
+
+  it('analyze_wallet requires address', () => {
+    const tool = createAnalyzeWalletTool(mockConfig)
+    const schema = tool.schema as { shape: { address: object } }
+
+    expect(schema.shape.address).toBeDefined()
+  })
+
+  it('sip_protection_comparison requires numeric inputs', () => {
+    const tool = createSIPComparisonTool()
+    const schema = tool.schema as {
+      shape: {
+        currentScore: object
+        addressReuseScore: object
+        clusterScore: object
+      }
+    }
+
+    expect(schema.shape.currentScore).toBeDefined()
+    expect(schema.shape.addressReuseScore).toBeDefined()
+    expect(schema.shape.clusterScore).toBeDefined()
+  })
+
+  it('explain_privacy_concept has valid enum values', () => {
+    const tool = createExplainTool()
+    const schema = tool.schema as { shape: { concept: { options: string[] } } }
+
+    expect(schema.shape.concept).toBeDefined()
+  })
+})
+
+describe('Integration with LangChain', () => {
+  const mockConfig = {
+    heliusApiKey: 'test-api-key',
+    cluster: 'mainnet-beta' as const,
+  }
+
+  it('tools are compatible with LangChain DynamicStructuredTool interface', () => {
+    const tools = createPrivacyAdvisorTools(mockConfig)
+
+    for (const tool of tools) {
+      expect(tool.name).toBeDefined()
+      expect(tool.description).toBeDefined()
+      expect(tool.schema).toBeDefined()
+      expect(typeof tool.invoke).toBe('function')
+    }
+  })
+
+  it('tools return string results for LLM consumption', async () => {
+    const tools = createPrivacyAdvisorTools(mockConfig)
+
+    const results = await Promise.all([
+      tools[0]?.invoke({ address: 'test123' }),
+      tools[1]?.invoke({ address: 'test123' }),
+      tools[2]?.invoke({
+        currentScore: 50,
+        addressReuseScore: 10,
+        clusterScore: 10,
+      }),
+      tools[3]?.invoke({ concept: 'stealth-address' }),
+    ])
+
+    for (const result of results) {
+      expect(typeof result).toBe('string')
+    }
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,6 +287,9 @@ importers:
       '@triton-one/yellowstone-grpc':
         specifier: ^4.0.2
         version: 4.0.2
+      langchain:
+        specifier: ^0.3.0
+        version: 0.3.37(@langchain/core@0.3.80)(ws@7.5.10)
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -1110,6 +1113,16 @@ packages:
     transitivePeerDependencies:
       - encoding
       - ws
+    dev: false
+
+  /@langchain/textsplitters@0.1.0(@langchain/core@0.3.80):
+    resolution: {integrity: sha512-djI4uw9rlkAb5iMhtLED+xJebDdAG935AdP4eRTB02R7OB/act55Bj9wsskhZsvuyQRpO4O1wQOp85s6T6GWmw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.2.21 <0.4.0'
+    dependencies:
+      '@langchain/core': 0.3.80
+      js-tiktoken: 1.0.21
     dev: false
 
   /@ledgerhq/devices@8.8.0:
@@ -2924,7 +2937,6 @@ packages:
 
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-    dev: true
 
   /aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
@@ -4492,7 +4504,6 @@ packages:
     hasBin: true
     dependencies:
       argparse: 2.0.1
-    dev: true
 
   /jsdom@27.4.0:
     resolution: {integrity: sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==}
@@ -4560,6 +4571,11 @@ packages:
       graceful-fs: 4.2.11
     dev: true
 
+  /jsonpointer@5.0.1:
+    resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
     dependencies:
@@ -4569,6 +4585,85 @@ packages:
   /kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
+
+  /langchain@0.3.37(@langchain/core@0.3.80)(ws@7.5.10):
+    resolution: {integrity: sha512-1jPsZ6xsxkcQPUvqRjvfuOLwZLLyt49hzcOK7OYAJovIkkOxd5gzK4Yw6giPUQ8g4XHyvULNlWBz+subdkcokw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/anthropic': '*'
+      '@langchain/aws': '*'
+      '@langchain/cerebras': '*'
+      '@langchain/cohere': '*'
+      '@langchain/core': '>=0.3.58 <0.4.0'
+      '@langchain/deepseek': '*'
+      '@langchain/google-genai': '*'
+      '@langchain/google-vertexai': '*'
+      '@langchain/google-vertexai-web': '*'
+      '@langchain/groq': '*'
+      '@langchain/mistralai': '*'
+      '@langchain/ollama': '*'
+      '@langchain/xai': '*'
+      axios: '*'
+      cheerio: '*'
+      handlebars: ^4.7.8
+      peggy: ^3.0.2
+      typeorm: '*'
+    peerDependenciesMeta:
+      '@langchain/anthropic':
+        optional: true
+      '@langchain/aws':
+        optional: true
+      '@langchain/cerebras':
+        optional: true
+      '@langchain/cohere':
+        optional: true
+      '@langchain/deepseek':
+        optional: true
+      '@langchain/google-genai':
+        optional: true
+      '@langchain/google-vertexai':
+        optional: true
+      '@langchain/google-vertexai-web':
+        optional: true
+      '@langchain/groq':
+        optional: true
+      '@langchain/mistralai':
+        optional: true
+      '@langchain/ollama':
+        optional: true
+      '@langchain/xai':
+        optional: true
+      axios:
+        optional: true
+      cheerio:
+        optional: true
+      handlebars:
+        optional: true
+      peggy:
+        optional: true
+      typeorm:
+        optional: true
+    dependencies:
+      '@langchain/core': 0.3.80
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80)(ws@7.5.10)
+      '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.80)
+      js-tiktoken: 1.0.21
+      js-yaml: 4.1.1
+      jsonpointer: 5.0.1
+      langsmith: 0.3.87
+      openapi-types: 12.1.3
+      p-retry: 4.6.2
+      uuid: 10.0.0
+      yaml: 2.8.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - encoding
+      - openai
+      - ws
+    dev: false
 
   /langsmith@0.3.87:
     resolution: {integrity: sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==}
@@ -5060,6 +5155,10 @@ packages:
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
+    dev: false
+
+  /openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
     dev: false
 
   /optionator@0.9.4:
@@ -6663,7 +6762,6 @@ packages:
     resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
     engines: {node: '>= 14.6'}
     hasBin: true
-    dev: true
 
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}


### PR DESCRIPTION
## Summary

Add LangChain-powered tools for the Privacy Advisor Agent, enabling AI-powered wallet privacy analysis and recommendations.

Closes #490

## Changes

- Add 4 new LangChain `DynamicStructuredTool` implementations:
  - `analyze_wallet` - Full wallet privacy analysis via SurveillanceAnalyzer
  - `quick_privacy_score` - Fast scoring for real-time UI feedback
  - `sip_protection_comparison` - Calculate SIP Protocol improvement projections
  - `explain_privacy_concept` - Plain English explanations of privacy concepts
- Add `createPrivacyAdvisorTools()` factory function for easy tool creation
- Export `ToolsConfig` type for custom tool configurations
- Add comprehensive test suite (21 tests)

## Usage

```typescript
import { createPrivacyAdvisorTools } from '@sip-protocol/sdk'

// Create all tools for a LangChain agent
const tools = createPrivacyAdvisorTools({
  heliusApiKey: process.env.HELIUS_API_KEY!,
  cluster: 'mainnet-beta',
})

// Or create individual tools
import { createAnalyzeWalletTool, createExplainTool } from '@sip-protocol/sdk'

const analyzeTool = createAnalyzeWalletTool({ heliusApiKey: '...' })
const explainTool = createExplainTool()
```

## Test Plan

- [x] All 21 new tests pass
- [x] Type check passes
- [x] Existing tests unaffected

---
🤖 Generated with [Claude Code](https://claude.ai/code)