### PR TITLE
fix(sdk): replace placeholder program IDs with clear markers (#528)

### DIFF
--- a/packages/sdk/src/privacy-backends/arcium-types.ts
+++ b/packages/sdk/src/privacy-backends/arcium-types.ts
@@ -304,11 +304,16 @@ export const ARCIUM_CLUSTERS: Record<ArciumNetwork, string> = {
 
 /**
  * Arcium program addresses on Solana
+ *
+ * NOTE: These are PLACEHOLDER addresses for type safety only.
+ * Real program IDs come from @arcium-hq/client SDK at runtime.
+ * The PLACEHOLDER prefix makes them obviously invalid to prevent
+ * accidental use in production or devnet testing.
  */
 export const ARCIUM_PROGRAM_IDS: Record<ArciumNetwork, string> = {
-  devnet: 'ArcmDevnetProgramAddress111111111111111111111',
-  testnet: 'ArcmTestnetProgramAddress11111111111111111111',
-  'mainnet-beta': 'ArcmMainnetProgramAddress11111111111111111111',
+  devnet: 'PLACEHLDRArciumDevnet11111111111111111111111',
+  testnet: 'PLACEHLDRArciumTestnet1111111111111111111111',
+  'mainnet-beta': 'PLACEHLDRArciumMainnet1111111111111111111111',
 }
 
 /**

--- a/packages/sdk/src/privacy-backends/cspl-types.ts
+++ b/packages/sdk/src/privacy-backends/cspl-types.ts
@@ -445,14 +445,19 @@ export const CSPL_TOKENS: Record<string, Partial<CSPLToken>> = {
 /**
  * C-SPL program IDs
  *
- * Note: These are placeholder values. Real values TBD when C-SPL launches.
+ * NOTE: TOKEN_PROGRAM and ATA_PROGRAM are PLACEHOLDER addresses.
+ * Real values TBD when C-SPL launches on Solana.
+ * The PLACEHOLDR prefix makes them obviously invalid to prevent
+ * accidental use in production.
+ *
+ * CONFIDENTIAL_TRANSFER is the real Solana Token-2022 program ID.
  */
 export const CSPL_PROGRAM_IDS = {
-  /** C-SPL token program */
-  TOKEN_PROGRAM: 'CSPL1111111111111111111111111111111111111111',
-  /** C-SPL associated token account program */
-  ATA_PROGRAM: 'CSPLAta11111111111111111111111111111111111111',
-  /** Confidential transfer extension */
+  /** C-SPL token program (PLACEHOLDER - TBD) */
+  TOKEN_PROGRAM: 'PLACEHLDRCSPLTokenProgram111111111111111111',
+  /** C-SPL associated token account program (PLACEHOLDER - TBD) */
+  ATA_PROGRAM: 'PLACEHLDRCSPLAtaProgram1111111111111111111',
+  /** Confidential transfer extension (REAL Solana Token-2022 program) */
   CONFIDENTIAL_TRANSFER: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
 } as const
 


### PR DESCRIPTION
## Summary

- Update ARCIUM_PROGRAM_IDS with `PLACEHOLDR` prefix to make them obviously invalid
- Update CSPL_PROGRAM_IDS (TOKEN_PROGRAM, ATA_PROGRAM) with `PLACEHOLDR` prefix
- Keep CONFIDENTIAL_TRANSFER as the real Solana Token-2022 program ID
- Add clear documentation explaining placeholder status

**Before:**
```typescript
devnet: 'ArcmDevnetProgramAddress111111111111111111111'
TOKEN_PROGRAM: 'CSPL1111111111111111111111111111111111111111'
```

**After:**
```typescript
devnet: 'PLACEHLDRArciumDevnet11111111111111111111111'
TOKEN_PROGRAM: 'PLACEHLDRCSPLTokenProgram111111111111111111'
```

All placeholders are valid base58 (32-44 chars, no 0/O/I/l characters).

## Test plan

- [x] Run Arcium tests (57 tests pass)
- [x] Verify all placeholders are valid base58 format

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)