### PR TITLE
feat(sdk): add privacy-aware logging utilities (#518)

### DIFF
--- a/packages/sdk/tests/privacy-logger.test.ts
+++ b/packages/sdk/tests/privacy-logger.test.ts
@@ -23,7 +23,7 @@ describe('redactAddress', () => {
 
 describe('redactSignature', () => {
   it('should redact a transaction signature', () => {
-    expect(redactSignature('5UHBqFQ6nFBfMqYD8T2N7YRB7gXqKcvZKTAGLvqCGxqB7QprZR8C3qYvzVNKxGRv8z')).toBe('5UHBqF...GRv8z')
+    expect(redactSignature('5UHBqFQ6nFBfMqYD8T2N7YRB7gXqKcvZKTAGLvqCGxqB7QprZR8C3qYvzVNKxGRv8z')).toBe('5UHBqF...xGRv8z')
   })
   it('should handle empty', () => {
     expect(redactSignature('')).toBe('[invalid]')


### PR DESCRIPTION
## Summary
- Add `privacy-logger.ts` with `PrivacyLogger` class and utility functions for automatic sensitive data redaction
- `redactAddress()` - Redacts wallet addresses to show only first/last 4 chars
- `redactSignature()` - Redacts transaction signatures
- `maskAmount()` - Masks amounts to show ranges (e.g., "1-10 SOL")
- `redactSensitiveData()` - Bulk redaction for objects with sensitive fields
- Update MagicBlock backend to use `magicBlockLogger.debug()`
- Update PrivacyCash backend to use `privacyCashLogger.warn()`
- Export logging utilities from SDK entry point

## Test plan
- [x] Run `pnpm vitest run tests/privacy-logger.test.ts` - All 19 tests pass
- [ ] Verify sensitive data is properly redacted in logs during usage
- [ ] Verify exports work correctly from `@sip-protocol/sdk`

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)