### PR TITLE
docs(sdk): add TODO comments for unused parameters

### DIFF
--- a/packages/sdk/src/privacy-backends/cspl-token.ts
+++ b/packages/sdk/src/privacy-backends/cspl-token.ts
@@ -487,7 +487,15 @@ export class CSPLTokenService {
    * @param owner - Token owner address
    * @returns Revoke result
    */
-  async revoke(csplMint: string, _delegate: string, _owner: string): Promise<ApproveResult> {
+  async revoke(
+    csplMint: string,
+    _delegate: string,
+    _owner: string
+  ): Promise<ApproveResult> {
+    // TODO(#536): _delegate and _owner are reserved for production implementation.
+    // They will be used in createRevokeTransaction() when C-SPL SDK is integrated.
+    // See: https://github.com/sip-protocol/sip-protocol/issues/536
+
     if (!this.initialized) {
       return {
         success: false,
@@ -505,7 +513,7 @@ export class CSPLTokenService {
 
     try {
       // In production: Create and submit revoke transaction
-      // const tx = await createRevokeTransaction(token, delegate, owner)
+      // const tx = await createRevokeTransaction(token, _delegate, _owner)
       // const signature = await sendTransaction(tx)
 
       // Simulated success

--- a/packages/sdk/src/privacy-backends/magicblock.ts
+++ b/packages/sdk/src/privacy-backends/magicblock.ts
@@ -399,6 +399,10 @@ export class MagicBlockBackend implements PrivacyBackend {
 
   /**
    * Estimate transfer cost in lamports
+   *
+   * TODO(#536): _params is reserved for dynamic cost calculation based on
+   * amount, token type, or other factors when TEE pricing becomes variable.
+   * Currently using fixed costs for simplicity.
    */
   private estimateTransferCost(_params: TransferParams): bigint {
     // Base transaction fee


### PR DESCRIPTION
## Summary

- Document intent for underscore-prefixed parameters reserved for future implementation
- Add TODO comments with issue reference for tracking

## Analysis

Reviewed all underscore-prefixed parameters in privacy-backends:

| File | Params | Status |
|------|--------|--------|
| arcium.ts:243 | `_params` | ✅ Correct - interface requirement, method returns error |
| inco.ts:239 | `_params` | ✅ Correct - interface requirement, method returns error |
| mock.ts:189 | `_params` | ✅ Correct - mock intentionally ignores params |
| cspl-token.ts:490 | `_delegate`, `_owner` | ⚠️ Added TODO - reserved for production |
| magicblock.ts:403 | `_params` | ⚠️ Added TODO - reserved for dynamic costs |

## Changes

- `cspl-token.ts`: Add TODO comment explaining `_delegate` and `_owner` are reserved for C-SPL SDK integration
- `magicblock.ts`: Add TODO comment explaining `_params` reserved for dynamic cost calculation

## Test plan

- [x] 67 related tests pass (combined-privacy + magicblock)

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)