### PR TITLE
feat(sdk): add env var configuration for Arcium RPC endpoints

### DIFF
--- a/packages/sdk/src/privacy-backends/index.ts
+++ b/packages/sdk/src/privacy-backends/index.ts
@@ -191,9 +191,18 @@ export {
   MAX_INPUT_SIZE_BYTES,
   MAX_TOTAL_INPUT_SIZE_BYTES,
   MAX_COMPUTATION_COST_LAMPORTS,
+  // Error handling
   ArciumError,
   isArciumError,
   type ArciumErrorCode,
+  // Environment variable configuration
+  ARCIUM_ENV_VARS,
+  DEFAULT_RPC_ENDPOINTS,
+  getEnvVar,
+  resolveRpcUrl,
+  resolveNetwork,
+  resolveTimeout,
+  resolveCluster,
   type ArciumNetwork,
   type ArciumConfig,
   type ArciumCluster,


### PR DESCRIPTION
## Summary
- Add environment variable configuration for Arcium backend settings
- Allow runtime override of RPC URLs, network, timeout, and cluster without code changes
- Support network-specific env vars (e.g., `ARCIUM_RPC_URL_DEVNET`) with fallback to generic vars

## Changes
- Add `ARCIUM_ENV_VARS` constant with all supported env var names
- Add `DEFAULT_RPC_ENDPOINTS` with default Solana RPC URLs per network
- Add resolver functions: `resolveRpcUrl`, `resolveNetwork`, `resolveTimeout`, `resolveCluster`
- Add `getEnvVar` helper for cross-platform env var reading (Node.js + browser)
- Update `ArciumBackend` constructor to use resolver functions
- Export new constants and functions from index.ts
- Add 34 new tests for env var configuration

## Configuration Priority
```
network-specific env → generic env → config → default
```

## Example Usage
```bash
# Configure via environment variables
export ARCIUM_RPC_URL_DEVNET=https://my-rpc.example.com
export ARCIUM_RPC_URL_MAINNET=https://mainnet.my-rpc.example.com
export ARCIUM_NETWORK=devnet
export ARCIUM_TIMEOUT_MS=600000
export ARCIUM_CLUSTER=custom-cluster
```

```typescript
// Or configure via constructor (env vars override)
const backend = new ArciumBackend({
  rpcUrl: 'https://my-rpc.example.com',
  network: 'devnet',
  timeout: 600_000,
})
```

## Test plan
- [x] All 130 Arcium tests pass
- [x] All 661 privacy backend tests pass
- [x] TypeScript typecheck passes
- [x] New tests for each resolver function
- [x] Tests for env var priority chain
- [x] Tests for invalid/missing env var handling

Fixes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)