### PR TITLE
feat(sdk): add configurable limits to ArciumBackend (#619)

### DIFF
--- a/packages/sdk/src/privacy-backends/index.ts
+++ b/packages/sdk/src/privacy-backends/index.ts
@@ -118,7 +118,7 @@ export {
 export { MockBackend, createMockFactory, type MockBackendConfig } from './mock'
 
 // Compute Backends
-export { ArciumBackend, type ArciumBackendConfig } from './arcium'
+export { ArciumBackend, type ArciumBackendConfig, type ArciumLimits } from './arcium'
 export { IncoBackend, type IncoBackendConfig } from './inco'
 
 // TEE Backend (Hardware-based Privacy)


### PR DESCRIPTION
## Summary

Closes #619

Adds runtime-configurable validation limits to `ArciumBackend` via the new `ArciumLimits` interface, allowing customization for different use cases.

## Changes

- Added `ArciumLimits` interface with 4 configurable limits:
  - `maxEncryptedInputs` - limit on number of encrypted inputs
  - `maxInputSizeBytes` - limit on individual input size  
  - `maxTotalInputSizeBytes` - limit on combined input size
  - `maxComputationCostLamports` - cap on computation costs
- Updated `ArciumBackendConfig` to accept optional `limits` property
- Updated validation methods to use instance limits instead of constants
- Added `getLimits()` method for inspecting current configuration
- Exported `ArciumLimits` type from `index.ts`

## Test Plan

- [x] Added 18 new tests for configurable limits
- [x] Tests cover custom limits, getLimits immutability, validation with custom limits
- [x] Boundary testing (MAX-1, MAX, MAX+1) for encrypted inputs and input sizes
- [x] All 94 Arcium tests pass

## Self-Audit

- [x] Code quality reviewed
- [x] No debug code
- [x] Error handling adequate
- [x] Tests added/updated
- [x] Types exported correctly

---
Solved by Claude via `/git:solve 619`
Worktree: `~/local-dev/sip-protocol-issue-619-arcium-configurable-limits`