### PR TITLE
feat(sdk): align CSPLClient.estimateCost to async pattern

### DIFF
--- a/packages/sdk/src/privacy-backends/cspl.ts
+++ b/packages/sdk/src/privacy-backends/cspl.ts
@@ -674,7 +674,9 @@ export class CSPLClient implements ICSPLClient {
    * @param operation - Operation type
    * @returns Estimated cost in lamports
    */
-  estimateCost(operation: keyof typeof CSPL_OPERATION_COSTS): bigint {
+  async estimateCost(
+    operation: keyof typeof CSPL_OPERATION_COSTS
+  ): Promise<bigint> {
     return CSPL_OPERATION_COSTS[operation]
   }
 

--- a/packages/sdk/tests/privacy-backends/cspl.test.ts
+++ b/packages/sdk/tests/privacy-backends/cspl.test.ts
@@ -795,8 +795,8 @@ describe('CSPLClient', () => {
       expect(tokens).toContain('C-USDT')
     })
 
-    it('should estimate cost', () => {
-      const cost = client.estimateCost('transfer')
+    it('should estimate cost', async () => {
+      const cost = await client.estimateCost('transfer')
 
       expect(cost).toBe(CSPL_OPERATION_COSTS.transfer)
     })


### PR DESCRIPTION
## Summary
- Makes `CSPLClient.estimateCost()` async to align with all other privacy backend `estimateCost` methods
- All backends now consistently return `Promise<bigint>` for cost estimation
- Updates test to use `async`/`await` pattern

## Motivation
Issue #531 identified inconsistency between `CSPLClient.estimateCost()` (sync, returns `bigint`) and other backends like `SIPNativeBackend`, `ArciumBackend`, `IncoBackend` which all have async `estimateCost` methods returning `Promise<bigint>`.

This alignment ensures:
- Consistent API patterns across all privacy backends
- Future-proofing for when cost estimation may need async operations (e.g., network calls for dynamic pricing)
- Better TypeScript type inference for callers

## Test plan
- [x] `pnpm typecheck` passes
- [x] All 86 CSPL tests pass
- [x] All 629 privacy backend tests pass
- [x] No breaking changes to existing callers (CSPLTokenService already wraps with async)

🤖 Generated with [Claude Code](https://claude.com/claude-code)