### PR TITLE
fix(sdk): align CSPLClient cost estimation to async for consistency

### DIFF
--- a/packages/sdk/src/privacy-backends/cspl.ts
+++ b/packages/sdk/src/privacy-backends/cspl.ts
@@ -671,20 +671,26 @@ export class CSPLClient implements ICSPLClient {
   /**
    * Estimate cost for an operation
    *
+   * Returns the estimated cost in lamports. Made async for consistency
+   * with other privacy backend cost estimation methods.
+   *
    * @param operation - Operation type
    * @returns Estimated cost in lamports
    */
-  estimateCost(operation: keyof typeof CSPL_OPERATION_COSTS): bigint {
+  async estimateCost(operation: keyof typeof CSPL_OPERATION_COSTS): Promise<bigint> {
     return CSPL_OPERATION_COSTS[operation]
   }
 
   /**
    * Estimate time for an operation
    *
+   * Returns the estimated time in milliseconds. Made async for consistency
+   * with other privacy backend estimation methods.
+   *
    * @param operation - Operation type
    * @returns Estimated time in milliseconds
    */
-  estimateTime(operation: keyof typeof CSPL_OPERATION_TIMES): number {
+  async estimateTime(operation: keyof typeof CSPL_OPERATION_TIMES): Promise<number> {
     return CSPL_OPERATION_TIMES[operation]
   }
 

--- a/packages/sdk/tests/privacy-backends/cspl.test.ts
+++ b/packages/sdk/tests/privacy-backends/cspl.test.ts
@@ -795,14 +795,14 @@ describe('CSPLClient', () => {
       expect(tokens).toContain('C-USDT')
     })
 
-    it('should estimate cost', () => {
-      const cost = client.estimateCost('transfer')
+    it('should estimate cost', async () => {
+      const cost = await client.estimateCost('transfer')
 
       expect(cost).toBe(CSPL_OPERATION_COSTS.transfer)
     })
 
-    it('should estimate time', () => {
-      const time = client.estimateTime('swap')
+    it('should estimate time', async () => {
+      const time = await client.estimateTime('swap')
 
       expect(time).toBe(CSPL_OPERATION_TIMES.swap)
     })


### PR DESCRIPTION
## Summary

Closes #531

Makes `CSPLClient.estimateCost()` and `estimateTime()` async to align with the `PrivacyBackend` interface pattern.

## Changes

- Made `CSPLClient.estimateCost()` return `Promise<bigint>` instead of `bigint`
- Made `CSPLClient.estimateTime()` return `Promise<number>` instead of `number`
- Updated tests to use `await`

## Rationale

All privacy backends use async cost estimation:
- `ArciumBackend.estimateCost()` - async
- `IncoBackend.estimateCost()` - async
- `SIPNativeBackend.estimateCost()` - async
- `MagicBlockBackend.estimateCost()` - async
- `PrivacyCashBackend.estimateCost()` - async
- `CSPLTokenService.estimateCost()` - async
- `CSPLClient.estimateCost()` - **was sync, now async**

This ensures consistent API semantics and allows for future async operations without breaking changes.

## Test Plan

- [x] `should estimate cost` test passes with await
- [x] `should estimate time` test passes with await
- [x] No other callers affected (CSPLClient is low-level, callers already use await)

---
Solved by Claude via `/git:solve 531`
Worktree: `~/local-dev/sip-protocol-issue-531-async-cost`