### PR TITLE
feat(sdk): implement LRU cache for token accounts (#525)

### DIFF
--- a/packages/sdk/src/privacy-backends/cspl.ts
+++ b/packages/sdk/src/privacy-backends/cspl.ts
@@ -69,6 +69,26 @@ import {
 
 import { isValidSolanaAddressFormat } from '../validation'
 import { deepFreeze } from './interface'
+import {
+  LRUCache,
+  DEFAULT_CACHE_SIZES,
+  DEFAULT_CACHE_TTL,
+  type LRUCacheStats,
+} from './lru-cache'
+
+/**
+ * Cache configuration for CSPLClient
+ */
+export interface CSPLCacheConfig {
+  /** Maximum entries in account cache (default: 1000) */
+  accountCacheSize?: number
+  /** Maximum entries in balance cache (default: 500) */
+  balanceCacheSize?: number
+  /** Account cache TTL in ms (default: 5 minutes) */
+  accountCacheTTL?: number
+  /** Balance cache TTL in ms (default: 30 seconds) */
+  balanceCacheTTL?: number
+}
 
 /**
  * Configuration for CSPLClient
@@ -82,6 +102,8 @@ export interface CSPLClientConfig {
   enableCompliance?: boolean
   /** Request timeout in milliseconds */
   timeout?: number
+  /** Cache configuration */
+  cache?: CSPLCacheConfig
 }
 
 /**
@@ -89,11 +111,22 @@ export interface CSPLClientConfig {
  *
  * Handles all operations for Confidential SPL tokens.
  */
+/**
+ * Extended cache stats including LRU metrics
+ */
+export interface CSPLCacheStats {
+  /** Account cache statistics */
+  accounts: LRUCacheStats
+  /** Balance cache statistics */
+  balances: LRUCacheStats
+}
+
 export class CSPLClient implements ICSPLClient {
-  private config: Required<CSPLClientConfig>
+  private config: Required<Omit<CSPLClientConfig, 'cache'>>
+  private cacheConfig: Required<CSPLCacheConfig>
   private connected: boolean = false
-  private accountCache: Map<string, ConfidentialTokenAccount> = new Map()
-  private balanceCache: Map<string, ConfidentialBalance> = new Map()
+  private accountCache: LRUCache<string, ConfidentialTokenAccount>
+  private balanceCache: LRUCache<string, ConfidentialBalance>
 
   /**
    * Create a new C-SPL client
@@ -107,6 +140,25 @@ export class CSPLClient implements ICSPLClient {
       enableCompliance: config.enableCompliance ?? false,
       timeout: config.timeout ?? 30_000,
     }
+
+    // Initialize cache configuration with defaults
+    this.cacheConfig = {
+      accountCacheSize: config.cache?.accountCacheSize ?? DEFAULT_CACHE_SIZES.TOKEN_ACCOUNTS,
+      balanceCacheSize: config.cache?.balanceCacheSize ?? DEFAULT_CACHE_SIZES.BALANCES,
+      accountCacheTTL: config.cache?.accountCacheTTL ?? DEFAULT_CACHE_TTL.TOKEN_ACCOUNTS,
+      balanceCacheTTL: config.cache?.balanceCacheTTL ?? DEFAULT_CACHE_TTL.BALANCES,
+    }
+
+    // Initialize LRU caches
+    this.accountCache = new LRUCache<string, ConfidentialTokenAccount>({
+      maxSize: this.cacheConfig.accountCacheSize,
+      ttl: this.cacheConfig.accountCacheTTL,
+    })
+
+    this.balanceCache = new LRUCache<string, ConfidentialBalance>({
+      maxSize: this.cacheConfig.balanceCacheSize,
+      ttl: this.cacheConfig.balanceCacheTTL,
+    })
   }
 
   /**
@@ -803,12 +855,47 @@ export class CSPLClient implements ICSPLClient {
   }
 
   /**
-   * Get cache stats
+   * Get cache entry counts (backward compatible)
+   *
+   * @returns Number of entries in each cache
    */
   getCacheStats(): { accounts: number; balances: number } {
     return {
       accounts: this.accountCache.size,
       balances: this.balanceCache.size,
+    }
+  }
+
+  /**
+   * Get detailed cache statistics including LRU metrics
+   *
+   * @returns Detailed cache stats with hit rates and eviction counts
+   */
+  getDetailedCacheStats(): CSPLCacheStats {
+    return {
+      accounts: this.accountCache.getStats(),
+      balances: this.balanceCache.getStats(),
+    }
+  }
+
+  /**
+   * Get cache configuration
+   *
+   * @returns Current cache configuration
+   */
+  getCacheConfig(): Readonly<CSPLCacheConfig> {
+    return deepFreeze({ ...this.cacheConfig })
+  }
+
+  /**
+   * Prune expired entries from all caches
+   *
+   * @returns Number of entries pruned from each cache
+   */
+  pruneExpiredCache(): { accounts: number; balances: number } {
+    return {
+      accounts: this.accountCache.prune(),
+      balances: this.balanceCache.prune(),
     }
   }
 }

--- a/packages/sdk/src/privacy-backends/index.ts
+++ b/packages/sdk/src/privacy-backends/index.ts
@@ -96,6 +96,13 @@ export { withTimeout } from './interface'
 
 // Utilities
 export { deepFreeze } from './interface'
+export {
+  LRUCache,
+  DEFAULT_CACHE_SIZES,
+  DEFAULT_CACHE_TTL,
+  type LRUCacheConfig,
+  type LRUCacheStats,
+} from './lru-cache'
 
 // Health tracking
 export { BackendHealthTracker } from './health'
@@ -207,7 +214,12 @@ export {
 } from './inco-types'
 
 // C-SPL (Confidential SPL) types and client
-export { CSPLClient, type CSPLClientConfig } from './cspl'
+export {
+  CSPLClient,
+  type CSPLClientConfig,
+  type CSPLCacheConfig,
+  type CSPLCacheStats,
+} from './cspl'
 export {
   CSPL_TOKENS,
   CSPL_PROGRAM_IDS,

--- a/packages/sdk/src/privacy-backends/lru-cache.ts
+++ b/packages/sdk/src/privacy-backends/lru-cache.ts
@@ -1,0 +1,343 @@
+/**
+ * LRU (Least Recently Used) Cache Implementation
+ *
+ * A generic, efficient LRU cache with configurable max size and optional TTL.
+ * Automatically evicts the least recently used entries when the cache is full.
+ *
+ * @example
+ * ```typescript
+ * // Basic usage with max size
+ * const cache = new LRUCache<string, User>({ maxSize: 100 })
+ * cache.set('user:123', user)
+ * const cached = cache.get('user:123')
+ *
+ * // With TTL expiration (5 minutes)
+ * const cacheWithTTL = new LRUCache<string, Balance>({
+ *   maxSize: 1000,
+ *   ttl: 5 * 60 * 1000,
+ * })
+ * ```
+ *
+ * @see https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)
+ */
+
+/**
+ * Configuration options for LRU cache
+ */
+export interface LRUCacheConfig {
+  /**
+   * Maximum number of entries to store.
+   * When exceeded, the least recently used entry is evicted.
+   *
+   * @default 1000
+   */
+  maxSize?: number
+
+  /**
+   * Time-to-live in milliseconds for cache entries.
+   * Entries older than this are considered expired and will be evicted.
+   * If not set, entries never expire based on time.
+   *
+   * @default undefined (no TTL)
+   */
+  ttl?: number
+
+  /**
+   * Called when an entry is evicted from the cache.
+   * Useful for cleanup operations or logging.
+   */
+  onEvict?: (key: string, value: unknown) => void
+}
+
+/**
+ * Internal cache entry with metadata
+ */
+interface CacheEntry<V> {
+  /** The cached value */
+  value: V
+  /** Timestamp when entry was created/updated */
+  createdAt: number
+}
+
+/**
+ * LRU Cache Statistics
+ */
+export interface LRUCacheStats {
+  /** Current number of entries */
+  size: number
+  /** Maximum allowed entries */
+  maxSize: number
+  /** Number of cache hits */
+  hits: number
+  /** Number of cache misses */
+  misses: number
+  /** Hit rate as a percentage (0-100) */
+  hitRate: number
+  /** Number of entries evicted */
+  evictions: number
+}
+
+/**
+ * LRU (Least Recently Used) Cache
+ *
+ * Efficient O(1) get/set operations using Map iteration order.
+ * When the cache exceeds maxSize, the oldest (least recently used) entries
+ * are automatically evicted.
+ *
+ * @typeParam K - Key type (must be a valid Map key)
+ * @typeParam V - Value type
+ */
+export class LRUCache<K extends string, V> {
+  private cache: Map<K, CacheEntry<V>> = new Map()
+  private readonly config: Required<Pick<LRUCacheConfig, 'maxSize'>> & LRUCacheConfig
+  private stats = { hits: 0, misses: 0, evictions: 0 }
+
+  /**
+   * Create a new LRU cache
+   *
+   * @param config - Cache configuration
+   */
+  constructor(config: LRUCacheConfig = {}) {
+    this.config = {
+      maxSize: config.maxSize ?? 1000,
+      ttl: config.ttl,
+      onEvict: config.onEvict,
+    }
+
+    if (this.config.maxSize < 1) {
+      throw new Error('maxSize must be at least 1')
+    }
+  }
+
+  /**
+   * Get a value from the cache
+   *
+   * If the entry exists and hasn't expired, it's moved to the end
+   * of the cache (most recently used position).
+   *
+   * @param key - Cache key
+   * @returns The cached value, or undefined if not found/expired
+   */
+  get(key: K): V | undefined {
+    const entry = this.cache.get(key)
+
+    if (!entry) {
+      this.stats.misses++
+      return undefined
+    }
+
+    // Check TTL expiration
+    if (this.isExpired(entry)) {
+      this.delete(key)
+      this.stats.misses++
+      return undefined
+    }
+
+    // Move to end (most recently used) by re-inserting
+    this.cache.delete(key)
+    this.cache.set(key, entry)
+
+    this.stats.hits++
+    return entry.value
+  }
+
+  /**
+   * Check if a key exists in the cache (without updating LRU order)
+   *
+   * @param key - Cache key
+   * @returns True if key exists and hasn't expired
+   */
+  has(key: K): boolean {
+    const entry = this.cache.get(key)
+    if (!entry) return false
+
+    if (this.isExpired(entry)) {
+      this.delete(key)
+      return false
+    }
+
+    return true
+  }
+
+  /**
+   * Set a value in the cache
+   *
+   * If the cache is at capacity, the least recently used entry
+   * is evicted before adding the new entry.
+   *
+   * @param key - Cache key
+   * @param value - Value to cache
+   */
+  set(key: K, value: V): void {
+    // Delete existing entry to update LRU order
+    if (this.cache.has(key)) {
+      this.cache.delete(key)
+    }
+
+    // Evict oldest entries if at capacity
+    while (this.cache.size >= this.config.maxSize) {
+      this.evictOldest()
+    }
+
+    // Add new entry at end (most recently used)
+    this.cache.set(key, {
+      value,
+      createdAt: Date.now(),
+    })
+  }
+
+  /**
+   * Delete an entry from the cache
+   *
+   * @param key - Cache key
+   * @returns True if the entry was deleted
+   */
+  delete(key: K): boolean {
+    const entry = this.cache.get(key)
+    if (!entry) return false
+
+    this.cache.delete(key)
+
+    if (this.config.onEvict) {
+      this.config.onEvict(key, entry.value)
+    }
+
+    return true
+  }
+
+  /**
+   * Clear all entries from the cache
+   */
+  clear(): void {
+    if (this.config.onEvict) {
+      for (const [key, entry] of this.cache) {
+        this.config.onEvict(key, entry.value)
+      }
+    }
+    this.cache.clear()
+  }
+
+  /**
+   * Get the current number of entries
+   */
+  get size(): number {
+    return this.cache.size
+  }
+
+  /**
+   * Get all keys in the cache (in LRU order, oldest first)
+   */
+  keys(): IterableIterator<K> {
+    return this.cache.keys()
+  }
+
+  /**
+   * Get all values in the cache (in LRU order, oldest first)
+   */
+  values(): V[] {
+    return Array.from(this.cache.values()).map(entry => entry.value)
+  }
+
+  /**
+   * Get cache statistics
+   *
+   * @returns Cache stats including hit rate and eviction count
+   */
+  getStats(): LRUCacheStats {
+    const totalAccesses = this.stats.hits + this.stats.misses
+    return {
+      size: this.cache.size,
+      maxSize: this.config.maxSize,
+      hits: this.stats.hits,
+      misses: this.stats.misses,
+      hitRate: totalAccesses > 0 ? (this.stats.hits / totalAccesses) * 100 : 0,
+      evictions: this.stats.evictions,
+    }
+  }
+
+  /**
+   * Reset cache statistics
+   */
+  resetStats(): void {
+    this.stats = { hits: 0, misses: 0, evictions: 0 }
+  }
+
+  /**
+   * Prune expired entries from the cache
+   *
+   * This is automatically called during get(), but can be called
+   * manually to clean up expired entries proactively.
+   *
+   * @returns Number of entries pruned
+   */
+  prune(): number {
+    if (!this.config.ttl) return 0
+
+    let pruned = 0
+    const now = Date.now()
+
+    for (const [key, entry] of this.cache) {
+      if (now - entry.createdAt > this.config.ttl) {
+        this.delete(key)
+        pruned++
+      }
+    }
+
+    return pruned
+  }
+
+  // ─── Private Methods ────────────────────────────────────────────────────────
+
+  /**
+   * Check if an entry has expired based on TTL
+   */
+  private isExpired(entry: CacheEntry<V>): boolean {
+    if (!this.config.ttl) return false
+    return Date.now() - entry.createdAt > this.config.ttl
+  }
+
+  /**
+   * Evict the oldest (least recently used) entry
+   */
+  private evictOldest(): void {
+    // Map iteration order is insertion order, so first entry is oldest
+    const oldestKey = this.cache.keys().next().value
+    if (oldestKey !== undefined) {
+      const entry = this.cache.get(oldestKey)
+      this.cache.delete(oldestKey)
+      this.stats.evictions++
+
+      if (this.config.onEvict && entry) {
+        this.config.onEvict(oldestKey, entry.value)
+      }
+    }
+  }
+}
+
+/**
+ * Default cache sizes for different use cases
+ */
+export const DEFAULT_CACHE_SIZES = {
+  /** Token accounts cache */
+  TOKEN_ACCOUNTS: 1000,
+  /** Balance cache */
+  BALANCES: 500,
+  /** Computation cache */
+  COMPUTATIONS: 100,
+  /** Pool info cache */
+  POOLS: 50,
+} as const
+
+/**
+ * Default TTL values in milliseconds
+ */
+export const DEFAULT_CACHE_TTL = {
+  /** Token accounts: 5 minutes */
+  TOKEN_ACCOUNTS: 5 * 60 * 1000,
+  /** Balances: 30 seconds (balances change frequently) */
+  BALANCES: 30 * 1000,
+  /** Computations: 10 minutes */
+  COMPUTATIONS: 10 * 60 * 1000,
+  /** Pool info: 1 minute */
+  POOLS: 60 * 1000,
+} as const

--- a/packages/sdk/tests/privacy-backends/lru-cache.test.ts
+++ b/packages/sdk/tests/privacy-backends/lru-cache.test.ts
@@ -1,0 +1,400 @@
+/**
+ * LRU Cache Tests
+ *
+ * Tests for the LRU (Least Recently Used) cache implementation.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  LRUCache,
+  DEFAULT_CACHE_SIZES,
+  DEFAULT_CACHE_TTL,
+} from '../../src/privacy-backends/lru-cache'
+
+describe('LRUCache', () => {
+  describe('basic operations', () => {
+    it('should store and retrieve values', () => {
+      const cache = new LRUCache<string, number>({ maxSize: 10 })
+
+      cache.set('a', 1)
+      cache.set('b', 2)
+
+      expect(cache.get('a')).toBe(1)
+      expect(cache.get('b')).toBe(2)
+    })
+
+    it('should return undefined for missing keys', () => {
+      const cache = new LRUCache<string, number>({ maxSize: 10 })
+
+      expect(cache.get('nonexistent')).toBeUndefined()
+    })
+
+    it('should overwrite existing values', () => {
+      const cache = new LRUCache<string, number>({ maxSize: 10 })
+
+      cache.set('a', 1)
+      cache.set('a', 2)
+
+      expect(cache.get('a')).toBe(2)
+      expect(cache.size).toBe(1)
+    })
+
+    it('should delete values', () => {
+      const cache = new LRUCache<string, number>({ maxSize: 10 })
+
+      cache.set('a', 1)
+      expect(cache.delete('a')).toBe(true)
+      expect(cache.get('a')).toBeUndefined()
+    })
+
+    it('should return false when deleting non-existent key', () => {
+      const cache = new LRUCache<string, number>({ maxSize: 10 })
+
+      expect(cache.delete('nonexistent')).toBe(false)
+    })
+
+    it('should clear all values', () => {
+      const cache = new LRUCache<string, number>({ maxSize: 10 })
+
+      cache.set('a', 1)
+      cache.set('b', 2)
+      cache.clear()
+
+      expect(cache.size).toBe(0)
+      expect(cache.get('a')).toBeUndefined()
+    })
+
+    it('should check if key exists with has()', () => {
+      const cache = new LRUCache<string, number>({ maxSize: 10 })
+
+      cache.set('a', 1)
+
+      expect(cache.has('a')).toBe(true)
+      expect(cache.has('b')).toBe(false)
+    })
+  })
+
+  describe('LRU eviction', () => {
+    it('should evict oldest entry when at capacity', () => {
+      const cache = new LRUCache<string, number>({ maxSize: 3 })
+
+      cache.set('a', 1)
+      cache.set('b', 2)
+      cache.set('c', 3)
+      cache.set('d', 4) // Should evict 'a'
+
+      expect(cache.get('a')).toBeUndefined()
+      expect(cache.get('b')).toBe(2)
+      expect(cache.get('c')).toBe(3)
+      expect(cache.get('d')).toBe(4)
+      expect(cache.size).toBe(3)
+    })
+
+    it('should move accessed entry to end (most recently used)', () => {
+      const cache = new LRUCache<string, number>({ maxSize: 3 })
+
+      cache.set('a', 1)
+      cache.set('b', 2)
+      cache.set('c', 3)
+
+      // Access 'a' to move it to the end
+      cache.get('a')
+
+      // Now 'b' is the oldest
+      cache.set('d', 4) // Should evict 'b'
+
+      expect(cache.get('a')).toBe(1)
+      expect(cache.get('b')).toBeUndefined()
+      expect(cache.get('c')).toBe(3)
+      expect(cache.get('d')).toBe(4)
+    })
+
+    it('should move updated entry to end', () => {
+      const cache = new LRUCache<string, number>({ maxSize: 3 })
+
+      cache.set('a', 1)
+      cache.set('b', 2)
+      cache.set('c', 3)
+
+      // Update 'a' to move it to the end
+      cache.set('a', 10)
+
+      // Now 'b' is the oldest
+      cache.set('d', 4) // Should evict 'b'
+
+      expect(cache.get('a')).toBe(10)
+      expect(cache.get('b')).toBeUndefined()
+    })
+
+    it('should evict multiple entries if needed', () => {
+      const cache = new LRUCache<string, number>({ maxSize: 2 })
+
+      cache.set('a', 1)
+      cache.set('b', 2)
+      cache.set('c', 3) // Evicts 'a'
+
+      expect(cache.size).toBe(2)
+      expect(cache.get('a')).toBeUndefined()
+    })
+  })
+
+  describe('TTL expiration', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('should expire entries after TTL', () => {
+      const cache = new LRUCache<string, number>({
+        maxSize: 10,
+        ttl: 1000, // 1 second
+      })
+
+      cache.set('a', 1)
+      expect(cache.get('a')).toBe(1)
+
+      // Advance time past TTL
+      vi.advanceTimersByTime(1001)
+
+      expect(cache.get('a')).toBeUndefined()
+    })
+
+    it('should not expire entries before TTL', () => {
+      const cache = new LRUCache<string, number>({
+        maxSize: 10,
+        ttl: 1000,
+      })
+
+      cache.set('a', 1)
+
+      // Advance time but not past TTL
+      vi.advanceTimersByTime(500)
+
+      expect(cache.get('a')).toBe(1)
+    })
+
+    it('should report expired entries as not existing via has()', () => {
+      const cache = new LRUCache<string, number>({
+        maxSize: 10,
+        ttl: 1000,
+      })
+
+      cache.set('a', 1)
+      expect(cache.has('a')).toBe(true)
+
+      vi.advanceTimersByTime(1001)
+
+      expect(cache.has('a')).toBe(false)
+    })
+
+    it('should prune expired entries', () => {
+      const cache = new LRUCache<string, number>({
+        maxSize: 10,
+        ttl: 1000,
+      })
+
+      cache.set('a', 1)
+      cache.set('b', 2)
+
+      vi.advanceTimersByTime(500)
+      cache.set('c', 3) // Added later, not expired yet
+
+      vi.advanceTimersByTime(600) // a and b are now expired, c is not
+
+      const pruned = cache.prune()
+
+      expect(pruned).toBe(2)
+      expect(cache.get('a')).toBeUndefined()
+      expect(cache.get('b')).toBeUndefined()
+      expect(cache.get('c')).toBe(3)
+    })
+  })
+
+  describe('onEvict callback', () => {
+    it('should call onEvict when entry is evicted', () => {
+      const onEvict = vi.fn()
+      const cache = new LRUCache<string, number>({
+        maxSize: 2,
+        onEvict,
+      })
+
+      cache.set('a', 1)
+      cache.set('b', 2)
+      cache.set('c', 3) // Evicts 'a'
+
+      expect(onEvict).toHaveBeenCalledWith('a', 1)
+    })
+
+    it('should call onEvict when entry is deleted', () => {
+      const onEvict = vi.fn()
+      const cache = new LRUCache<string, number>({
+        maxSize: 10,
+        onEvict,
+      })
+
+      cache.set('a', 1)
+      cache.delete('a')
+
+      expect(onEvict).toHaveBeenCalledWith('a', 1)
+    })
+
+    it('should call onEvict for all entries when cleared', () => {
+      const onEvict = vi.fn()
+      const cache = new LRUCache<string, number>({
+        maxSize: 10,
+        onEvict,
+      })
+
+      cache.set('a', 1)
+      cache.set('b', 2)
+      cache.clear()
+
+      expect(onEvict).toHaveBeenCalledTimes(2)
+      expect(onEvict).toHaveBeenCalledWith('a', 1)
+      expect(onEvict).toHaveBeenCalledWith('b', 2)
+    })
+  })
+
+  describe('statistics', () => {
+    it('should track hits and misses', () => {
+      const cache = new LRUCache<string, number>({ maxSize: 10 })
+
+      cache.set('a', 1)
+      cache.get('a') // Hit
+      cache.get('a') // Hit
+      cache.get('b') // Miss
+      cache.get('c') // Miss
+
+      const stats = cache.getStats()
+      expect(stats.hits).toBe(2)
+      expect(stats.misses).toBe(2)
+      expect(stats.hitRate).toBe(50)
+    })
+
+    it('should track evictions', () => {
+      const cache = new LRUCache<string, number>({ maxSize: 2 })
+
+      cache.set('a', 1)
+      cache.set('b', 2)
+      cache.set('c', 3) // Evicts 'a'
+      cache.set('d', 4) // Evicts 'b'
+
+      const stats = cache.getStats()
+      expect(stats.evictions).toBe(2)
+    })
+
+    it('should reset statistics', () => {
+      const cache = new LRUCache<string, number>({ maxSize: 10 })
+
+      cache.set('a', 1)
+      cache.get('a')
+      cache.get('b')
+
+      cache.resetStats()
+
+      const stats = cache.getStats()
+      expect(stats.hits).toBe(0)
+      expect(stats.misses).toBe(0)
+      expect(stats.evictions).toBe(0)
+    })
+
+    it('should report correct size and maxSize', () => {
+      const cache = new LRUCache<string, number>({ maxSize: 100 })
+
+      cache.set('a', 1)
+      cache.set('b', 2)
+
+      const stats = cache.getStats()
+      expect(stats.size).toBe(2)
+      expect(stats.maxSize).toBe(100)
+    })
+
+    it('should handle hit rate when no accesses', () => {
+      const cache = new LRUCache<string, number>({ maxSize: 10 })
+
+      const stats = cache.getStats()
+      expect(stats.hitRate).toBe(0)
+    })
+  })
+
+  describe('iteration', () => {
+    it('should iterate keys in LRU order (oldest first)', () => {
+      const cache = new LRUCache<string, number>({ maxSize: 10 })
+
+      cache.set('a', 1)
+      cache.set('b', 2)
+      cache.set('c', 3)
+
+      const keys = Array.from(cache.keys())
+      expect(keys).toEqual(['a', 'b', 'c'])
+    })
+
+    it('should return values in LRU order', () => {
+      const cache = new LRUCache<string, number>({ maxSize: 10 })
+
+      cache.set('a', 1)
+      cache.set('b', 2)
+      cache.set('c', 3)
+
+      expect(cache.values()).toEqual([1, 2, 3])
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should throw when maxSize is less than 1', () => {
+      expect(() => new LRUCache<string, number>({ maxSize: 0 })).toThrow('maxSize must be at least 1')
+      expect(() => new LRUCache<string, number>({ maxSize: -1 })).toThrow('maxSize must be at least 1')
+    })
+
+    it('should work with maxSize of 1', () => {
+      const cache = new LRUCache<string, number>({ maxSize: 1 })
+
+      cache.set('a', 1)
+      cache.set('b', 2) // Evicts 'a'
+
+      expect(cache.size).toBe(1)
+      expect(cache.get('a')).toBeUndefined()
+      expect(cache.get('b')).toBe(2)
+    })
+
+    it('should handle complex object values', () => {
+      interface User {
+        id: number
+        name: string
+      }
+
+      const cache = new LRUCache<string, User>({ maxSize: 10 })
+
+      const user = { id: 1, name: 'Alice' }
+      cache.set('user:1', user)
+
+      expect(cache.get('user:1')).toEqual({ id: 1, name: 'Alice' })
+    })
+
+    it('should use default maxSize when not specified', () => {
+      const cache = new LRUCache<string, number>()
+
+      const stats = cache.getStats()
+      expect(stats.maxSize).toBe(1000)
+    })
+  })
+
+  describe('default cache sizes', () => {
+    it('should define reasonable defaults', () => {
+      expect(DEFAULT_CACHE_SIZES.TOKEN_ACCOUNTS).toBe(1000)
+      expect(DEFAULT_CACHE_SIZES.BALANCES).toBe(500)
+      expect(DEFAULT_CACHE_SIZES.COMPUTATIONS).toBe(100)
+      expect(DEFAULT_CACHE_SIZES.POOLS).toBe(50)
+    })
+
+    it('should define reasonable TTL values', () => {
+      expect(DEFAULT_CACHE_TTL.TOKEN_ACCOUNTS).toBe(5 * 60 * 1000) // 5 minutes
+      expect(DEFAULT_CACHE_TTL.BALANCES).toBe(30 * 1000) // 30 seconds
+      expect(DEFAULT_CACHE_TTL.COMPUTATIONS).toBe(10 * 60 * 1000) // 10 minutes
+      expect(DEFAULT_CACHE_TTL.POOLS).toBe(60 * 1000) // 1 minute
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Implements LRU cache for `CSPLClient` token account and balance caches
- Adds configurable cache size and TTL
- Prevents unbounded memory growth in long-running services
- Provides cache statistics with hit rates and eviction metrics

Closes #525

## Changes

### New Files
- `src/privacy-backends/lru-cache.ts` - Generic LRU cache implementation with:
  - Configurable max size (default: 1000 accounts, 500 balances)
  - Optional TTL (default: 5 min accounts, 30 sec balances)
  - Cache statistics (hits, misses, hit rate, evictions)
  - `prune()` method for manual cleanup

### Modified Files
- `src/privacy-backends/cspl.ts`:
  - Replace `Map` caches with `LRUCache`
  - Add `CSPLCacheConfig` interface
  - Add `getDetailedCacheStats()` for LRU metrics
  - Add `getCacheConfig()` for config inspection
  - Add `pruneExpiredCache()` for manual cleanup
  - Keep backward-compatible `getCacheStats()` returning simple counts

- `src/privacy-backends/index.ts`:
  - Export `LRUCache`, `DEFAULT_CACHE_SIZES`, `DEFAULT_CACHE_TTL`
  - Export `CSPLCacheConfig`, `CSPLCacheStats` types

### Tests Added
- `tests/privacy-backends/lru-cache.test.ts` (31 tests) - Core LRU cache tests
- `tests/privacy-backends/cspl.test.ts` (+5 tests) - Integration tests for:
  - Detailed cache stats with LRU metrics
  - Cache configuration
  - Custom cache configuration
  - Expired entry pruning
  - LRU eviction behavior

## Test plan
- [x] `pnpm typecheck` passes
- [x] All 91 CSPL tests pass
- [x] All 31 LRU cache tests pass
- [x] All 665 privacy backend tests pass
- [x] Backward compatible `getCacheStats()` preserved

## Self-Audit
- [x] Code follows existing patterns
- [x] No debug code
- [x] Cache keys use `confidentialMint` (tested eviction)
- [x] Default values match documented defaults
- [x] TTL and size bounds are reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)