### PR TITLE
feat(sdk): implement LRU cache for CSPLClient token accounts

### DIFF
--- a/packages/sdk/src/privacy-backends/index.ts
+++ b/packages/sdk/src/privacy-backends/index.ts
@@ -95,7 +95,7 @@ export {
 export { withTimeout } from './interface'
 
 // Utilities
-export { deepFreeze } from './interface'
+export { deepFreeze, LRUCache, type LRUCacheConfig } from './interface'
 
 // Health tracking
 export { BackendHealthTracker } from './health'


### PR DESCRIPTION
## Summary

Closes #525

Implements bounded memory usage for C-SPL token account and balance caches with LRU eviction and optional TTL expiration. This prevents unbounded memory growth in long-running services.

## Changes

- **New `LRUCache<T>` class** in `interface.ts`:
  - Configurable max size (default: 100)
  - Optional TTL expiration
  - O(1) get/set operations
  - Detailed statistics (hits, misses, evictions, hit rate)

- **Updated `CSPLClient`**:
  - Uses LRU caches instead of unbounded `Map` objects
  - New config options: `cacheMaxSize`, `cacheTtlMs`
  - Enhanced `getCacheStats()` with detailed per-cache stats
  - New `getCacheConfig()` method

- **Exports**:
  - `LRUCache` class
  - `LRUCacheConfig` type

## Defaults

| Config | Default | Description |
|--------|---------|-------------|
| `cacheMaxSize` | 100 | Max entries before LRU eviction |
| `cacheTtlMs` | 300,000 | TTL (5 minutes) |

## Test Plan

- [x] 16 new LRU cache tests (all pass)
- [x] Updated CSPL tests for new stats format (86/88 pass, 2 failures are pre-existing package issues)
- [x] Tests cover: basic ops, LRU eviction, TTL expiration, statistics

---
Solved by Claude via `/git:solve 525`
Worktree: `~/local-dev/sip-protocol-issue-525-lru-cache`