### PR TITLE
chore(react-native): bump version to 0.1.1

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sip-protocol/react-native",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "React Native SDK for Shielded Intents Protocol - privacy on iOS/Android",
   "author": "SIP Protocol <hello@sip-protocol.org>",
   "homepage": "https://sip-protocol.org",


### PR DESCRIPTION
## Summary

Bump @sip-protocol/react-native version to 0.1.1 to fix Release workflow failure.

## Problem

The Release workflow is failing because version 0.1.0 was already published to npm, but the local version wasn't incremented. This causes a 403 error when trying to republish.

## Fix

Bump version from 0.1.0 → 0.1.1