### PR TITLE
docs: add sources of truth inventory, update M16 status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Quick reference for navigating between SIP Protocol repositories.
 **Key Commands:**
 ```bash
 pnpm install                    # Install dependencies
-pnpm test -- --run              # Run all tests (2,757 tests)
+pnpm test -- --run              # Run all tests (4,108+ tests)
 pnpm typecheck                  # Type check
 pnpm build                      # Build all packages
 ```
@@ -227,6 +227,23 @@ pnpm preview                    # Preview build
 
 ---
 
+## SOURCES OF TRUTH
+
+> **Code is truth. Docs are derived.** Before updating documentation, verify against code.
+
+See **[docs/INVENTORY.md](docs/INVENTORY.md)** for full ecosystem inventory.
+
+**Quick verification (run from repo root):**
+```bash
+ls packages/ programs/ contracts/ examples/   # Component inventory
+pnpm turbo test -- --run 2>&1 | grep "Tests"  # Test counts
+gh issue list --search "EPIC" --state open    # Active milestones
+```
+
+**Update triggers:** New package, version bump, test count change (>10%), new program/contract.
+
+---
+
 ## CURRENT FOCUS
 
 See [ROADMAP.md](ROADMAP.md) for detailed milestone tracking and priorities.
@@ -248,7 +265,7 @@ See [ROADMAP.md](ROADMAP.md) for detailed milestone tracking and priorities.
 
 **SIP (Shielded Intents Protocol)** is the privacy standard for Web3 — like HTTPS for the internet. One toggle to shield sender, amount, and recipient using stealth addresses, Pedersen commitments, and viewing keys for compliance.
 
-**Status:** M15 Complete | 2,757 tests (SDK: 2,474, React: 57, CLI: 33, API: 67, Website: 126) | Live at sip-protocol.org
+**Status:** M16 Complete | 4,108+ tests (SDK: 3,988, React: 82, CLI: 10, API: 18, RN: 10) | Live at sip-protocol.org
 
 **🏆 Achievement:** Winner — [Zypherpunk Hackathon](https://zypherpunk.xyz) ($4,500: NEAR $4,000 + Tachyon $500) | Dec 2025 | #14 of 88 | [Devfolio](https://devfolio.co/projects/sip-protocol-2026)
 
@@ -356,7 +373,7 @@ const payments = await scanForPayments({
 # Install dependencies
 pnpm install
 
-# Run all tests (2,757 tests)
+# Run all tests (4,108+ tests)
 pnpm test -- --run
 
 # Run E2E tests only (128 tests)
@@ -374,17 +391,17 @@ pnpm build
 
 ---
 
-## Test Suite (2,757 total tests)
+## Test Suite (4,108+ total tests)
 
 ### Package Test Counts
 
 | Package | Tests | Location |
 |---------|-------|----------|
-| @sip-protocol/sdk | 2,474 | `packages/sdk/tests/` |
-| @sip-protocol/react | 57 | `packages/react/tests/` |
-| @sip-protocol/cli | 33 | `packages/cli/tests/` |
-| @sip-protocol/api | 67 | `packages/api/tests/` |
-| sip-website | 126 | `tests/` (in sip-website repo) |
+| @sip-protocol/sdk | 3,988 | `packages/sdk/tests/` |
+| @sip-protocol/react | 82 | `packages/react/tests/` |
+| @sip-protocol/cli | 10 | `packages/cli/tests/` |
+| @sip-protocol/api | 18 | `packages/api/tests/` |
+| @sip-protocol/react-native | 10 | `packages/react-native/tests/` |
 
 ### SDK Test Breakdown
 
@@ -648,4 +665,4 @@ ssh core  # Admin user for nginx/system config
 ---
 
 **Last Updated:** 2025-12-31
-**Status:** M15 Complete | Phase 4 Starting (M16-M18) | 2,757 Tests | 6 Packages | 🏆 Zypherpunk Winner ($4,500, #14/88)
+**Status:** M16 Complete | Phase 4 Active (M17-M18) | 4,108+ Tests | 7 Packages | 🏆 Zypherpunk Winner ($4,500, #14/88)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 [![pnpm](https://img.shields.io/badge/pnpm-Monorepo-F69220?logo=pnpm&logoColor=white)](https://pnpm.io/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
-**🏆 Winner — [Zypherpunk Hackathon](https://zypherpunk.xyz) NEAR Track ($4,000)**
+**🏆 Winner — [Zypherpunk Hackathon](https://zypherpunk.xyz) ($4,500: NEAR $4,000 + Tachyon $500) | #14 of 88**
 
 </div>
 
@@ -375,11 +375,23 @@ User Input → Privacy Layer → Intent Creation → Solver Network → Executio
 
 ## 📚 Packages
 
-| Package | Description | Status |
-|---------|-------------|--------|
-| [`@sip-protocol/sdk`](packages/sdk) | Core SDK for creating shielded intents | ✅ Active |
-| [`@sip-protocol/types`](packages/types) | TypeScript type definitions | ✅ Active |
-| [`examples`](examples/) | Integration examples and reference implementations | ✅ Active |
+| Package | Version | Description | Tests |
+|---------|---------|-------------|-------|
+| [`@sip-protocol/sdk`](packages/sdk) | 0.7.3 | Core SDK for shielded intents | 3,988 |
+| [`@sip-protocol/types`](packages/types) | 0.2.1 | TypeScript type definitions | - |
+| [`@sip-protocol/react`](packages/react) | 0.1.0 | React hooks for SIP | 82 |
+| [`@sip-protocol/cli`](packages/cli) | 0.2.0 | CLI tool | 10 |
+| [`@sip-protocol/api`](packages/api) | 0.1.0 | REST API wrapper | 18 |
+| [`@sip-protocol/react-native`](packages/react-native) | 0.1.1 | iOS/Android SDK | 10 |
+| [`circuits`](packages/circuits) | - | Noir ZK circuits | - |
+
+**On-chain Programs:**
+| Program | Description |
+|---------|-------------|
+| [`sip-privacy`](programs/sip-privacy) | Solana Anchor program |
+| [`sip-ethereum`](contracts/sip-ethereum) | Ethereum Foundry contracts |
+
+**Examples:** 11 integration examples in [`examples/`](examples/)
 
 ---
 
@@ -422,39 +434,29 @@ See [SDK README](packages/sdk/README.md) for detailed provider documentation.
 
 ## 🗺️ Roadmap
 
-### Phase 1: Foundation ✅ **Complete**
+See [ROADMAP.md](ROADMAP.md) for detailed milestone tracking.
 
-- ✅ Core type definitions (ShieldedIntent, PrivacyLevel, StealthAddress)
-- ✅ SDK architecture (SIP client, IntentBuilder)
-- ✅ Stealth address generation (secp256k1, EIP-5564 style)
-- ✅ Pedersen commitment implementation
-- ✅ Reference application with comparison view
-- ✅ Monorepo setup (pnpm + Turborepo)
+### Phase 1-3: Foundation ✅ **Complete** (M1-M15)
 
-### Phase 2: Core Protocol 🔄 **In Progress**
+- ✅ Core SDK with stealth addresses, Pedersen commitments, viewing keys
+- ✅ Multi-chain support (15+ chains including Solana, Ethereum, NEAR)
+- ✅ ZK proof system (Noir circuits, browser proving)
+- ✅ NEAR Intents + Zcash integration
+- ✅ React, CLI, API packages
+- ✅ 4,108+ tests
 
-- ✅ Zcash testnet RPC client
-- ✅ Shielded transaction support
-- ✅ Solver interface design
-- ⏳ NEAR 1Click API integration
-- ⏳ End-to-end shielded flow
-- ⏳ Mock ZK proof generation
+### Phase 4: Same-Chain Expansion 🎯 **Active** (M16-M18)
 
-### Phase 3: Integration 📋 **Planned**
+- ✅ M16: Narrative capture (content, community, positioning)
+- 🔲 M17: Solana same-chain privacy (Anchor program)
+- 🔲 M18: Ethereum same-chain privacy (Solidity contracts)
 
-- [ ] Real ZK proof generation
-- [ ] Solver network integration
-- [ ] Multi-chain execution
-- [ ] Viewing key verification
-- [ ] Transaction status tracking
+### Phase 5: Technical Moat 🔲 **Planned** (M19-M22)
 
-### Phase 4: Production 🚀 **Future**
-
-- [ ] Security audit
-- [ ] Mainnet deployment
-- [ ] SDK v1.0 release
-- [ ] Documentation site
-- [ ] Additional chain support
+- 🔲 M19: Proof composition (Zcash + Mina)
+- 🔲 M20: Multi-language SDK (Python, Rust, Go)
+- 🔲 M21: SIP-EIP standard proposal
+- 🔲 M22: Institutional custody integration
 
 ---
 
@@ -483,7 +485,7 @@ See [SDK README](packages/sdk/README.md) for detailed provider documentation.
 
 ```bash
 # Clone the repository
-git clone https://github.com/RECTOR-LABS/sip-protocol.git
+git clone https://github.com/sip-protocol/sip-protocol.git
 cd sip-protocol
 
 # Install dependencies
@@ -496,10 +498,11 @@ pnpm dev
 ### Commands
 
 ```bash
-pnpm dev        # Start development server (port 3000)
-pnpm build      # Build all packages
-pnpm lint       # Lint code
-pnpm typecheck  # Type check
+pnpm dev              # Start development server
+pnpm build            # Build all packages
+pnpm test -- --run    # Run all tests (4,108+)
+pnpm lint             # Lint code
+pnpm typecheck        # Type check
 ```
 
 ---
@@ -595,7 +598,7 @@ SIP builds on the shoulders of giants:
 
 <div align="center">
 
-**🏆 Winner — [Zypherpunk Hackathon](https://zypherpunk.xyz) NEAR Track**
+**🏆 Winner — [Zypherpunk Hackathon](https://zypherpunk.xyz) ($4,500) | #14 of 88**
 
 *Privacy is not a feature. It's a right.*
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -732,16 +732,16 @@ See private strategy docs: `~/.claude/sip-protocol/SOLANA-PRIVACY-HACK.md`
 
 ---
 
-#### M16: Narrative Capture & Positioning 🔲 Q1 2026
+#### M16: Narrative Capture & Positioning ✅ Complete
 
-Establish SIP as "the right way to do privacy" before competitors solidify.
+Established SIP as "the right way to do privacy" — cryptographic vs pool mixing narrative.
 
 | Issue | Description | Budget | Status |
 |-------|-------------|--------|--------|
-| [#451](../../issues/451) | [EPIC] Narrative Capture | $10K total | 🎯 Starting |
-| [#384-391](../../issues?q=is%3Aissue+M16+article) | Content Campaign (8 articles + 15 threads) | $4,500 (45%) | 🔲 Planned |
-| [#392-395](../../issues?q=is%3Aissue+M16+community) | Community Building (Discord + Twitter) | $3,500 (35%) | 🔲 Planned |
-| [#396](../../issues/396) | Ecosystem Presentations (3 events) | $2,000 (20%) | 🔲 Planned |
+| [#451](../../issues/451) | [EPIC] Narrative Capture | $10K total | ✅ Done |
+| [#384-391](../../issues?q=is%3Aissue+M16+article) | Content Campaign (8 articles + 15 threads) | $4,500 (45%) | ✅ Done |
+| [#392-395](../../issues?q=is%3Aissue+M16+community) | Community Building (Discord + Twitter) | $3,500 (35%) | ✅ Done |
+| [#396](../../issues/396) | Ecosystem Presentations (3 events) | $2,000 (20%) | ✅ Done |
 
 **Deliverables:**
 - **Content:** 8 technical articles (Medium, Mirror, dev.to) + 15 Twitter threads
@@ -1358,13 +1358,13 @@ SIP is **chain-agnostic** — we enhance every chain, compete with none.
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 **Current focus areas:**
-- M16: Narrative capture and competitive positioning
-- M17: Solana same-chain privacy module
+- M17: Solana same-chain privacy module (30 issues)
+- Solana Privacy Hack (Jan 12 - Feb 1, 2026)
 - External security audit (M8 completion)
 - Foundation grant applications
 
 ---
 
-*Last updated: January 13, 2026*
-*Added: Full Stack Privacy concept (Dark AMM + SIP integration)*
-*Hackathon sprint added: Solana Privacy Hack (Jan 12 - Feb 1, 2026)*
+*Last updated: January 18, 2026*
+*M16 Narrative Capture completed*
+*Hackathon sprint active: Solana Privacy Hack (Jan 12 - Feb 1, 2026)*

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -1,0 +1,235 @@
+# SIP Protocol Ecosystem Inventory
+
+> **Source of Truth** for all SIP Protocol repositories and components.
+> Update this file when code structure changes.
+
+---
+
+## Quick Verification
+
+```bash
+# Run from sip-protocol/ root
+ls packages/                              # NPM packages (7)
+ls programs/                              # Solana programs
+ls contracts/                             # Ethereum contracts
+ls examples/                              # Integration examples (11)
+pnpm turbo test -- --run 2>&1 | grep "Tests"  # Test counts
+gh issue list --search "EPIC" --state open    # Active milestones
+```
+
+---
+
+## 1. sip-protocol/sip-protocol (Core Monorepo)
+
+### NPM Packages
+
+| Package | Version | Description | Tests |
+|---------|---------|-------------|-------|
+| `@sip-protocol/sdk` | 0.7.3 | Core SDK for shielded intents | 3,988 |
+| `@sip-protocol/types` | 0.2.1 | TypeScript type definitions | - |
+| `@sip-protocol/react` | 0.1.0 | React hooks | 82 |
+| `@sip-protocol/cli` | 0.2.0 | CLI tool | 10 |
+| `@sip-protocol/api` | 0.1.0 | REST API wrapper | 18 |
+| `@sip-protocol/react-native` | 0.1.1 | iOS/Android SDK | 10 |
+| `circuits` | - | Noir ZK circuits | - |
+
+**Total tests: 4,108+**
+
+### Solana Programs
+
+| Location | Description | Language |
+|----------|-------------|----------|
+| `programs/sip-privacy/` | Privacy program | Rust (Anchor) |
+
+**Structure:**
+```
+programs/sip-privacy/programs/sip-privacy/src/
+├── lib.rs              # Main program entry
+├── commitment/         # Pedersen commitment logic
+└── zk_verifier/        # ZK proof verification
+```
+
+### Ethereum Contracts
+
+| Location | Description | Language |
+|----------|-------------|----------|
+| `contracts/sip-ethereum/` | Privacy contracts | Solidity 0.8.24 (Foundry) |
+
+**Contracts:**
+```
+contracts/sip-ethereum/src/
+├── SIPPrivacy.sol              # Main privacy contract
+├── StealthAddressRegistry.sol  # Stealth address management
+├── ZKVerifier.sol              # ZK proof verification
+├── PedersenVerifier.sol        # Commitment verification
+├── interfaces/                 # Contract interfaces
+└── utils/                      # Utility libraries
+```
+
+### Examples
+
+| Directory | Description |
+|-----------|-------------|
+| `noir-solana-demo` | Noir circuits + Solana integration |
+| `compliance` | Viewing key compliance demo |
+| `private-payment` | Private payment flow |
+| `private-swap` | Private swap implementation |
+| `wallet-integration` | Wallet adapter examples |
+| `zcash-connection` | Zcash RPC integration |
+| `near-integration` | NEAR Intents integration |
+| `range-sas` | Range proofs with stealth addresses |
+| `react-hooks` | React hooks usage |
+| `solana-integration` | Solana same-chain privacy |
+| `ethereum-integration` | Ethereum same-chain privacy |
+
+### Documentation
+
+| Location | Description |
+|----------|-------------|
+| `docs/specs/` | Protocol specifications (17 files) |
+| `docs/security/` | Security docs, audit prep (7 files) |
+| `docs/research/` | Feasibility studies (2 files) |
+| `docs/workshops/` | Developer materials (4 files) |
+| `docs/content/` | M16 content campaign (4 files) |
+| `docs/community/` | Discord, DevRel, LOI templates (4 files) |
+| `docs/bounties/` | Hackathon submissions (2 files) |
+| `docs/circuits/` | Constraint analysis (1 file) |
+| `docs/runbooks/` | Incident response (1 file) |
+
+---
+
+## 2. sip-protocol/sip-app
+
+**Version:** 0.1.0
+**Stack:** Next.js 14, React 18, Tailwind, Zustand
+**Deployment:** app.sip-protocol.org (port 5005)
+
+### App Routes
+
+| Route | Description |
+|-------|-------------|
+| `/(dex)/` | Private DEX with Jupiter integration |
+| `/(payments)/` | Private payments (hackathon focus) |
+| `/(wallet)/` | Wallet interface |
+| `/(enterprise)/` | Compliance dashboard |
+| `/(tools)/` | Developer tools |
+| `/api/` | API routes |
+
+---
+
+## 3. sip-protocol/sip-website
+
+**Version:** 0.0.1
+**Stack:** Next.js 14, React 18, Tailwind
+**Deployment:** sip-protocol.org (port 5000)
+
+### Pages
+
+| Route | Description |
+|-------|-------------|
+| `/about` | About page |
+| `/features` | Feature showcase |
+| `/sdk` | SDK documentation |
+| `/roadmap` | Public roadmap |
+| `/pitch-deck` | Investor pitch |
+
+**Note:** Demo pages deprecated, migrated to sip-app.
+
+---
+
+## 4. sip-protocol/docs-sip
+
+**Version:** 0.0.0
+**Stack:** Astro Starlight, MDX
+**Deployment:** docs.sip-protocol.org (port 5003)
+
+### Documentation Sections
+
+| Section | Description |
+|---------|-------------|
+| `concepts/` | Core concepts |
+| `guides/` | How-to guides |
+| `specs/` | Technical specs |
+| `integrations/` | Integration guides |
+| `reference/` | API reference |
+| `security/` | Security documentation |
+| `cookbook/` | Code recipes |
+
+---
+
+## 5. sip-protocol/blog-sip
+
+**Version:** 0.0.1
+**Stack:** Astro 4, MDX, Tailwind
+**Deployment:** blog.sip-protocol.org (port 5004)
+
+**Posts:** 26 articles
+
+### Topics
+
+- Privacy architecture (Pedersen, stealth addresses)
+- Competitor analysis (PrivacyCash, pool mixing)
+- Integration tutorials (Arcium, Inco)
+- Regulatory landscape
+- SDK getting started
+
+---
+
+## 6. sip-protocol/circuits
+
+**Stack:** Noir, Barretenberg, Nargo CLI
+
+### Circuits
+
+| Circuit | Description |
+|---------|-------------|
+| Funding Proof | Prove balance >= minimum |
+| Validity Proof | Prove intent authorization |
+| Fulfillment Proof | Prove fulfillment correctness |
+
+---
+
+## 7. sip-protocol/.github
+
+### Contents
+
+| File | Description |
+|------|-------------|
+| `profile/README.md` | Organization profile page |
+| `ISSUE_TEMPLATE/` | Default issue templates |
+| `workflows/` | Shared GitHub Actions |
+
+---
+
+## VPS Deployment
+
+| Service | Port | Container | Domain |
+|---------|------|-----------|--------|
+| sip-website | 5000 | sip-website | sip-protocol.org |
+| sip-docs | 5003 | sip-docs | docs.sip-protocol.org |
+| sip-blog | 5004 | sip-blog | blog.sip-protocol.org |
+| sip-app | 5005 | sip-app | app.sip-protocol.org |
+
+---
+
+## Milestone Status
+
+| Phase | Milestones | Status |
+|-------|------------|--------|
+| Phase 1-3 | M1-M15 | ✅ Complete |
+| Phase 4 | M16 Narrative | ✅ Complete |
+| Phase 4 | M17 Solana Same-Chain | 🎯 Active (30 issues) |
+| Phase 4 | M18 Ethereum Same-Chain | 🔲 Planned |
+| Phase 5 | M19-M22 | 🔲 Planned |
+
+---
+
+## Update Log
+
+| Date | Change |
+|------|--------|
+| 2026-01-18 | Initial inventory, M16 complete |
+
+---
+
+*Last updated: January 18, 2026*


### PR DESCRIPTION
## Summary

- Add ecosystem-wide "Sources of Truth" system to prevent documentation drift
- Update all stale documentation to reflect current code state
- Close M16 milestone (Narrative Capture complete)

## Changes

### New: docs/INVENTORY.md
Full ecosystem inventory covering all 7 repos:
- Package versions and test counts
- Solana programs (sip-privacy)
- Ethereum contracts (sip-ethereum)
- Examples (11 directories)
- VPS deployment info
- Milestone status

### CLAUDE.md
- Added lean "Sources of Truth" section pointing to INVENTORY.md
- Updated test counts: 2,757 → 4,108+
- Updated package count: 6 → 7 (added react-native)
- Updated status: M15 → M16 Complete

### README.md
- Updated packages table: 3 → 7 packages + programs/contracts
- Fixed clone URL: RECTOR-LABS → sip-protocol
- Added test command: `pnpm test -- --run`
- Rewrote roadmap section: Phase 1-4 → M1-M22 structure
- Updated hackathon award: $4,000 → $4,500

### ROADMAP.md
- Marked M16 as ✅ Complete
- Updated current focus to M17

## Test plan

- [x] Verify package count matches `ls packages/`
- [x] Verify test counts match `pnpm turbo test` output
- [x] Verify clone URL works
- [x] Check all internal links resolve