### PR TITLE
feat(solana): M17 SDK Foundation - ed25519 cryptographic primitives

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -49,8 +49,8 @@
     "example:auction": "tsx examples/auction-example.ts"
   },
   "optionalDependencies": {
-    "socks-proxy-agent": "^8.0.0",
-    "https-proxy-agent": "^7.0.0"
+    "https-proxy-agent": "^7.0.0",
+    "socks-proxy-agent": "^8.0.0"
   },
   "dependencies": {
     "@aztec/bb.js": "3.0.1",
@@ -66,6 +66,8 @@
     "@noir-lang/types": "1.0.0-beta.18",
     "@radr/shadowwire": "^1.1.1",
     "@scure/base": "^2.0.0",
+    "@scure/bip32": "^2.0.1",
+    "@scure/bip39": "^2.0.1",
     "@sip-protocol/types": "^0.2.1",
     "@solana/spl-token": "^0.4.14",
     "@solana/web3.js": "^1.98.4",
@@ -77,10 +79,10 @@
   "devDependencies": {
     "@grpc/grpc-js": "^1.14.3",
     "@types/node": "^20.10.0",
-    "socks-proxy-agent": "^8.0.0",
-    "https-proxy-agent": "^7.0.0",
     "@vitest/coverage-v8": "1.6.1",
     "fast-check": "^4.5.3",
+    "https-proxy-agent": "^7.0.0",
+    "socks-proxy-agent": "^8.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.3.0",
     "vitest": "^1.1.0"

--- a/packages/sdk/src/chains/solana/commitment.ts
+++ b/packages/sdk/src/chains/solana/commitment.ts
@@ -1,0 +1,577 @@
+/**
+ * Solana Pedersen Commitment Implementation
+ *
+ * Ed25519-based Pedersen commitments for SPL token privacy on Solana.
+ *
+ * ## Security Properties
+ *
+ * - **Hiding (Computational)**: Cannot determine value from commitment
+ * - **Binding (Computational)**: Cannot open commitment to different value
+ * - **Homomorphic**: C(v1) + C(v2) = C(v1 + v2) when blindings sum
+ *
+ * ## Ed25519 vs Secp256k1
+ *
+ * This implementation uses ed25519 (Curve25519 in Edwards form) for
+ * compatibility with Solana's native cryptography. The core SDK uses
+ * secp256k1 for EVM compatibility.
+ *
+ * @module chains/solana/commitment
+ */
+
+import { ed25519 } from '@noble/curves/ed25519'
+import { sha256 } from '@noble/hashes/sha2'
+import { bytesToHex, randomBytes } from '@noble/hashes/utils'
+import type { HexString } from '@sip-protocol/types'
+import { ValidationError, CryptoError, ErrorCode } from '../../errors'
+import { isValidHex } from '../../validation'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/**
+ * A Pedersen commitment with associated blinding factor
+ */
+export interface SolanaPedersenCommitment {
+  /**
+   * The commitment point C = v*G + r*H (compressed ed25519, 32 bytes)
+   */
+  commitment: HexString
+
+  /**
+   * The blinding factor r (32 bytes, secret)
+   * Required to open/verify the commitment
+   */
+  blinding: HexString
+}
+
+/**
+ * A commitment point without the blinding factor (for public sharing)
+ */
+export interface SolanaCommitmentPoint {
+  /**
+   * The commitment point (compressed ed25519, 32 bytes)
+   */
+  commitment: HexString
+}
+
+/**
+ * SPL token commitment with amount and token info
+ */
+export interface SPLTokenCommitment extends SolanaPedersenCommitment {
+  /**
+   * SPL token mint address
+   */
+  mint: string
+
+  /**
+   * Token decimals (for display/calculation)
+   */
+  decimals: number
+
+  /**
+   * Original amount in smallest units (u64)
+   */
+  amountRaw?: bigint
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * Domain separation tag for H generation (ed25519 version)
+ */
+const H_DOMAIN = 'SIP-SOLANA-PEDERSEN-GENERATOR-H-v1'
+
+/**
+ * The generator G (ed25519 base point)
+ */
+const G = ed25519.ExtendedPoint.BASE
+
+/**
+ * The ed25519 curve order L (number of points in the subgroup)
+ */
+export const ED25519_ORDER = 2n ** 252n + 27742317777372353535851937790883648493n
+
+/**
+ * Ed25519 cofactor (the curve has order 8*L where L is the prime subgroup order)
+ * We multiply hash-derived points by the cofactor to ensure they're in the
+ * prime-order subgroup, which is required for correct homomorphic properties.
+ */
+const ED25519_COFACTOR = 8n
+
+/**
+ * Maximum SPL token amount (u64::MAX)
+ */
+export const MAX_SPL_AMOUNT = 2n ** 64n - 1n
+
+// ─── Generator H Construction ─────────────────────────────────────────────────
+
+/**
+ * The independent generator H (NUMS point)
+ * Constructed via hash-to-curve with nothing-up-my-sleeve string.
+ * IMPORTANT: Must be defined after ED25519_COFACTOR for proper initialization order.
+ */
+const H = generateH()
+
+/**
+ * Generate the independent generator H using NUMS method for ed25519
+ *
+ * We use a simple hash-and-check approach:
+ * 1. Hash domain||counter to get 32 bytes
+ * 2. Try to decode as an ed25519 point
+ * 3. Clear the cofactor by multiplying by 8 (ensures point is in prime-order subgroup)
+ * 4. If valid and not identity/G, use it
+ *
+ * This ensures nobody knows the discrete log of H w.r.t. G.
+ *
+ * IMPORTANT: The cofactor clearing step is essential for Pedersen commitments.
+ * Without it, H might not have order L, breaking the homomorphic property:
+ * (r1 + r2) mod L * H would not equal r1*H + r2*H
+ */
+function generateH(): typeof G {
+  let counter = 0
+
+  while (counter < 256) {
+    // Create candidate by hashing domain + counter
+    const input = new TextEncoder().encode(`${H_DOMAIN}:${counter}`)
+    const hashBytes = sha256(input)
+
+    try {
+      // Try to interpret hash as a compressed ed25519 point
+      // Ed25519 points are encoded as the y-coordinate with sign bit
+      const rawPoint = ed25519.ExtendedPoint.fromHex(hashBytes)
+
+      // Clear the cofactor: multiply by 8 to get a point in the prime-order subgroup
+      // This ensures the point has order L (not 2L, 4L, or 8L)
+      const point = rawPoint.multiply(ED25519_COFACTOR)
+
+      // Ensure point is not identity (could happen if rawPoint had small order)
+      if (!point.equals(ed25519.ExtendedPoint.ZERO)) {
+        // Check it's not G by comparing serialized form
+        const gBytes = G.toRawBytes()
+        const hBytes = point.toRawBytes()
+        if (bytesToHex(gBytes) !== bytesToHex(hBytes)) {
+          return point
+        }
+      }
+    } catch {
+      // Not a valid point encoding, try next counter
+    }
+
+    counter++
+  }
+
+  throw new CryptoError(
+    'Failed to generate H point - this should never happen',
+    ErrorCode.CRYPTO_FAILED,
+    { context: { domain: H_DOMAIN } }
+  )
+}
+
+// ─── Core Functions ───────────────────────────────────────────────────────────
+
+/**
+ * Create a Pedersen commitment to a value (ed25519)
+ *
+ * C = v*G + r*H
+ *
+ * @param value - The value to commit to (must be < curve order)
+ * @param blinding - Optional blinding factor (random 32 bytes if not provided)
+ * @returns The commitment and blinding factor
+ *
+ * @example
+ * ```typescript
+ * // Commit to 1000 tokens (smallest units)
+ * const { commitment, blinding } = commitSolana(1000n)
+ *
+ * // Verify the commitment
+ * const valid = verifyOpeningSolana(commitment, 1000n, blinding)
+ * ```
+ */
+export function commitSolana(
+  value: bigint,
+  blinding?: Uint8Array,
+): SolanaPedersenCommitment {
+  // Validate value type
+  if (typeof value !== 'bigint') {
+    throw new ValidationError('must be a bigint', 'value', { received: typeof value })
+  }
+
+  // Validate value is in valid range
+  if (value < 0n) {
+    throw new ValidationError('must be non-negative', 'value')
+  }
+  if (value >= ED25519_ORDER) {
+    throw new ValidationError(
+      'must be less than curve order',
+      'value',
+      { curveOrder: ED25519_ORDER.toString(16) }
+    )
+  }
+
+  // Generate or use provided blinding factor
+  const r = blinding ?? randomBytes(32)
+  if (r.length !== 32) {
+    throw new ValidationError('must be 32 bytes', 'blinding', { received: r.length })
+  }
+
+  // Ensure blinding is in valid range (mod L)
+  const rScalar = bytesToBigInt(r) % ED25519_ORDER
+  if (rScalar === 0n) {
+    // Regenerate if we got zero (extremely rare)
+    return commitSolana(value, randomBytes(32))
+  }
+
+  // C = v*G + r*H
+  let C: typeof G
+
+  if (value === 0n) {
+    // Only blinding contributes: C = r*H
+    C = H.multiply(rScalar)
+  } else {
+    // Normal case: C = v*G + r*H
+    const vG = G.multiply(value)
+    const rH = H.multiply(rScalar)
+    C = vG.add(rH)
+  }
+
+  // Return the reduced scalar as blinding (important for homomorphic ops)
+  const rScalarBytes = bigIntToBytes(rScalar, 32)
+
+  return {
+    commitment: `0x${bytesToHex(C.toRawBytes())}` as HexString,
+    blinding: `0x${bytesToHex(rScalarBytes)}` as HexString,
+  }
+}
+
+/**
+ * Verify that a commitment opens to a specific value
+ *
+ * @param commitment - The commitment point to verify
+ * @param value - The claimed value
+ * @param blinding - The blinding factor used
+ * @returns true if the commitment opens correctly
+ */
+export function verifyOpeningSolana(
+  commitment: HexString,
+  value: bigint,
+  blinding: HexString,
+): boolean {
+  try {
+    // Parse the commitment point
+    const commitmentBytes = hexToBytes(commitment.slice(2))
+    const C = ed25519.ExtendedPoint.fromHex(commitmentBytes)
+
+    // Parse blinding factor
+    const blindingBytes = hexToBytes(blinding.slice(2))
+    const rScalar = bytesToBigInt(blindingBytes) % ED25519_ORDER
+
+    // Recompute expected commitment
+    let expected: typeof G
+
+    if (value === 0n) {
+      expected = H.multiply(rScalar)
+    } else if (rScalar === 0n) {
+      expected = G.multiply(value)
+    } else {
+      const vG = G.multiply(value)
+      const rH = H.multiply(rScalar)
+      expected = vG.add(rH)
+    }
+
+    // Check equality
+    return C.equals(expected)
+  } catch {
+    return false
+  }
+}
+
+// ─── SPL Token Specific Functions ─────────────────────────────────────────────
+
+/**
+ * Create a commitment for an SPL token amount
+ *
+ * Handles SPL token decimals and u64 amount validation.
+ *
+ * @param amount - Token amount in smallest units (u64)
+ * @param mint - SPL token mint address
+ * @param decimals - Token decimals (e.g., 6 for USDC, 9 for SOL)
+ * @returns SPL token commitment with metadata
+ *
+ * @example
+ * ```typescript
+ * // Commit to 100 USDC (6 decimals)
+ * const commitment = commitSPLToken(
+ *   100_000_000n, // 100 USDC in smallest units
+ *   'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', // USDC mint
+ *   6
+ * )
+ * ```
+ */
+export function commitSPLToken(
+  amount: bigint,
+  mint: string,
+  decimals: number,
+  blinding?: Uint8Array,
+): SPLTokenCommitment {
+  // Validate amount is valid u64
+  if (amount < 0n || amount > MAX_SPL_AMOUNT) {
+    throw new ValidationError(
+      'SPL token amount must be a valid u64 (0 to 2^64-1)',
+      'amount',
+      { max: MAX_SPL_AMOUNT.toString() }
+    )
+  }
+
+  // Validate decimals
+  if (decimals < 0 || decimals > 18 || !Number.isInteger(decimals)) {
+    throw new ValidationError(
+      'decimals must be an integer between 0 and 18',
+      'decimals'
+    )
+  }
+
+  // Create the commitment
+  const { commitment, blinding: blindingHex } = commitSolana(amount, blinding)
+
+  return {
+    commitment,
+    blinding: blindingHex,
+    mint,
+    decimals,
+    amountRaw: amount,
+  }
+}
+
+/**
+ * Verify an SPL token commitment
+ *
+ * @param tokenCommitment - The SPL token commitment to verify
+ * @param expectedAmount - The expected amount in smallest units
+ * @returns true if the commitment opens correctly
+ */
+export function verifySPLTokenCommitment(
+  tokenCommitment: SPLTokenCommitment,
+  expectedAmount: bigint,
+): boolean {
+  return verifyOpeningSolana(
+    tokenCommitment.commitment,
+    expectedAmount,
+    tokenCommitment.blinding
+  )
+}
+
+/**
+ * Convert human-readable token amount to smallest units
+ *
+ * @param amount - Human-readable amount (e.g., 100.5)
+ * @param decimals - Token decimals
+ * @returns Amount in smallest units as bigint
+ *
+ * @example
+ * ```typescript
+ * // 100.5 USDC (6 decimals) = 100,500,000 units
+ * const units = toSmallestUnits(100.5, 6)
+ * // 100_500_000n
+ * ```
+ */
+export function toSmallestUnits(amount: number | string, decimals: number): bigint {
+  const [whole, fraction = ''] = String(amount).split('.')
+  const paddedFraction = fraction.padEnd(decimals, '0').slice(0, decimals)
+  return BigInt(whole + paddedFraction)
+}
+
+/**
+ * Convert smallest units to human-readable amount
+ *
+ * @param amount - Amount in smallest units
+ * @param decimals - Token decimals
+ * @returns Human-readable string
+ *
+ * @example
+ * ```typescript
+ * // 100,500,000 units (6 decimals) = "100.5"
+ * const readable = fromSmallestUnits(100_500_000n, 6)
+ * // "100.5"
+ * ```
+ */
+export function fromSmallestUnits(amount: bigint, decimals: number): string {
+  const str = amount.toString().padStart(decimals + 1, '0')
+  const whole = str.slice(0, -decimals) || '0'
+  const fraction = str.slice(-decimals).replace(/0+$/, '')
+  return fraction ? `${whole}.${fraction}` : whole
+}
+
+// ─── Homomorphic Operations ───────────────────────────────────────────────────
+
+/**
+ * Add two commitments homomorphically (ed25519)
+ *
+ * C1 + C2 = (v1+v2)*G + (r1+r2)*H
+ *
+ * @param c1 - First commitment point
+ * @param c2 - Second commitment point
+ * @returns Sum of commitments
+ */
+export function addCommitmentsSolana(
+  c1: HexString,
+  c2: HexString,
+): SolanaCommitmentPoint {
+  if (!isValidHex(c1)) {
+    throw new ValidationError('must be a valid hex string', 'c1')
+  }
+  if (!isValidHex(c2)) {
+    throw new ValidationError('must be a valid hex string', 'c2')
+  }
+
+  let point1: typeof G
+  let point2: typeof G
+
+  try {
+    point1 = ed25519.ExtendedPoint.fromHex(hexToBytes(c1.slice(2)))
+  } catch {
+    throw new ValidationError('must be a valid ed25519 point', 'c1')
+  }
+  try {
+    point2 = ed25519.ExtendedPoint.fromHex(hexToBytes(c2.slice(2)))
+  } catch {
+    throw new ValidationError('must be a valid ed25519 point', 'c2')
+  }
+
+  const sum = point1.add(point2)
+
+  return {
+    commitment: `0x${bytesToHex(sum.toRawBytes())}` as HexString,
+  }
+}
+
+/**
+ * Subtract two commitments homomorphically (ed25519)
+ *
+ * C1 - C2 = (v1-v2)*G + (r1-r2)*H
+ *
+ * @param c1 - First commitment point
+ * @param c2 - Second commitment point (to subtract)
+ * @returns Difference of commitments
+ */
+export function subtractCommitmentsSolana(
+  c1: HexString,
+  c2: HexString,
+): SolanaCommitmentPoint {
+  if (!isValidHex(c1)) {
+    throw new ValidationError('must be a valid hex string', 'c1')
+  }
+  if (!isValidHex(c2)) {
+    throw new ValidationError('must be a valid hex string', 'c2')
+  }
+
+  let point1: typeof G
+  let point2: typeof G
+
+  try {
+    point1 = ed25519.ExtendedPoint.fromHex(hexToBytes(c1.slice(2)))
+  } catch {
+    throw new ValidationError('must be a valid ed25519 point', 'c1')
+  }
+  try {
+    point2 = ed25519.ExtendedPoint.fromHex(hexToBytes(c2.slice(2)))
+  } catch {
+    throw new ValidationError('must be a valid ed25519 point', 'c2')
+  }
+
+  const diff = point1.subtract(point2)
+
+  // Handle identity point
+  if (diff.equals(ed25519.ExtendedPoint.ZERO)) {
+    // Return zero point representation
+    return {
+      commitment: '0x' + '00'.repeat(32) as HexString,
+    }
+  }
+
+  return {
+    commitment: `0x${bytesToHex(diff.toRawBytes())}` as HexString,
+  }
+}
+
+/**
+ * Add blinding factors (ed25519)
+ *
+ * @param b1 - First blinding factor
+ * @param b2 - Second blinding factor
+ * @returns Sum of blindings (mod curve order)
+ */
+export function addBlindingsSolana(b1: HexString, b2: HexString): HexString {
+  const r1 = bytesToBigInt(hexToBytes(b1.slice(2)))
+  const r2 = bytesToBigInt(hexToBytes(b2.slice(2)))
+
+  const sum = (r1 + r2) % ED25519_ORDER
+  const sumBytes = bigIntToBytes(sum, 32)
+
+  return `0x${bytesToHex(sumBytes)}` as HexString
+}
+
+/**
+ * Subtract blinding factors (ed25519)
+ *
+ * @param b1 - First blinding factor
+ * @param b2 - Second blinding factor (to subtract)
+ * @returns Difference of blindings (mod curve order)
+ */
+export function subtractBlindingsSolana(b1: HexString, b2: HexString): HexString {
+  const r1 = bytesToBigInt(hexToBytes(b1.slice(2)))
+  const r2 = bytesToBigInt(hexToBytes(b2.slice(2)))
+
+  const diff = (r1 - r2 + ED25519_ORDER) % ED25519_ORDER
+  const diffBytes = bigIntToBytes(diff, 32)
+
+  return `0x${bytesToHex(diffBytes)}` as HexString
+}
+
+// ─── Generator Access ─────────────────────────────────────────────────────────
+
+/**
+ * Get the ed25519 generators for ZK proof integration
+ */
+export function getGeneratorsSolana(): {
+  G: HexString
+  H: HexString
+} {
+  return {
+    G: `0x${bytesToHex(G.toRawBytes())}` as HexString,
+    H: `0x${bytesToHex(H.toRawBytes())}` as HexString,
+  }
+}
+
+/**
+ * Generate a random blinding factor (32 bytes)
+ */
+export function generateBlindingSolana(): HexString {
+  return `0x${bytesToHex(randomBytes(32))}` as HexString
+}
+
+// ─── Utility Functions ────────────────────────────────────────────────────────
+
+function bytesToBigInt(bytes: Uint8Array): bigint {
+  let result = 0n
+  for (const byte of bytes) {
+    result = (result << 8n) + BigInt(byte)
+  }
+  return result
+}
+
+function bigIntToBytes(value: bigint, length: number): Uint8Array {
+  const bytes = new Uint8Array(length)
+  let v = value
+  for (let i = length - 1; i >= 0; i--) {
+    bytes[i] = Number(v & 0xffn)
+    v >>= 8n
+  }
+  return bytes
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16)
+  }
+  return bytes
+}

--- a/packages/sdk/src/chains/solana/index.ts
+++ b/packages/sdk/src/chains/solana/index.ts
@@ -134,3 +134,59 @@ export {
   type SIPEnhancedTransaction,
   type TransactionSummary,
 } from './providers'
+
+// Key Derivation (BIP39/SLIP-0010)
+export {
+  deriveSolanaStealthKeys,
+  deriveViewingKeyFromSpending,
+  generateMnemonic,
+  isValidMnemonic,
+  validateMnemonic,
+  validateDerivationPath,
+  getDerivationPath,
+  SOLANA_DEFAULT_PATH,
+  type SolanaKeyDerivationOptions,
+  type SolanaKeyDerivationResult,
+} from './key-derivation'
+
+// Pedersen Commitments (ed25519)
+export {
+  commitSolana,
+  verifyOpeningSolana,
+  commitSPLToken,
+  verifySPLTokenCommitment,
+  toSmallestUnits,
+  fromSmallestUnits,
+  addCommitmentsSolana,
+  subtractCommitmentsSolana,
+  addBlindingsSolana,
+  subtractBlindingsSolana,
+  getGeneratorsSolana,
+  generateBlindingSolana,
+  ED25519_ORDER,
+  MAX_SPL_AMOUNT,
+  type SolanaPedersenCommitment,
+  type SolanaCommitmentPoint,
+  type SPLTokenCommitment,
+} from './commitment'
+
+// Viewing Key Management
+export {
+  generateViewingKeyFromSpending,
+  generateRandomViewingKey,
+  computeViewingKeyHash,
+  computeViewingKeyHashFromPrivate,
+  exportViewingKey,
+  importViewingKey,
+  encryptForViewing,
+  decryptWithViewing,
+  createMemoryStorage,
+  isAnnouncementForViewingKey,
+  deriveChildViewingKey,
+  getViewingPublicKey,
+  type SolanaViewingKey,
+  type ViewingKeyExport,
+  type EncryptedPayload,
+  type SolanaTransactionData,
+  type ViewingKeyStorage,
+} from './viewing-key'

--- a/packages/sdk/src/chains/solana/key-derivation.ts
+++ b/packages/sdk/src/chains/solana/key-derivation.ts
@@ -1,0 +1,418 @@
+/**
+ * Solana Key Derivation for SIP Stealth Addresses
+ *
+ * Derives spending and viewing keypairs from Solana seed phrases (BIP39 mnemonics)
+ * using standard Solana derivation paths (SLIP-0010 for ed25519).
+ *
+ * @module chains/solana/key-derivation
+ */
+
+import {
+  generateMnemonic as bip39GenerateMnemonic,
+  validateMnemonic as bip39ValidateMnemonic,
+  mnemonicToSeedSync,
+} from '@scure/bip39'
+import { wordlist as english } from '@scure/bip39/wordlists/english.js'
+import { ed25519 } from '@noble/curves/ed25519'
+import { sha256, sha512 } from '@noble/hashes/sha2'
+import { hmac } from '@noble/hashes/hmac'
+import type { StealthMetaAddress, HexString } from '@sip-protocol/types'
+import { ValidationError } from '../../errors'
+import { bytesToHex } from '../../stealth/utils'
+import { secureWipe } from '../../secure-memory'
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * Standard Solana derivation path (BIP44)
+ *
+ * m/44'/501'/account'/change'
+ *
+ * - 44' = BIP44 purpose
+ * - 501' = Solana coin type
+ * - 0' = first account
+ * - 0' = external chain (most wallets use this)
+ */
+export const SOLANA_DEFAULT_PATH = "m/44'/501'/0'/0'"
+
+/**
+ * SIP-specific derivation context for viewing key
+ *
+ * The viewing key is derived deterministically from the spending key
+ * using HMAC-SHA256 with this context string.
+ */
+const VIEWING_KEY_CONTEXT = 'SIP-viewing-key-v1'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/**
+ * Options for key derivation from mnemonic
+ */
+export interface SolanaKeyDerivationOptions {
+  /**
+   * BIP39 mnemonic phrase (12 or 24 words)
+   */
+  mnemonic: string
+
+  /**
+   * Optional passphrase for BIP39 seed derivation
+   * @default undefined (no passphrase)
+   */
+  passphrase?: string
+
+  /**
+   * Derivation path for the spending key
+   * @default "m/44'/501'/0'/0'" (standard Solana)
+   */
+  derivationPath?: string
+
+  /**
+   * Account index to use (modifies derivation path)
+   * @default 0
+   */
+  accountIndex?: number
+
+  /**
+   * Optional label for the generated meta-address
+   */
+  label?: string
+}
+
+/**
+ * Result of key derivation
+ */
+export interface SolanaKeyDerivationResult {
+  /**
+   * The stealth meta-address (safe to share publicly)
+   */
+  metaAddress: StealthMetaAddress
+
+  /**
+   * Spending private key (CRITICAL - never share)
+   */
+  spendingPrivateKey: HexString
+
+  /**
+   * Viewing private key (sensitive - share only with auditors)
+   */
+  viewingPrivateKey: HexString
+
+  /**
+   * The derivation path used
+   */
+  derivationPath: string
+}
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+
+/**
+ * Validate a BIP39 mnemonic phrase
+ *
+ * @param mnemonic - The mnemonic to validate
+ * @returns true if valid
+ * @throws {ValidationError} if invalid
+ */
+export function validateMnemonic(mnemonic: string): boolean {
+  if (!mnemonic || typeof mnemonic !== 'string') {
+    throw new ValidationError('Mnemonic must be a non-empty string', 'mnemonic')
+  }
+
+  // Normalize: trim, lowercase, and collapse multiple spaces
+  const words = mnemonic.trim().toLowerCase().split(/\s+/)
+  const normalized = words.join(' ')
+
+  // Standard BIP39 supports 12, 15, 18, 21, or 24 words
+  const validLengths = [12, 15, 18, 21, 24]
+  if (!validLengths.includes(words.length)) {
+    throw new ValidationError(
+      `Mnemonic must have 12, 15, 18, 21, or 24 words (got ${words.length})`,
+      'mnemonic'
+    )
+  }
+
+  // Validate using bip39 library
+  if (!bip39ValidateMnemonic(normalized, english)) {
+    throw new ValidationError(
+      'Invalid mnemonic: checksum failed or contains invalid words',
+      'mnemonic'
+    )
+  }
+
+  return true
+}
+
+/**
+ * Validate a derivation path
+ *
+ * @param path - The derivation path to validate
+ * @returns true if valid
+ * @throws {ValidationError} if invalid
+ */
+export function validateDerivationPath(path: string): boolean {
+  if (!path || typeof path !== 'string') {
+    throw new ValidationError('Derivation path must be a non-empty string', 'derivationPath')
+  }
+
+  // Must start with 'm/'
+  if (!path.startsWith('m/')) {
+    throw new ValidationError("Derivation path must start with 'm/'", 'derivationPath')
+  }
+
+  // Validate path format (e.g., m/44'/501'/0'/0')
+  const pathRegex = /^m(\/\d+'?)*$/
+  if (!pathRegex.test(path)) {
+    throw new ValidationError(
+      'Invalid derivation path format. Use format like m/44\'/501\'/0\'/0\'',
+      'derivationPath'
+    )
+  }
+
+  return true
+}
+
+// ─── SLIP-0010 ed25519 Key Derivation ─────────────────────────────────────────
+
+/**
+ * Derive ed25519 private key using SLIP-0010 from BIP39 seed
+ *
+ * SLIP-0010 defines ed25519 key derivation differently from secp256k1.
+ * It uses HMAC-SHA512 at each derivation level.
+ *
+ * Note: SLIP-0010 for ed25519 only supports hardened derivation.
+ *
+ * @param seed - 64-byte BIP39 seed
+ * @param path - Derivation path (all indices must be hardened)
+ * @returns 32-byte ed25519 private key
+ */
+function slip0010DeriveEd25519(seed: Uint8Array, path: string): Uint8Array {
+  // SLIP-0010 ed25519 master key derivation using HMAC-SHA512
+  const I = hmac(sha512, 'ed25519 seed', seed)
+
+  let key: Uint8Array = new Uint8Array(I.slice(0, 32))
+  let chainCode: Uint8Array = new Uint8Array(I.slice(32, 64))
+
+  // Parse path components (skip 'm')
+  const components = path.split('/').slice(1)
+
+  for (const component of components) {
+    // All ed25519 derivations must be hardened
+    const hardened = component.endsWith("'")
+    const indexStr = hardened ? component.slice(0, -1) : component
+    const index = parseInt(indexStr, 10)
+
+    if (!hardened) {
+      throw new ValidationError(
+        'SLIP-0010 ed25519 only supports hardened derivation. Add \' to path index.',
+        'derivationPath'
+      )
+    }
+
+    // Hardened child: index + 0x80000000
+    const hardenedIndex = index + 0x80000000
+
+    // HMAC-SHA512(chainCode, 0x00 || key || index)
+    const data = new Uint8Array(1 + 32 + 4)
+    data[0] = 0x00
+    data.set(key, 1)
+    new DataView(data.buffer).setUint32(33, hardenedIndex, false) // big-endian
+
+    const derivedI = hmac(sha512, chainCode, data)
+
+    // Split into key (first 32 bytes) and chain code (last 32 bytes)
+    key = new Uint8Array(derivedI.slice(0, 32))
+    chainCode = new Uint8Array(derivedI.slice(32, 64))
+  }
+
+  return key
+}
+
+// ─── Key Derivation ───────────────────────────────────────────────────────────
+
+/**
+ * Derive spending and viewing keypairs from a Solana mnemonic
+ *
+ * This is the primary function for generating SIP stealth keys from an existing
+ * Solana wallet's seed phrase.
+ *
+ * @param options - Derivation options including mnemonic and optional path
+ * @returns Stealth meta-address and private keys
+ *
+ * @example Basic usage
+ * ```typescript
+ * const result = deriveSolanaStealthKeys({
+ *   mnemonic: 'abandon abandon abandon ... about',
+ * })
+ *
+ * console.log('Meta-address:', result.metaAddress)
+ * // Share metaAddress with senders
+ * // Keep spendingPrivateKey SECURE
+ * // viewingPrivateKey can be shared with auditors
+ * ```
+ *
+ * @example With custom derivation path
+ * ```typescript
+ * const result = deriveSolanaStealthKeys({
+ *   mnemonic: 'your twelve word mnemonic phrase here ...',
+ *   derivationPath: "m/44'/501'/1'/0'", // Second account
+ *   label: 'Trading account',
+ * })
+ * ```
+ *
+ * @example With account index shorthand
+ * ```typescript
+ * const result = deriveSolanaStealthKeys({
+ *   mnemonic: 'your mnemonic...',
+ *   accountIndex: 2, // Uses m/44'/501'/2'/0'
+ * })
+ * ```
+ */
+export function deriveSolanaStealthKeys(
+  options: SolanaKeyDerivationOptions
+): SolanaKeyDerivationResult {
+  // Validate mnemonic
+  validateMnemonic(options.mnemonic)
+
+  // Determine derivation path
+  let derivationPath = options.derivationPath ?? SOLANA_DEFAULT_PATH
+
+  // If accountIndex is specified, override the path
+  if (options.accountIndex !== undefined) {
+    if (options.accountIndex < 0 || !Number.isInteger(options.accountIndex)) {
+      throw new ValidationError(
+        'accountIndex must be a non-negative integer',
+        'accountIndex'
+      )
+    }
+    derivationPath = `m/44'/501'/${options.accountIndex}'/0'`
+  }
+
+  validateDerivationPath(derivationPath)
+
+  // Convert mnemonic to seed (normalize whitespace and case)
+  const normalizedMnemonic = options.mnemonic.trim().toLowerCase().split(/\s+/).join(' ')
+  const seed = mnemonicToSeedSync(normalizedMnemonic, options.passphrase)
+
+  let spendingPrivateKeyBytes: Uint8Array | null = null
+  let viewingPrivateKeyBytes: Uint8Array | null = null
+
+  try {
+    // Derive spending key using SLIP-0010 for ed25519
+    spendingPrivateKeyBytes = slip0010DeriveEd25519(seed, derivationPath)
+
+    // Derive viewing key deterministically from spending key
+    // Using HMAC-SHA256 with context ensures:
+    // 1. Different key from spending key
+    // 2. Deterministic (can be recovered from spending key)
+    // 3. Cryptographically secure derivation
+    viewingPrivateKeyBytes = hmac(
+      sha256,
+      new TextEncoder().encode(VIEWING_KEY_CONTEXT),
+      spendingPrivateKeyBytes
+    )
+
+    // Derive public keys
+    const spendingPublicKey = ed25519.getPublicKey(spendingPrivateKeyBytes)
+    const viewingPublicKey = ed25519.getPublicKey(viewingPrivateKeyBytes)
+
+    return {
+      metaAddress: {
+        spendingKey: `0x${bytesToHex(spendingPublicKey)}` as HexString,
+        viewingKey: `0x${bytesToHex(viewingPublicKey)}` as HexString,
+        chain: 'solana',
+        label: options.label,
+      },
+      spendingPrivateKey: `0x${bytesToHex(spendingPrivateKeyBytes)}` as HexString,
+      viewingPrivateKey: `0x${bytesToHex(viewingPrivateKeyBytes)}` as HexString,
+      derivationPath,
+    }
+  } finally {
+    // Secure wipe sensitive data
+    secureWipe(seed)
+    if (spendingPrivateKeyBytes) secureWipe(spendingPrivateKeyBytes)
+    if (viewingPrivateKeyBytes) secureWipe(viewingPrivateKeyBytes)
+  }
+}
+
+/**
+ * Derive viewing key from spending key
+ *
+ * Useful when you have the spending private key but need to generate
+ * the corresponding viewing key.
+ *
+ * @param spendingPrivateKey - The spending private key
+ * @returns The viewing private key
+ */
+export function deriveViewingKeyFromSpending(
+  spendingPrivateKey: HexString
+): HexString {
+  if (!spendingPrivateKey || !spendingPrivateKey.startsWith('0x')) {
+    throw new ValidationError(
+      'spendingPrivateKey must be a hex string with 0x prefix',
+      'spendingPrivateKey'
+    )
+  }
+
+  const spendingBytes = new Uint8Array(
+    (spendingPrivateKey.slice(2).match(/.{2}/g) ?? []).map(b => parseInt(b, 16))
+  )
+
+  if (spendingBytes.length !== 32) {
+    throw new ValidationError(
+      'spendingPrivateKey must be 32 bytes',
+      'spendingPrivateKey'
+    )
+  }
+
+  try {
+    const viewingBytes = hmac(
+      sha256,
+      new TextEncoder().encode(VIEWING_KEY_CONTEXT),
+      spendingBytes
+    )
+
+    return `0x${bytesToHex(viewingBytes)}` as HexString
+  } finally {
+    secureWipe(spendingBytes)
+  }
+}
+
+/**
+ * Generate a new random mnemonic phrase
+ *
+ * @param strength - Entropy strength in bits (128 = 12 words, 256 = 24 words)
+ * @returns A new BIP39 mnemonic phrase
+ */
+export function generateMnemonic(strength: 128 | 256 = 128): string {
+  return bip39GenerateMnemonic(english, strength)
+}
+
+/**
+ * Check if a string is a valid BIP39 mnemonic
+ *
+ * @param mnemonic - The string to check
+ * @returns true if valid mnemonic, false otherwise
+ */
+export function isValidMnemonic(mnemonic: string): boolean {
+  try {
+    validateMnemonic(mnemonic)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Get derivation path for a specific account index
+ *
+ * @param accountIndex - Account index (0-based)
+ * @returns Standard Solana derivation path for that account
+ */
+export function getDerivationPath(accountIndex: number = 0): string {
+  if (accountIndex < 0 || !Number.isInteger(accountIndex)) {
+    throw new ValidationError(
+      'accountIndex must be a non-negative integer',
+      'accountIndex'
+    )
+  }
+  return `m/44'/501'/${accountIndex}'/0'`
+}

--- a/packages/sdk/src/chains/solana/viewing-key.ts
+++ b/packages/sdk/src/chains/solana/viewing-key.ts
@@ -1,0 +1,807 @@
+/**
+ * Solana Viewing Key Management
+ *
+ * Provides viewing key generation, export/import, encryption, and storage
+ * for selective disclosure and compliance on Solana.
+ *
+ * ## Architecture
+ *
+ * ```
+ * Spending Private Key
+ *         │
+ *         ▼ HMAC-SHA256(context)
+ * Viewing Private Key (32 bytes)
+ *         │
+ *         ▼ ed25519.getPublicKey()
+ * Viewing Public Key (32 bytes)
+ *         │
+ *         ▼ sha256()
+ * Viewing Key Hash (32 bytes) ← Used for announcement matching
+ * ```
+ *
+ * ## Security Properties
+ *
+ * - Viewing keys can decrypt but NOT spend funds
+ * - Hash is safe to publish on-chain for announcement matching
+ * - XChaCha20-Poly1305 provides authenticated encryption
+ *
+ * @module chains/solana/viewing-key
+ */
+
+import { ed25519 } from '@noble/curves/ed25519'
+import { sha256 } from '@noble/hashes/sha256'
+import { hmac } from '@noble/hashes/hmac'
+import { hkdf } from '@noble/hashes/hkdf'
+import { bytesToHex, hexToBytes, randomBytes, utf8ToBytes } from '@noble/hashes/utils'
+import { xchacha20poly1305 } from '@noble/ciphers/chacha.js'
+import type { HexString, Hash } from '@sip-protocol/types'
+import { ValidationError, CryptoError, ErrorCode } from '../../errors'
+import { isValidHex } from '../../validation'
+import { secureWipe } from '../../secure-memory'
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * Domain separation for viewing key derivation from spending key
+ */
+const VIEWING_KEY_CONTEXT = 'SIP-viewing-key-v1'
+
+/**
+ * Domain separation for encryption key derivation
+ */
+const ENCRYPTION_DOMAIN = 'SIP-SOLANA-VIEWING-KEY-ENCRYPTION-V1'
+
+/**
+ * XChaCha20-Poly1305 nonce size (24 bytes)
+ */
+const NONCE_SIZE = 24
+
+/**
+ * Standard export format version for viewing keys
+ */
+const EXPORT_VERSION = 1
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/**
+ * A Solana viewing key with associated metadata
+ */
+export interface SolanaViewingKey {
+  /**
+   * The viewing private key (32 bytes)
+   * Used for decryption and stealth address scanning
+   */
+  privateKey: HexString
+
+  /**
+   * The viewing public key (32 bytes)
+   * Can be shared for encryption
+   */
+  publicKey: HexString
+
+  /**
+   * Hash of the viewing public key for announcement matching
+   * This is published on-chain to enable efficient scanning
+   */
+  hash: Hash
+
+  /**
+   * Optional label for this viewing key
+   */
+  label?: string
+
+  /**
+   * Timestamp when this key was created
+   */
+  createdAt: number
+}
+
+/**
+ * Standard export format for viewing keys
+ */
+export interface ViewingKeyExport {
+  /**
+   * Export format version
+   */
+  version: number
+
+  /**
+   * The chain this key is for
+   */
+  chain: 'solana'
+
+  /**
+   * The viewing private key (hex encoded)
+   */
+  privateKey: HexString
+
+  /**
+   * The viewing public key (hex encoded)
+   */
+  publicKey: HexString
+
+  /**
+   * Hash for announcement matching
+   */
+  hash: Hash
+
+  /**
+   * Optional label
+   */
+  label?: string
+
+  /**
+   * Creation timestamp
+   */
+  createdAt: number
+
+  /**
+   * Export timestamp
+   */
+  exportedAt: number
+}
+
+/**
+ * Encrypted data structure for viewing key operations
+ */
+export interface EncryptedPayload {
+  /**
+   * The encrypted ciphertext (hex encoded)
+   */
+  ciphertext: HexString
+
+  /**
+   * The nonce used for encryption (hex encoded, 24 bytes)
+   */
+  nonce: HexString
+
+  /**
+   * Hash of the viewing key that can decrypt this
+   */
+  viewingKeyHash: Hash
+}
+
+/**
+ * Transaction data that can be encrypted for viewing
+ */
+export interface SolanaTransactionData {
+  /**
+   * Sender's public key or address
+   */
+  sender: string
+
+  /**
+   * Recipient's stealth address
+   */
+  recipient: string
+
+  /**
+   * Amount in smallest units (string for bigint serialization)
+   */
+  amount: string
+
+  /**
+   * Token mint address (null for native SOL)
+   */
+  mint: string | null
+
+  /**
+   * Transaction timestamp
+   */
+  timestamp: number
+
+  /**
+   * Optional memo
+   */
+  memo?: string
+}
+
+/**
+ * Interface for viewing key storage providers
+ */
+export interface ViewingKeyStorage {
+  /**
+   * Store a viewing key
+   * @param key - The viewing key to store
+   * @returns Promise resolving to the key's hash (for identification)
+   */
+  save(key: SolanaViewingKey): Promise<Hash>
+
+  /**
+   * Retrieve a viewing key by its hash
+   * @param hash - The viewing key hash
+   * @returns Promise resolving to the key or null if not found
+   */
+  load(hash: Hash): Promise<SolanaViewingKey | null>
+
+  /**
+   * List all stored viewing keys
+   * @returns Promise resolving to array of keys
+   */
+  list(): Promise<SolanaViewingKey[]>
+
+  /**
+   * Delete a viewing key by its hash
+   * @param hash - The viewing key hash
+   * @returns Promise resolving to true if deleted, false if not found
+   */
+  delete(hash: Hash): Promise<boolean>
+}
+
+// ─── Viewing Key Generation ───────────────────────────────────────────────────
+
+/**
+ * Generate a viewing key from a spending private key
+ *
+ * The viewing key is derived deterministically using HMAC-SHA256 with domain
+ * separation, ensuring it cannot be used to derive the spending key.
+ *
+ * @param spendingPrivateKey - The spending private key (32 bytes, hex)
+ * @param label - Optional label for the viewing key
+ * @returns The generated viewing key with public key and hash
+ *
+ * @example
+ * ```typescript
+ * const viewingKey = generateViewingKeyFromSpending(
+ *   spendingPrivateKey,
+ *   'My Wallet'
+ * )
+ *
+ * // Share the public key for encryption
+ * console.log('Public key:', viewingKey.publicKey)
+ *
+ * // Use hash for on-chain announcement matching
+ * console.log('Hash:', viewingKey.hash)
+ * ```
+ */
+export function generateViewingKeyFromSpending(
+  spendingPrivateKey: HexString,
+  label?: string
+): SolanaViewingKey {
+  // Validate input
+  if (!spendingPrivateKey || !spendingPrivateKey.startsWith('0x')) {
+    throw new ValidationError(
+      'spendingPrivateKey must be a hex string with 0x prefix',
+      'spendingPrivateKey'
+    )
+  }
+
+  const spendingBytes = hexToBytes(spendingPrivateKey.slice(2))
+
+  if (spendingBytes.length !== 32) {
+    throw new ValidationError(
+      'spendingPrivateKey must be 32 bytes',
+      'spendingPrivateKey'
+    )
+  }
+
+  let viewingPrivateBytes: Uint8Array | null = null
+
+  try {
+    // Derive viewing key using HMAC-SHA256 with domain separation
+    viewingPrivateBytes = hmac(
+      sha256,
+      utf8ToBytes(VIEWING_KEY_CONTEXT),
+      spendingBytes
+    )
+
+    // Derive public key
+    const viewingPublicBytes = ed25519.getPublicKey(viewingPrivateBytes)
+
+    // Compute hash for announcement matching
+    const hashBytes = sha256(viewingPublicBytes)
+
+    return {
+      privateKey: `0x${bytesToHex(viewingPrivateBytes)}` as HexString,
+      publicKey: `0x${bytesToHex(viewingPublicBytes)}` as HexString,
+      hash: `0x${bytesToHex(hashBytes)}` as Hash,
+      label,
+      createdAt: Date.now(),
+    }
+  } finally {
+    // Secure wipe sensitive data
+    secureWipe(spendingBytes)
+    if (viewingPrivateBytes) secureWipe(viewingPrivateBytes)
+  }
+}
+
+/**
+ * Generate a new random viewing key
+ *
+ * Creates a cryptographically random viewing key that is NOT derived from
+ * a spending key. Use this for standalone viewing keys or testing.
+ *
+ * @param label - Optional label for the viewing key
+ * @returns The generated viewing key
+ *
+ * @example
+ * ```typescript
+ * const viewingKey = generateRandomViewingKey('Audit Key')
+ * ```
+ */
+export function generateRandomViewingKey(label?: string): SolanaViewingKey {
+  const privateBytes = randomBytes(32)
+
+  try {
+    const publicBytes = ed25519.getPublicKey(privateBytes)
+    const hashBytes = sha256(publicBytes)
+
+    return {
+      privateKey: `0x${bytesToHex(privateBytes)}` as HexString,
+      publicKey: `0x${bytesToHex(publicBytes)}` as HexString,
+      hash: `0x${bytesToHex(hashBytes)}` as Hash,
+      label,
+      createdAt: Date.now(),
+    }
+  } finally {
+    secureWipe(privateBytes)
+  }
+}
+
+// ─── Viewing Key Hash ─────────────────────────────────────────────────────────
+
+/**
+ * Compute the viewing key hash from a public key
+ *
+ * The hash is used for announcement matching on-chain. Recipients publish
+ * their viewing key hash, and senders include it in transaction announcements.
+ *
+ * @param viewingPublicKey - The viewing public key (32 bytes, hex)
+ * @returns The hash for announcement matching
+ *
+ * @example
+ * ```typescript
+ * const hash = computeViewingKeyHash(viewingKey.publicKey)
+ * // Use hash in transaction announcements
+ * ```
+ */
+export function computeViewingKeyHash(viewingPublicKey: HexString): Hash {
+  if (!viewingPublicKey || !viewingPublicKey.startsWith('0x')) {
+    throw new ValidationError(
+      'viewingPublicKey must be a hex string with 0x prefix',
+      'viewingPublicKey'
+    )
+  }
+
+  const publicBytes = hexToBytes(viewingPublicKey.slice(2))
+
+  if (publicBytes.length !== 32) {
+    throw new ValidationError(
+      'viewingPublicKey must be 32 bytes',
+      'viewingPublicKey'
+    )
+  }
+
+  const hashBytes = sha256(publicBytes)
+  return `0x${bytesToHex(hashBytes)}` as Hash
+}
+
+/**
+ * Compute viewing key hash from a private key
+ *
+ * Derives the public key and computes its hash.
+ *
+ * @param viewingPrivateKey - The viewing private key (32 bytes, hex)
+ * @returns The hash for announcement matching
+ */
+export function computeViewingKeyHashFromPrivate(
+  viewingPrivateKey: HexString
+): Hash {
+  if (!viewingPrivateKey || !viewingPrivateKey.startsWith('0x')) {
+    throw new ValidationError(
+      'viewingPrivateKey must be a hex string with 0x prefix',
+      'viewingPrivateKey'
+    )
+  }
+
+  const privateBytes = hexToBytes(viewingPrivateKey.slice(2))
+
+  if (privateBytes.length !== 32) {
+    throw new ValidationError(
+      'viewingPrivateKey must be 32 bytes',
+      'viewingPrivateKey'
+    )
+  }
+
+  try {
+    const publicBytes = ed25519.getPublicKey(privateBytes)
+    const hashBytes = sha256(publicBytes)
+    return `0x${bytesToHex(hashBytes)}` as Hash
+  } finally {
+    secureWipe(privateBytes)
+  }
+}
+
+// ─── Export/Import ────────────────────────────────────────────────────────────
+
+/**
+ * Export a viewing key in standard JSON format
+ *
+ * The export format includes version information for forward compatibility
+ * and can be safely serialized to JSON.
+ *
+ * @param viewingKey - The viewing key to export
+ * @returns The export object (serialize with JSON.stringify)
+ *
+ * @example
+ * ```typescript
+ * const exported = exportViewingKey(viewingKey)
+ * const json = JSON.stringify(exported)
+ *
+ * // Save to file or send to auditor
+ * ```
+ */
+export function exportViewingKey(viewingKey: SolanaViewingKey): ViewingKeyExport {
+  return {
+    version: EXPORT_VERSION,
+    chain: 'solana',
+    privateKey: viewingKey.privateKey,
+    publicKey: viewingKey.publicKey,
+    hash: viewingKey.hash,
+    label: viewingKey.label,
+    createdAt: viewingKey.createdAt,
+    exportedAt: Date.now(),
+  }
+}
+
+/**
+ * Import a viewing key from standard JSON format
+ *
+ * Validates the export format and reconstructs the viewing key object.
+ *
+ * @param exported - The exported viewing key data
+ * @returns The imported viewing key
+ * @throws {ValidationError} If the export format is invalid
+ *
+ * @example
+ * ```typescript
+ * const json = await readFile('viewing-key.json')
+ * const exported = JSON.parse(json)
+ * const viewingKey = importViewingKey(exported)
+ * ```
+ */
+export function importViewingKey(exported: ViewingKeyExport): SolanaViewingKey {
+  // Validate version
+  if (exported.version !== EXPORT_VERSION) {
+    throw new ValidationError(
+      `Unsupported export version: ${exported.version}. Expected: ${EXPORT_VERSION}`,
+      'version'
+    )
+  }
+
+  // Validate chain
+  if (exported.chain !== 'solana') {
+    throw new ValidationError(
+      `Invalid chain: ${exported.chain}. Expected: solana`,
+      'chain'
+    )
+  }
+
+  // Validate keys
+  if (!isValidHex(exported.privateKey) || exported.privateKey.length !== 66) {
+    throw new ValidationError('Invalid private key format', 'privateKey')
+  }
+
+  if (!isValidHex(exported.publicKey) || exported.publicKey.length !== 66) {
+    throw new ValidationError('Invalid public key format', 'publicKey')
+  }
+
+  if (!isValidHex(exported.hash) || exported.hash.length !== 66) {
+    throw new ValidationError('Invalid hash format', 'hash')
+  }
+
+  // Verify the hash matches the public key
+  const computedHash = computeViewingKeyHash(exported.publicKey)
+  if (computedHash !== exported.hash) {
+    throw new ValidationError(
+      'Hash does not match public key',
+      'hash',
+      { expected: computedHash, received: exported.hash }
+    )
+  }
+
+  // Verify public key matches private key
+  const privateBytes = hexToBytes(exported.privateKey.slice(2))
+  try {
+    const derivedPublic = `0x${bytesToHex(ed25519.getPublicKey(privateBytes))}` as HexString
+    if (derivedPublic !== exported.publicKey) {
+      throw new ValidationError(
+        'Public key does not match private key',
+        'publicKey'
+      )
+    }
+  } finally {
+    secureWipe(privateBytes)
+  }
+
+  return {
+    privateKey: exported.privateKey,
+    publicKey: exported.publicKey,
+    hash: exported.hash,
+    label: exported.label,
+    createdAt: exported.createdAt,
+  }
+}
+
+// ─── Encryption/Decryption ────────────────────────────────────────────────────
+
+/**
+ * Derive an encryption key from a viewing key using HKDF
+ *
+ * @param viewingKey - The viewing key (private or public depending on operation)
+ * @param isPublic - Whether the key is public (for encryption) or private (for key agreement)
+ * @returns 32-byte encryption key (caller must wipe after use)
+ */
+function deriveEncryptionKey(key: HexString, salt?: Uint8Array): Uint8Array {
+  const keyBytes = hexToBytes(key.slice(2))
+
+  try {
+    // Use HKDF to derive a proper encryption key
+    const hkdfSalt = salt ?? utf8ToBytes(ENCRYPTION_DOMAIN)
+    return hkdf(sha256, keyBytes, hkdfSalt, utf8ToBytes('encryption'), 32)
+  } finally {
+    secureWipe(keyBytes)
+  }
+}
+
+/**
+ * Encrypt transaction data for viewing key holders
+ *
+ * Uses XChaCha20-Poly1305 authenticated encryption with a random nonce.
+ * The encryption key is derived from the viewing private key using HKDF.
+ *
+ * @param data - Transaction data to encrypt
+ * @param viewingKey - The viewing key for encryption
+ * @returns Encrypted payload with nonce and key hash
+ *
+ * @example
+ * ```typescript
+ * const encrypted = encryptForViewing({
+ *   sender: senderPubkey.toBase58(),
+ *   recipient: stealthAddress.toBase58(),
+ *   amount: '1000000',
+ *   mint: USDC_MINT.toBase58(),
+ *   timestamp: Date.now(),
+ * }, viewingKey)
+ *
+ * // Store encrypted.ciphertext on-chain or off-chain
+ * ```
+ */
+export function encryptForViewing(
+  data: SolanaTransactionData,
+  viewingKey: SolanaViewingKey
+): EncryptedPayload {
+  // Derive encryption key from viewing private key
+  const encKey = deriveEncryptionKey(viewingKey.privateKey)
+
+  try {
+    // Generate random nonce
+    const nonce = randomBytes(NONCE_SIZE)
+
+    // Serialize data to JSON
+    const plaintext = utf8ToBytes(JSON.stringify(data))
+
+    // Encrypt with XChaCha20-Poly1305
+    const cipher = xchacha20poly1305(encKey, nonce)
+    const ciphertext = cipher.encrypt(plaintext)
+
+    return {
+      ciphertext: `0x${bytesToHex(ciphertext)}` as HexString,
+      nonce: `0x${bytesToHex(nonce)}` as HexString,
+      viewingKeyHash: viewingKey.hash,
+    }
+  } finally {
+    secureWipe(encKey)
+  }
+}
+
+/**
+ * Decrypt transaction data with a viewing key
+ *
+ * @param encrypted - The encrypted payload
+ * @param viewingKey - The viewing key for decryption
+ * @returns The decrypted transaction data
+ * @throws {CryptoError} If decryption fails (wrong key or tampered data)
+ *
+ * @example
+ * ```typescript
+ * const data = decryptWithViewing(encrypted, viewingKey)
+ * console.log('Amount:', data.amount)
+ * console.log('Sender:', data.sender)
+ * ```
+ */
+export function decryptWithViewing(
+  encrypted: EncryptedPayload,
+  viewingKey: SolanaViewingKey
+): SolanaTransactionData {
+  // Verify the viewing key can decrypt this
+  if (encrypted.viewingKeyHash !== viewingKey.hash) {
+    throw new CryptoError(
+      'Viewing key hash does not match encrypted payload',
+      ErrorCode.DECRYPTION_FAILED,
+      { context: { expected: encrypted.viewingKeyHash, received: viewingKey.hash } }
+    )
+  }
+
+  // Derive encryption key
+  const encKey = deriveEncryptionKey(viewingKey.privateKey)
+
+  try {
+    // Parse ciphertext and nonce
+    const ciphertext = hexToBytes(encrypted.ciphertext.slice(2))
+    const nonce = hexToBytes(encrypted.nonce.slice(2))
+
+    if (nonce.length !== NONCE_SIZE) {
+      throw new ValidationError(
+        `Invalid nonce length: ${nonce.length}. Expected: ${NONCE_SIZE}`,
+        'nonce'
+      )
+    }
+
+    // Decrypt with XChaCha20-Poly1305
+    const cipher = xchacha20poly1305(encKey, nonce)
+    const plaintext = cipher.decrypt(ciphertext)
+
+    // Parse JSON
+    const json = new TextDecoder().decode(plaintext)
+    return JSON.parse(json) as SolanaTransactionData
+  } catch (error) {
+    if (error instanceof ValidationError || error instanceof CryptoError) {
+      throw error
+    }
+    throw new CryptoError(
+      'Failed to decrypt: authentication failed or data corrupted',
+      ErrorCode.DECRYPTION_FAILED,
+      { cause: error instanceof Error ? error : undefined }
+    )
+  } finally {
+    secureWipe(encKey)
+  }
+}
+
+// ─── In-Memory Storage ────────────────────────────────────────────────────────
+
+/**
+ * Simple in-memory viewing key storage
+ *
+ * Useful for testing and temporary storage. For production use,
+ * implement a persistent storage provider.
+ *
+ * @example
+ * ```typescript
+ * const storage = createMemoryStorage()
+ *
+ * // Store a key
+ * await storage.save(viewingKey)
+ *
+ * // List all keys
+ * const keys = await storage.list()
+ *
+ * // Load a specific key
+ * const key = await storage.load(hash)
+ * ```
+ */
+export function createMemoryStorage(): ViewingKeyStorage {
+  const keys = new Map<Hash, SolanaViewingKey>()
+
+  return {
+    async save(key: SolanaViewingKey): Promise<Hash> {
+      keys.set(key.hash, { ...key })
+      return key.hash
+    },
+
+    async load(hash: Hash): Promise<SolanaViewingKey | null> {
+      const key = keys.get(hash)
+      return key ? { ...key } : null
+    },
+
+    async list(): Promise<SolanaViewingKey[]> {
+      return Array.from(keys.values()).map(k => ({ ...k }))
+    },
+
+    async delete(hash: Hash): Promise<boolean> {
+      return keys.delete(hash)
+    },
+  }
+}
+
+// ─── Utilities ────────────────────────────────────────────────────────────────
+
+/**
+ * Check if an announcement hash matches a viewing key
+ *
+ * Used during scanning to efficiently filter announcements that belong
+ * to this viewing key.
+ *
+ * @param announcementHash - Hash from the on-chain announcement
+ * @param viewingKey - The viewing key to check against
+ * @returns true if the announcement is for this viewing key
+ */
+export function isAnnouncementForViewingKey(
+  announcementHash: Hash,
+  viewingKey: SolanaViewingKey
+): boolean {
+  return announcementHash === viewingKey.hash
+}
+
+/**
+ * Derive a child viewing key for hierarchical key management
+ *
+ * Uses HMAC-SHA256 with the parent key and child path to derive
+ * a new independent viewing key.
+ *
+ * @param parentKey - The parent viewing key
+ * @param childPath - A path string for derivation (e.g., "audit/2024")
+ * @param label - Optional label for the child key
+ * @returns The derived child viewing key
+ *
+ * @example
+ * ```typescript
+ * const auditKey = deriveChildViewingKey(masterKey, 'audit/2024', 'Audit 2024')
+ * const accountingKey = deriveChildViewingKey(masterKey, 'accounting', 'Accounting')
+ * ```
+ */
+export function deriveChildViewingKey(
+  parentKey: SolanaViewingKey,
+  childPath: string,
+  label?: string
+): SolanaViewingKey {
+  if (!childPath || typeof childPath !== 'string') {
+    throw new ValidationError('childPath must be a non-empty string', 'childPath')
+  }
+
+  const parentBytes = hexToBytes(parentKey.privateKey.slice(2))
+
+  try {
+    // Derive child key using HMAC-SHA256
+    const childBytes = hmac(sha256, utf8ToBytes(childPath), parentBytes)
+    const publicBytes = ed25519.getPublicKey(childBytes)
+    const hashBytes = sha256(publicBytes)
+
+    const result: SolanaViewingKey = {
+      privateKey: `0x${bytesToHex(childBytes)}` as HexString,
+      publicKey: `0x${bytesToHex(publicBytes)}` as HexString,
+      hash: `0x${bytesToHex(hashBytes)}` as Hash,
+      label: label ?? `${parentKey.label ?? 'Key'}/${childPath}`,
+      createdAt: Date.now(),
+    }
+
+    // Wipe child bytes after creating hex
+    secureWipe(childBytes)
+
+    return result
+  } finally {
+    secureWipe(parentBytes)
+  }
+}
+
+/**
+ * Get the public key from a viewing private key
+ *
+ * @param viewingPrivateKey - The viewing private key
+ * @returns The corresponding public key
+ */
+export function getViewingPublicKey(viewingPrivateKey: HexString): HexString {
+  if (!viewingPrivateKey || !viewingPrivateKey.startsWith('0x')) {
+    throw new ValidationError(
+      'viewingPrivateKey must be a hex string with 0x prefix',
+      'viewingPrivateKey'
+    )
+  }
+
+  const privateBytes = hexToBytes(viewingPrivateKey.slice(2))
+
+  if (privateBytes.length !== 32) {
+    throw new ValidationError(
+      'viewingPrivateKey must be 32 bytes',
+      'viewingPrivateKey'
+    )
+  }
+
+  try {
+    const publicBytes = ed25519.getPublicKey(privateBytes)
+    return `0x${bytesToHex(publicBytes)}` as HexString
+  } finally {
+    secureWipe(privateBytes)
+  }
+}

--- a/packages/sdk/tests/chains/solana/commitment.test.ts
+++ b/packages/sdk/tests/chains/solana/commitment.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Solana Pedersen Commitment Tests
+ *
+ * Tests for ed25519-based Pedersen commitments on Solana.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  commitSolana,
+  verifyOpeningSolana,
+  commitSPLToken,
+  verifySPLTokenCommitment,
+  toSmallestUnits,
+  fromSmallestUnits,
+  addCommitmentsSolana,
+  subtractCommitmentsSolana,
+  addBlindingsSolana,
+  subtractBlindingsSolana,
+  getGeneratorsSolana,
+  generateBlindingSolana,
+  ED25519_ORDER,
+  MAX_SPL_AMOUNT,
+} from '../../../src/chains/solana/commitment'
+import type { HexString } from '@sip-protocol/types'
+
+describe('Solana Pedersen Commitments', () => {
+  // ─── Basic Commitment ─────────────────────────────────────────────────────
+
+  describe('commitSolana', () => {
+    it('should create a commitment to a value', () => {
+      const { commitment, blinding } = commitSolana(100n)
+
+      expect(commitment).toMatch(/^0x[0-9a-f]{64}$/) // 32 bytes ed25519 point
+      expect(blinding).toMatch(/^0x[0-9a-f]{64}$/)   // 32 bytes blinding
+    })
+
+    it('should create different commitments for same value (random blinding)', () => {
+      const c1 = commitSolana(100n)
+      const c2 = commitSolana(100n)
+
+      // Same value but different blindings = different commitments
+      expect(c1.commitment).not.toBe(c2.commitment)
+      expect(c1.blinding).not.toBe(c2.blinding)
+    })
+
+    it('should create deterministic commitment with provided blinding', () => {
+      const blinding = new Uint8Array(32).fill(1) // Fixed blinding
+      const c1 = commitSolana(100n, blinding)
+      const c2 = commitSolana(100n, blinding)
+
+      expect(c1.commitment).toBe(c2.commitment)
+    })
+
+    it('should create valid commitment for zero value', () => {
+      const { commitment, blinding } = commitSolana(0n)
+
+      expect(commitment).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(verifyOpeningSolana(commitment, 0n, blinding)).toBe(true)
+    })
+
+    it('should throw for negative values', () => {
+      expect(() => commitSolana(-1n)).toThrow()
+    })
+
+    it('should throw for value >= curve order', () => {
+      expect(() => commitSolana(ED25519_ORDER)).toThrow()
+      expect(() => commitSolana(ED25519_ORDER + 1n)).toThrow()
+    })
+
+    it('should throw for invalid blinding length', () => {
+      const shortBlinding = new Uint8Array(16)
+      expect(() => commitSolana(100n, shortBlinding)).toThrow()
+    })
+  })
+
+  // ─── Verification ─────────────────────────────────────────────────────────
+
+  describe('verifyOpeningSolana', () => {
+    it('should verify correct opening', () => {
+      const { commitment, blinding } = commitSolana(12345n)
+
+      expect(verifyOpeningSolana(commitment, 12345n, blinding)).toBe(true)
+    })
+
+    it('should reject wrong value', () => {
+      const { commitment, blinding } = commitSolana(100n)
+
+      expect(verifyOpeningSolana(commitment, 99n, blinding)).toBe(false)
+      expect(verifyOpeningSolana(commitment, 101n, blinding)).toBe(false)
+    })
+
+    it('should reject wrong blinding', () => {
+      const { commitment } = commitSolana(100n)
+      const wrongBlinding = '0x' + '00'.repeat(31) + '01' as HexString
+
+      expect(verifyOpeningSolana(commitment, 100n, wrongBlinding)).toBe(false)
+    })
+
+    it('should verify zero value commitment', () => {
+      const { commitment, blinding } = commitSolana(0n)
+
+      expect(verifyOpeningSolana(commitment, 0n, blinding)).toBe(true)
+      expect(verifyOpeningSolana(commitment, 1n, blinding)).toBe(false)
+    })
+
+    it('should verify large values', () => {
+      const largeValue = 2n ** 63n - 1n // Max u64 / 2
+      const { commitment, blinding } = commitSolana(largeValue)
+
+      expect(verifyOpeningSolana(commitment, largeValue, blinding)).toBe(true)
+    })
+  })
+
+  // ─── SPL Token Commitments ────────────────────────────────────────────────
+
+  describe('commitSPLToken', () => {
+    const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+
+    it('should create SPL token commitment', () => {
+      const commitment = commitSPLToken(100_000_000n, USDC_MINT, 6)
+
+      expect(commitment.commitment).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(commitment.blinding).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(commitment.mint).toBe(USDC_MINT)
+      expect(commitment.decimals).toBe(6)
+      expect(commitment.amountRaw).toBe(100_000_000n)
+    })
+
+    it('should verify SPL token commitment', () => {
+      const commitment = commitSPLToken(100_000_000n, USDC_MINT, 6)
+
+      expect(verifySPLTokenCommitment(commitment, 100_000_000n)).toBe(true)
+      expect(verifySPLTokenCommitment(commitment, 100_000_001n)).toBe(false)
+    })
+
+    it('should handle max u64 amount', () => {
+      const commitment = commitSPLToken(MAX_SPL_AMOUNT, USDC_MINT, 6)
+
+      expect(commitment.amountRaw).toBe(MAX_SPL_AMOUNT)
+      expect(verifySPLTokenCommitment(commitment, MAX_SPL_AMOUNT)).toBe(true)
+    })
+
+    it('should throw for amount > u64', () => {
+      expect(() => commitSPLToken(MAX_SPL_AMOUNT + 1n, USDC_MINT, 6)).toThrow()
+    })
+
+    it('should throw for negative amount', () => {
+      expect(() => commitSPLToken(-1n, USDC_MINT, 6)).toThrow()
+    })
+
+    it('should throw for invalid decimals', () => {
+      expect(() => commitSPLToken(100n, USDC_MINT, -1)).toThrow()
+      expect(() => commitSPLToken(100n, USDC_MINT, 19)).toThrow()
+      expect(() => commitSPLToken(100n, USDC_MINT, 1.5)).toThrow()
+    })
+  })
+
+  // ─── Unit Conversion ──────────────────────────────────────────────────────
+
+  describe('toSmallestUnits', () => {
+    it('should convert whole numbers', () => {
+      expect(toSmallestUnits(100, 6)).toBe(100_000_000n)
+      expect(toSmallestUnits(1, 9)).toBe(1_000_000_000n)
+    })
+
+    it('should convert fractional numbers', () => {
+      expect(toSmallestUnits(100.5, 6)).toBe(100_500_000n)
+      expect(toSmallestUnits(0.001, 9)).toBe(1_000_000n)
+    })
+
+    it('should handle string inputs', () => {
+      expect(toSmallestUnits('100.5', 6)).toBe(100_500_000n)
+      expect(toSmallestUnits('1', 9)).toBe(1_000_000_000n)
+    })
+
+    it('should truncate excess precision', () => {
+      // 6 decimals, but input has more
+      expect(toSmallestUnits('100.1234567', 6)).toBe(100_123_456n)
+    })
+  })
+
+  describe('fromSmallestUnits', () => {
+    it('should convert to human-readable', () => {
+      expect(fromSmallestUnits(100_000_000n, 6)).toBe('100')
+      expect(fromSmallestUnits(100_500_000n, 6)).toBe('100.5')
+    })
+
+    it('should handle small amounts', () => {
+      expect(fromSmallestUnits(1n, 6)).toBe('0.000001')
+      expect(fromSmallestUnits(1_000_000n, 9)).toBe('0.001')
+    })
+
+    it('should strip trailing zeros', () => {
+      expect(fromSmallestUnits(100_000_000n, 6)).toBe('100')
+      expect(fromSmallestUnits(100_100_000n, 6)).toBe('100.1')
+    })
+  })
+
+  // ─── Homomorphic Addition ─────────────────────────────────────────────────
+
+  describe('addCommitmentsSolana', () => {
+    it('should add commitments homomorphically', () => {
+      const c1 = commitSolana(100n)
+      const c2 = commitSolana(50n)
+
+      const sum = addCommitmentsSolana(c1.commitment, c2.commitment)
+      const blindingSum = addBlindingsSolana(c1.blinding, c2.blinding)
+
+      // The sum should verify for 150
+      expect(verifyOpeningSolana(sum.commitment, 150n, blindingSum)).toBe(true)
+    })
+
+    it('should handle multiple additions', () => {
+      const c1 = commitSolana(10n)
+      const c2 = commitSolana(20n)
+      const c3 = commitSolana(30n)
+
+      const sum12 = addCommitmentsSolana(c1.commitment, c2.commitment)
+      const blindSum12 = addBlindingsSolana(c1.blinding, c2.blinding)
+
+      const sum123 = addCommitmentsSolana(sum12.commitment, c3.commitment)
+      const blindSum123 = addBlindingsSolana(blindSum12, c3.blinding)
+
+      expect(verifyOpeningSolana(sum123.commitment, 60n, blindSum123)).toBe(true)
+    })
+
+    it('should throw for invalid commitment', () => {
+      expect(() => addCommitmentsSolana('invalid' as HexString, '0x' + '00'.repeat(32) as HexString)).toThrow()
+    })
+  })
+
+  // ─── Homomorphic Subtraction ──────────────────────────────────────────────
+
+  describe('subtractCommitmentsSolana', () => {
+    it('should subtract commitments homomorphically', () => {
+      const c1 = commitSolana(100n)
+      const c2 = commitSolana(40n)
+
+      const diff = subtractCommitmentsSolana(c1.commitment, c2.commitment)
+      const blindingDiff = subtractBlindingsSolana(c1.blinding, c2.blinding)
+
+      // The difference should verify for 60
+      expect(verifyOpeningSolana(diff.commitment, 60n, blindingDiff)).toBe(true)
+    })
+
+    it('should handle subtraction to zero', () => {
+      const blinding = new Uint8Array(32).fill(42)
+      const c1 = commitSolana(100n, blinding)
+      const c2 = commitSolana(100n, blinding)
+
+      const diff = subtractCommitmentsSolana(c1.commitment, c2.commitment)
+
+      // Result should be zero point
+      expect(diff.commitment).toBe('0x' + '00'.repeat(32))
+    })
+  })
+
+  // ─── Blinding Factor Operations ───────────────────────────────────────────
+
+  describe('blinding operations', () => {
+    it('should add blindings modulo curve order', () => {
+      const b1 = generateBlindingSolana()
+      const b2 = generateBlindingSolana()
+
+      const sum = addBlindingsSolana(b1, b2)
+      expect(sum).toMatch(/^0x[0-9a-f]{64}$/)
+    })
+
+    it('should subtract blindings modulo curve order', () => {
+      const b1 = generateBlindingSolana()
+      const b2 = generateBlindingSolana()
+
+      const diff = subtractBlindingsSolana(b1, b2)
+      expect(diff).toMatch(/^0x[0-9a-f]{64}$/)
+    })
+
+    it('should handle b1 - b1 = 0', () => {
+      const b = generateBlindingSolana()
+      const diff = subtractBlindingsSolana(b, b)
+
+      expect(diff).toBe('0x' + '00'.repeat(32))
+    })
+  })
+
+  // ─── Generators ───────────────────────────────────────────────────────────
+
+  describe('getGeneratorsSolana', () => {
+    it('should return valid generators', () => {
+      const { G, H } = getGeneratorsSolana()
+
+      expect(G).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(H).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(G).not.toBe(H) // G and H must be different
+    })
+  })
+
+  describe('generateBlindingSolana', () => {
+    it('should generate random 32-byte blinding', () => {
+      const b1 = generateBlindingSolana()
+      const b2 = generateBlindingSolana()
+
+      expect(b1).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(b2).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(b1).not.toBe(b2) // Should be different
+    })
+  })
+
+  // ─── Edge Cases ───────────────────────────────────────────────────────────
+
+  describe('Edge Cases', () => {
+    it('should handle commitment arithmetic with zero', () => {
+      const c1 = commitSolana(100n)
+      const c0 = commitSolana(0n)
+
+      const sum = addCommitmentsSolana(c1.commitment, c0.commitment)
+      const blindSum = addBlindingsSolana(c1.blinding, c0.blinding)
+
+      // 100 + 0 = 100
+      expect(verifyOpeningSolana(sum.commitment, 100n, blindSum)).toBe(true)
+    })
+
+    it('should work with various SPL token amounts', () => {
+      const amounts = [
+        0n,
+        1n,
+        1000n,
+        1_000_000n,
+        1_000_000_000n,
+        MAX_SPL_AMOUNT / 2n,
+        MAX_SPL_AMOUNT,
+      ]
+
+      for (const amount of amounts) {
+        const commitment = commitSolana(amount)
+        expect(verifyOpeningSolana(commitment.commitment, amount, commitment.blinding)).toBe(true)
+      }
+    })
+
+    it('should maintain hiding property', () => {
+      // Different values with different blindings should produce different commitments
+      const commitments = new Set<string>()
+
+      for (let i = 0n; i < 100n; i++) {
+        const { commitment } = commitSolana(i)
+        commitments.add(commitment)
+      }
+
+      // All commitments should be unique
+      expect(commitments.size).toBe(100)
+    })
+  })
+})

--- a/packages/sdk/tests/chains/solana/key-derivation.test.ts
+++ b/packages/sdk/tests/chains/solana/key-derivation.test.ts
@@ -1,0 +1,424 @@
+/**
+ * Solana Key Derivation Tests
+ *
+ * Tests for BIP39 mnemonic to SIP stealth key derivation.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  deriveSolanaStealthKeys,
+  deriveViewingKeyFromSpending,
+  generateMnemonic,
+  isValidMnemonic,
+  validateMnemonic,
+  validateDerivationPath,
+  getDerivationPath,
+  SOLANA_DEFAULT_PATH,
+} from '../../../src/chains/solana/key-derivation'
+import {
+  generateEd25519StealthAddress,
+  checkEd25519StealthAddress,
+  deriveEd25519StealthPrivateKey,
+  ed25519PublicKeyToSolanaAddress,
+  isValidSolanaAddress,
+} from '../../../src/stealth'
+import { ed25519 } from '@noble/curves/ed25519'
+
+// Standard BIP39 test vector (12 words)
+const TEST_MNEMONIC_12 = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+
+// 24-word mnemonic
+const TEST_MNEMONIC_24 = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art'
+
+describe('Solana Key Derivation', () => {
+  // ─── deriveSolanaStealthKeys ─────────────────────────────────────────────────
+
+  describe('deriveSolanaStealthKeys', () => {
+    it('should derive keys from 12-word mnemonic', () => {
+      const result = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+      })
+
+      // Verify structure
+      expect(result.metaAddress).toBeDefined()
+      expect(result.metaAddress.chain).toBe('solana')
+      expect(result.metaAddress.spendingKey).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(result.metaAddress.viewingKey).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(result.spendingPrivateKey).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(result.viewingPrivateKey).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(result.derivationPath).toBe(SOLANA_DEFAULT_PATH)
+    })
+
+    it('should derive keys from 24-word mnemonic', () => {
+      const result = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_24,
+      })
+
+      expect(result.metaAddress.chain).toBe('solana')
+      expect(result.metaAddress.spendingKey).toMatch(/^0x[0-9a-f]{64}$/)
+    })
+
+    it('should produce different keys for different mnemonics', () => {
+      const result1 = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+      })
+
+      const result2 = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_24,
+      })
+
+      expect(result1.metaAddress.spendingKey).not.toBe(result2.metaAddress.spendingKey)
+      expect(result1.metaAddress.viewingKey).not.toBe(result2.metaAddress.viewingKey)
+    })
+
+    it('should produce deterministic output (same mnemonic = same keys)', () => {
+      const result1 = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+      })
+
+      const result2 = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+      })
+
+      expect(result1.metaAddress.spendingKey).toBe(result2.metaAddress.spendingKey)
+      expect(result1.metaAddress.viewingKey).toBe(result2.metaAddress.viewingKey)
+      expect(result1.spendingPrivateKey).toBe(result2.spendingPrivateKey)
+      expect(result1.viewingPrivateKey).toBe(result2.viewingPrivateKey)
+    })
+
+    it('should use custom derivation path', () => {
+      const customPath = "m/44'/501'/1'/0'"
+      const result = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+        derivationPath: customPath,
+      })
+
+      expect(result.derivationPath).toBe(customPath)
+    })
+
+    it('should derive different keys for different accounts', () => {
+      const result0 = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+        accountIndex: 0,
+      })
+
+      const result1 = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+        accountIndex: 1,
+      })
+
+      const result2 = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+        accountIndex: 2,
+      })
+
+      // All should be different
+      expect(result0.metaAddress.spendingKey).not.toBe(result1.metaAddress.spendingKey)
+      expect(result1.metaAddress.spendingKey).not.toBe(result2.metaAddress.spendingKey)
+      expect(result0.metaAddress.spendingKey).not.toBe(result2.metaAddress.spendingKey)
+    })
+
+    it('should handle passphrase', () => {
+      const withoutPassphrase = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+      })
+
+      const withPassphrase = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+        passphrase: 'secret',
+      })
+
+      // Different passphrase = different keys
+      expect(withoutPassphrase.metaAddress.spendingKey).not.toBe(withPassphrase.metaAddress.spendingKey)
+    })
+
+    it('should include label in meta-address', () => {
+      const result = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+        label: 'My Trading Account',
+      })
+
+      expect(result.metaAddress.label).toBe('My Trading Account')
+    })
+
+    it('should throw for invalid mnemonic', () => {
+      expect(() =>
+        deriveSolanaStealthKeys({
+          mnemonic: 'invalid mnemonic phrase',
+        })
+      ).toThrow()
+    })
+
+    it('should throw for wrong word count', () => {
+      expect(() =>
+        deriveSolanaStealthKeys({
+          mnemonic: 'abandon abandon abandon', // Only 3 words
+        })
+      ).toThrow()
+    })
+
+    it('should throw for non-hardened path', () => {
+      expect(() =>
+        deriveSolanaStealthKeys({
+          mnemonic: TEST_MNEMONIC_12,
+          derivationPath: "m/44/501/0/0", // Missing hardened indicators
+        })
+      ).toThrow('hardened')
+    })
+  })
+
+  // ─── Stealth Address Integration ─────────────────────────────────────────────
+
+  describe('Integration with Stealth Addresses', () => {
+    it('should generate valid stealth addresses from derived keys', () => {
+      const { metaAddress, spendingPrivateKey, viewingPrivateKey } = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+      })
+
+      // Generate stealth address
+      const { stealthAddress } = generateEd25519StealthAddress(metaAddress)
+
+      // Should produce valid Solana address
+      const solanaAddress = ed25519PublicKeyToSolanaAddress(stealthAddress.address)
+      expect(isValidSolanaAddress(solanaAddress)).toBe(true)
+    })
+
+    it('should verify stealth address ownership with derived keys', () => {
+      const { metaAddress, spendingPrivateKey, viewingPrivateKey } = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+      })
+
+      // Generate stealth address
+      const { stealthAddress } = generateEd25519StealthAddress(metaAddress)
+
+      // Check if it's ours
+      const isOurs = checkEd25519StealthAddress(
+        stealthAddress,
+        spendingPrivateKey,
+        viewingPrivateKey
+      )
+
+      expect(isOurs).toBe(true)
+    })
+
+    it('should derive private key for received payment', () => {
+      const { metaAddress, spendingPrivateKey, viewingPrivateKey } = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+      })
+
+      // Generate stealth address (simulating sender)
+      const { stealthAddress } = generateEd25519StealthAddress(metaAddress)
+
+      // Derive private key (as recipient)
+      const recovery = deriveEd25519StealthPrivateKey(
+        stealthAddress,
+        spendingPrivateKey,
+        viewingPrivateKey
+      )
+
+      // Verify the derived key matches the stealth address
+      expect(recovery.stealthAddress).toBe(stealthAddress.address)
+
+      // Verify we can derive the correct public key
+      const privateKeyBytes = Buffer.from(recovery.privateKey.slice(2), 'hex')
+      const scalar = BigInt('0x' + privateKeyBytes.reverse().toString('hex'))
+      const derivedPubPoint = ed25519.ExtendedPoint.BASE.multiply(
+        scalar % (2n ** 252n + 27742317777372353535851937790883648493n)
+      )
+      const derivedPubKey = '0x' + Buffer.from(derivedPubPoint.toRawBytes()).toString('hex')
+
+      expect(derivedPubKey.toLowerCase()).toBe(stealthAddress.address.toLowerCase())
+    })
+
+    it('should produce unique stealth addresses for each payment', () => {
+      const { metaAddress } = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+      })
+
+      const addresses: string[] = []
+      for (let i = 0; i < 10; i++) {
+        const { stealthAddress } = generateEd25519StealthAddress(metaAddress)
+        addresses.push(stealthAddress.address)
+      }
+
+      // All should be unique
+      const unique = new Set(addresses)
+      expect(unique.size).toBe(10)
+    })
+  })
+
+  // ─── deriveViewingKeyFromSpending ────────────────────────────────────────────
+
+  describe('deriveViewingKeyFromSpending', () => {
+    it('should derive viewing key from spending key', () => {
+      const { spendingPrivateKey, viewingPrivateKey } = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+      })
+
+      const derived = deriveViewingKeyFromSpending(spendingPrivateKey)
+
+      expect(derived).toBe(viewingPrivateKey)
+    })
+
+    it('should be deterministic', () => {
+      const { spendingPrivateKey } = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+      })
+
+      const derived1 = deriveViewingKeyFromSpending(spendingPrivateKey)
+      const derived2 = deriveViewingKeyFromSpending(spendingPrivateKey)
+
+      expect(derived1).toBe(derived2)
+    })
+
+    it('should throw for invalid spending key', () => {
+      expect(() => deriveViewingKeyFromSpending('invalid')).toThrow()
+      expect(() => deriveViewingKeyFromSpending('0xabc' as any)).toThrow() // Wrong length
+    })
+  })
+
+  // ─── Mnemonic Utilities ──────────────────────────────────────────────────────
+
+  describe('generateMnemonic', () => {
+    it('should generate 12-word mnemonic by default', () => {
+      const mnemonic = generateMnemonic()
+      const words = mnemonic.split(' ')
+
+      expect(words.length).toBe(12)
+      expect(isValidMnemonic(mnemonic)).toBe(true)
+    })
+
+    it('should generate 24-word mnemonic when requested', () => {
+      const mnemonic = generateMnemonic(256)
+      const words = mnemonic.split(' ')
+
+      expect(words.length).toBe(24)
+      expect(isValidMnemonic(mnemonic)).toBe(true)
+    })
+
+    it('should produce unique mnemonics', () => {
+      const mnemonic1 = generateMnemonic()
+      const mnemonic2 = generateMnemonic()
+
+      expect(mnemonic1).not.toBe(mnemonic2)
+    })
+  })
+
+  describe('isValidMnemonic', () => {
+    it('should return true for valid mnemonics', () => {
+      expect(isValidMnemonic(TEST_MNEMONIC_12)).toBe(true)
+      expect(isValidMnemonic(TEST_MNEMONIC_24)).toBe(true)
+    })
+
+    it('should return false for invalid mnemonics', () => {
+      expect(isValidMnemonic('invalid')).toBe(false)
+      expect(isValidMnemonic('')).toBe(false)
+      expect(isValidMnemonic('abandon abandon abandon')).toBe(false) // Wrong count
+    })
+  })
+
+  describe('validateMnemonic', () => {
+    it('should return true for valid mnemonic', () => {
+      expect(validateMnemonic(TEST_MNEMONIC_12)).toBe(true)
+    })
+
+    it('should throw for invalid mnemonic', () => {
+      expect(() => validateMnemonic('invalid')).toThrow()
+    })
+  })
+
+  // ─── Derivation Path Utilities ───────────────────────────────────────────────
+
+  describe('validateDerivationPath', () => {
+    it('should accept valid paths', () => {
+      expect(validateDerivationPath("m/44'/501'/0'/0'")).toBe(true)
+      expect(validateDerivationPath("m/44'/501'/1'/0'")).toBe(true)
+      expect(validateDerivationPath("m/44'/501'/0'/1'")).toBe(true)
+    })
+
+    it('should throw for invalid paths', () => {
+      expect(() => validateDerivationPath('')).toThrow()
+      expect(() => validateDerivationPath('invalid')).toThrow()
+      expect(() => validateDerivationPath("44'/501'/0'/0'")).toThrow() // Missing m/
+    })
+  })
+
+  describe('getDerivationPath', () => {
+    it('should return default path for index 0', () => {
+      expect(getDerivationPath(0)).toBe("m/44'/501'/0'/0'")
+    })
+
+    it('should return correct path for other indices', () => {
+      expect(getDerivationPath(1)).toBe("m/44'/501'/1'/0'")
+      expect(getDerivationPath(5)).toBe("m/44'/501'/5'/0'")
+      expect(getDerivationPath(100)).toBe("m/44'/501'/100'/0'")
+    })
+
+    it('should throw for negative index', () => {
+      expect(() => getDerivationPath(-1)).toThrow()
+    })
+  })
+
+  describe('SOLANA_DEFAULT_PATH', () => {
+    it('should be standard Solana path', () => {
+      expect(SOLANA_DEFAULT_PATH).toBe("m/44'/501'/0'/0'")
+    })
+  })
+
+  // ─── Edge Cases ──────────────────────────────────────────────────────────────
+
+  describe('Edge Cases', () => {
+    it('should handle mnemonic with extra whitespace', () => {
+      const messyMnemonic = '  abandon  abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about  '
+      const result = deriveSolanaStealthKeys({
+        mnemonic: messyMnemonic,
+      })
+
+      // Compare with clean mnemonic
+      const cleanResult = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+      })
+
+      expect(result.metaAddress.spendingKey).toBe(cleanResult.metaAddress.spendingKey)
+    })
+
+    it('should handle uppercase mnemonic', () => {
+      const uppercaseMnemonic = TEST_MNEMONIC_12.toUpperCase()
+      const result = deriveSolanaStealthKeys({
+        mnemonic: uppercaseMnemonic,
+      })
+
+      const lowercaseResult = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+      })
+
+      expect(result.metaAddress.spendingKey).toBe(lowercaseResult.metaAddress.spendingKey)
+    })
+
+    it('should derive valid ed25519 public keys', () => {
+      const { metaAddress, spendingPrivateKey, viewingPrivateKey } = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC_12,
+      })
+
+      // Verify spending key is valid ed25519
+      const spendingPubBytes = Buffer.from(metaAddress.spendingKey.slice(2), 'hex')
+      expect(() => ed25519.ExtendedPoint.fromHex(spendingPubBytes)).not.toThrow()
+
+      // Verify viewing key is valid ed25519
+      const viewingPubBytes = Buffer.from(metaAddress.viewingKey.slice(2), 'hex')
+      expect(() => ed25519.ExtendedPoint.fromHex(viewingPubBytes)).not.toThrow()
+    })
+
+    it('should work with many account indices', () => {
+      for (let i = 0; i < 20; i++) {
+        const result = deriveSolanaStealthKeys({
+          mnemonic: TEST_MNEMONIC_12,
+          accountIndex: i,
+        })
+
+        expect(result.metaAddress.spendingKey).toMatch(/^0x[0-9a-f]{64}$/)
+        expect(result.derivationPath).toBe(`m/44'/501'/${i}'/0'`)
+      }
+    })
+  })
+})

--- a/packages/sdk/tests/chains/solana/viewing-key.test.ts
+++ b/packages/sdk/tests/chains/solana/viewing-key.test.ts
@@ -1,0 +1,523 @@
+/**
+ * Solana Viewing Key Tests
+ *
+ * Tests for viewing key generation, export/import, encryption, and storage.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  generateViewingKeyFromSpending,
+  generateRandomViewingKey,
+  computeViewingKeyHash,
+  computeViewingKeyHashFromPrivate,
+  exportViewingKey,
+  importViewingKey,
+  encryptForViewing,
+  decryptWithViewing,
+  createMemoryStorage,
+  isAnnouncementForViewingKey,
+  deriveChildViewingKey,
+  getViewingPublicKey,
+  type SolanaViewingKey,
+  type SolanaTransactionData,
+} from '../../../src/chains/solana/viewing-key'
+import { deriveSolanaStealthKeys } from '../../../src/chains/solana/key-derivation'
+import type { Hash, HexString } from '@sip-protocol/types'
+
+// Test mnemonic (standard BIP39 test vector)
+const TEST_MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+
+describe('Solana Viewing Key', () => {
+  // ─── Generation ─────────────────────────────────────────────────────────────
+
+  describe('generateViewingKeyFromSpending', () => {
+    it('should generate viewing key from spending key', () => {
+      const { spendingPrivateKey } = deriveSolanaStealthKeys({ mnemonic: TEST_MNEMONIC })
+      const viewingKey = generateViewingKeyFromSpending(spendingPrivateKey, 'Test Key')
+
+      expect(viewingKey.privateKey).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(viewingKey.publicKey).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(viewingKey.hash).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(viewingKey.label).toBe('Test Key')
+      expect(viewingKey.createdAt).toBeLessThanOrEqual(Date.now())
+    })
+
+    it('should produce deterministic results', () => {
+      const { spendingPrivateKey } = deriveSolanaStealthKeys({ mnemonic: TEST_MNEMONIC })
+
+      const key1 = generateViewingKeyFromSpending(spendingPrivateKey)
+      const key2 = generateViewingKeyFromSpending(spendingPrivateKey)
+
+      expect(key1.privateKey).toBe(key2.privateKey)
+      expect(key1.publicKey).toBe(key2.publicKey)
+      expect(key1.hash).toBe(key2.hash)
+    })
+
+    it('should match key derivation viewing key', () => {
+      const { spendingPrivateKey, viewingPrivateKey, metaAddress } = deriveSolanaStealthKeys({
+        mnemonic: TEST_MNEMONIC,
+      })
+
+      const viewingKey = generateViewingKeyFromSpending(spendingPrivateKey)
+
+      expect(viewingKey.privateKey).toBe(viewingPrivateKey)
+      expect(viewingKey.publicKey).toBe(metaAddress.viewingKey)
+    })
+
+    it('should throw for invalid spending key', () => {
+      expect(() => generateViewingKeyFromSpending('invalid' as HexString)).toThrow()
+      expect(() => generateViewingKeyFromSpending('0xabc' as HexString)).toThrow() // Wrong length
+      expect(() => generateViewingKeyFromSpending('' as HexString)).toThrow()
+    })
+  })
+
+  describe('generateRandomViewingKey', () => {
+    it('should generate random viewing key', () => {
+      const key = generateRandomViewingKey('Random Key')
+
+      expect(key.privateKey).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(key.publicKey).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(key.hash).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(key.label).toBe('Random Key')
+    })
+
+    it('should produce different keys each time', () => {
+      const key1 = generateRandomViewingKey()
+      const key2 = generateRandomViewingKey()
+
+      expect(key1.privateKey).not.toBe(key2.privateKey)
+      expect(key1.publicKey).not.toBe(key2.publicKey)
+      expect(key1.hash).not.toBe(key2.hash)
+    })
+  })
+
+  // ─── Hash Computation ───────────────────────────────────────────────────────
+
+  describe('computeViewingKeyHash', () => {
+    it('should compute hash from public key', () => {
+      const key = generateRandomViewingKey()
+      const hash = computeViewingKeyHash(key.publicKey)
+
+      expect(hash).toBe(key.hash)
+      expect(hash).toMatch(/^0x[0-9a-f]{64}$/)
+    })
+
+    it('should produce consistent results', () => {
+      const key = generateRandomViewingKey()
+
+      const hash1 = computeViewingKeyHash(key.publicKey)
+      const hash2 = computeViewingKeyHash(key.publicKey)
+
+      expect(hash1).toBe(hash2)
+    })
+
+    it('should throw for invalid public key', () => {
+      expect(() => computeViewingKeyHash('invalid' as HexString)).toThrow()
+      expect(() => computeViewingKeyHash('0xabc' as HexString)).toThrow()
+    })
+  })
+
+  describe('computeViewingKeyHashFromPrivate', () => {
+    it('should compute same hash as from public key', () => {
+      const key = generateRandomViewingKey()
+
+      const hashFromPublic = computeViewingKeyHash(key.publicKey)
+      const hashFromPrivate = computeViewingKeyHashFromPrivate(key.privateKey)
+
+      expect(hashFromPrivate).toBe(hashFromPublic)
+      expect(hashFromPrivate).toBe(key.hash)
+    })
+  })
+
+  describe('getViewingPublicKey', () => {
+    it('should derive public key from private key', () => {
+      const key = generateRandomViewingKey()
+      const publicKey = getViewingPublicKey(key.privateKey)
+
+      expect(publicKey).toBe(key.publicKey)
+    })
+  })
+
+  // ─── Export/Import ──────────────────────────────────────────────────────────
+
+  describe('exportViewingKey', () => {
+    it('should export viewing key in standard format', () => {
+      const key = generateRandomViewingKey('Export Test')
+      const exported = exportViewingKey(key)
+
+      expect(exported.version).toBe(1)
+      expect(exported.chain).toBe('solana')
+      expect(exported.privateKey).toBe(key.privateKey)
+      expect(exported.publicKey).toBe(key.publicKey)
+      expect(exported.hash).toBe(key.hash)
+      expect(exported.label).toBe('Export Test')
+      expect(exported.createdAt).toBe(key.createdAt)
+      expect(exported.exportedAt).toBeLessThanOrEqual(Date.now())
+    })
+
+    it('should produce valid JSON', () => {
+      const key = generateRandomViewingKey()
+      const exported = exportViewingKey(key)
+      const json = JSON.stringify(exported)
+
+      expect(() => JSON.parse(json)).not.toThrow()
+    })
+  })
+
+  describe('importViewingKey', () => {
+    it('should import exported viewing key', () => {
+      const original = generateRandomViewingKey('Import Test')
+      const exported = exportViewingKey(original)
+      const imported = importViewingKey(exported)
+
+      expect(imported.privateKey).toBe(original.privateKey)
+      expect(imported.publicKey).toBe(original.publicKey)
+      expect(imported.hash).toBe(original.hash)
+      expect(imported.label).toBe(original.label)
+      expect(imported.createdAt).toBe(original.createdAt)
+    })
+
+    it('should verify hash matches public key', () => {
+      const key = generateRandomViewingKey()
+      const exported = exportViewingKey(key)
+
+      // Tamper with hash
+      exported.hash = '0x' + '00'.repeat(32) as Hash
+
+      expect(() => importViewingKey(exported)).toThrow(/hash/i)
+    })
+
+    it('should verify public key matches private key', () => {
+      const key1 = generateRandomViewingKey()
+      const key2 = generateRandomViewingKey()
+      const exported = exportViewingKey(key1)
+
+      // Mix keys
+      exported.publicKey = key2.publicKey
+      exported.hash = key2.hash
+
+      expect(() => importViewingKey(exported)).toThrow(/public key/i)
+    })
+
+    it('should reject invalid version', () => {
+      const key = generateRandomViewingKey()
+      const exported = exportViewingKey(key)
+      exported.version = 999
+
+      expect(() => importViewingKey(exported)).toThrow(/version/i)
+    })
+
+    it('should reject invalid chain', () => {
+      const key = generateRandomViewingKey()
+      const exported = exportViewingKey(key)
+      ;(exported as any).chain = 'ethereum'
+
+      expect(() => importViewingKey(exported)).toThrow(/chain/i)
+    })
+  })
+
+  // ─── Encryption/Decryption ──────────────────────────────────────────────────
+
+  describe('encryptForViewing', () => {
+    it('should encrypt transaction data', () => {
+      const key = generateRandomViewingKey()
+      const data: SolanaTransactionData = {
+        sender: 'So11111111111111111111111111111111111111112',
+        recipient: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        amount: '1000000',
+        mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        timestamp: Date.now(),
+        memo: 'Test payment',
+      }
+
+      const encrypted = encryptForViewing(data, key)
+
+      expect(encrypted.ciphertext).toMatch(/^0x[0-9a-f]+$/)
+      expect(encrypted.nonce).toMatch(/^0x[0-9a-f]{48}$/) // 24 bytes = 48 hex chars
+      expect(encrypted.viewingKeyHash).toBe(key.hash)
+    })
+
+    it('should produce different ciphertext each time', () => {
+      const key = generateRandomViewingKey()
+      const data: SolanaTransactionData = {
+        sender: 'sender',
+        recipient: 'recipient',
+        amount: '100',
+        mint: null,
+        timestamp: 12345,
+      }
+
+      const enc1 = encryptForViewing(data, key)
+      const enc2 = encryptForViewing(data, key)
+
+      expect(enc1.ciphertext).not.toBe(enc2.ciphertext)
+      expect(enc1.nonce).not.toBe(enc2.nonce)
+    })
+  })
+
+  describe('decryptWithViewing', () => {
+    it('should decrypt encrypted data', () => {
+      const key = generateRandomViewingKey()
+      const original: SolanaTransactionData = {
+        sender: 'So11111111111111111111111111111111111111112',
+        recipient: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        amount: '1000000',
+        mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        timestamp: 1234567890,
+        memo: 'Test payment',
+      }
+
+      const encrypted = encryptForViewing(original, key)
+      const decrypted = decryptWithViewing(encrypted, key)
+
+      expect(decrypted.sender).toBe(original.sender)
+      expect(decrypted.recipient).toBe(original.recipient)
+      expect(decrypted.amount).toBe(original.amount)
+      expect(decrypted.mint).toBe(original.mint)
+      expect(decrypted.timestamp).toBe(original.timestamp)
+      expect(decrypted.memo).toBe(original.memo)
+    })
+
+    it('should handle null mint', () => {
+      const key = generateRandomViewingKey()
+      const data: SolanaTransactionData = {
+        sender: 'sender',
+        recipient: 'recipient',
+        amount: '100',
+        mint: null,
+        timestamp: 12345,
+      }
+
+      const encrypted = encryptForViewing(data, key)
+      const decrypted = decryptWithViewing(encrypted, key)
+
+      expect(decrypted.mint).toBeNull()
+    })
+
+    it('should reject wrong viewing key', () => {
+      const key1 = generateRandomViewingKey()
+      const key2 = generateRandomViewingKey()
+      const data: SolanaTransactionData = {
+        sender: 'sender',
+        recipient: 'recipient',
+        amount: '100',
+        mint: null,
+        timestamp: 12345,
+      }
+
+      const encrypted = encryptForViewing(data, key1)
+
+      expect(() => decryptWithViewing(encrypted, key2)).toThrow(/hash/i)
+    })
+
+    it('should detect tampered ciphertext', () => {
+      const key = generateRandomViewingKey()
+      const data: SolanaTransactionData = {
+        sender: 'sender',
+        recipient: 'recipient',
+        amount: '100',
+        mint: null,
+        timestamp: 12345,
+      }
+
+      const encrypted = encryptForViewing(data, key)
+
+      // Tamper with ciphertext
+      const tamperedCiphertext = encrypted.ciphertext.slice(0, -4) + 'ffff' as HexString
+
+      expect(() =>
+        decryptWithViewing({ ...encrypted, ciphertext: tamperedCiphertext }, key)
+      ).toThrow(/decrypt/i)
+    })
+  })
+
+  // ─── Storage ────────────────────────────────────────────────────────────────
+
+  describe('createMemoryStorage', () => {
+    let storage: ReturnType<typeof createMemoryStorage>
+
+    beforeEach(() => {
+      storage = createMemoryStorage()
+    })
+
+    it('should save and load viewing key', async () => {
+      const key = generateRandomViewingKey('Storage Test')
+
+      const savedHash = await storage.save(key)
+      expect(savedHash).toBe(key.hash)
+
+      const loaded = await storage.load(key.hash)
+      expect(loaded).not.toBeNull()
+      expect(loaded!.privateKey).toBe(key.privateKey)
+      expect(loaded!.label).toBe(key.label)
+    })
+
+    it('should return null for unknown hash', async () => {
+      const result = await storage.load('0x' + '00'.repeat(32) as Hash)
+      expect(result).toBeNull()
+    })
+
+    it('should list all stored keys', async () => {
+      const key1 = generateRandomViewingKey('Key 1')
+      const key2 = generateRandomViewingKey('Key 2')
+
+      await storage.save(key1)
+      await storage.save(key2)
+
+      const list = await storage.list()
+      expect(list).toHaveLength(2)
+      expect(list.map(k => k.label)).toContain('Key 1')
+      expect(list.map(k => k.label)).toContain('Key 2')
+    })
+
+    it('should delete viewing key', async () => {
+      const key = generateRandomViewingKey()
+
+      await storage.save(key)
+      expect(await storage.load(key.hash)).not.toBeNull()
+
+      const deleted = await storage.delete(key.hash)
+      expect(deleted).toBe(true)
+
+      expect(await storage.load(key.hash)).toBeNull()
+    })
+
+    it('should return false when deleting non-existent key', async () => {
+      const deleted = await storage.delete('0x' + '00'.repeat(32) as Hash)
+      expect(deleted).toBe(false)
+    })
+  })
+
+  // ─── Utilities ──────────────────────────────────────────────────────────────
+
+  describe('isAnnouncementForViewingKey', () => {
+    it('should return true for matching hash', () => {
+      const key = generateRandomViewingKey()
+      expect(isAnnouncementForViewingKey(key.hash, key)).toBe(true)
+    })
+
+    it('should return false for non-matching hash', () => {
+      const key = generateRandomViewingKey()
+      const otherHash = '0x' + '00'.repeat(32) as Hash
+      expect(isAnnouncementForViewingKey(otherHash, key)).toBe(false)
+    })
+  })
+
+  describe('deriveChildViewingKey', () => {
+    it('should derive child key from parent', () => {
+      const parent = generateRandomViewingKey('Parent')
+      const child = deriveChildViewingKey(parent, 'child/path', 'Child Key')
+
+      expect(child.privateKey).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(child.publicKey).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(child.hash).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(child.label).toBe('Child Key')
+    })
+
+    it('should produce different key from parent', () => {
+      const parent = generateRandomViewingKey()
+      const child = deriveChildViewingKey(parent, 'path')
+
+      expect(child.privateKey).not.toBe(parent.privateKey)
+      expect(child.publicKey).not.toBe(parent.publicKey)
+      expect(child.hash).not.toBe(parent.hash)
+    })
+
+    it('should produce deterministic results', () => {
+      const parent = generateRandomViewingKey()
+
+      const child1 = deriveChildViewingKey(parent, 'same/path')
+      const child2 = deriveChildViewingKey(parent, 'same/path')
+
+      expect(child1.privateKey).toBe(child2.privateKey)
+      expect(child1.hash).toBe(child2.hash)
+    })
+
+    it('should produce different keys for different paths', () => {
+      const parent = generateRandomViewingKey()
+
+      const child1 = deriveChildViewingKey(parent, 'path/1')
+      const child2 = deriveChildViewingKey(parent, 'path/2')
+
+      expect(child1.privateKey).not.toBe(child2.privateKey)
+    })
+
+    it('should use default label from parent', () => {
+      const parent = generateRandomViewingKey('Parent Key')
+      const child = deriveChildViewingKey(parent, 'audit')
+
+      expect(child.label).toBe('Parent Key/audit')
+    })
+
+    it('should throw for empty path', () => {
+      const parent = generateRandomViewingKey()
+      expect(() => deriveChildViewingKey(parent, '')).toThrow()
+    })
+  })
+
+  // ─── Integration ────────────────────────────────────────────────────────────
+
+  describe('Integration', () => {
+    it('should work end-to-end: derive, encrypt, store, load, decrypt', async () => {
+      // Derive viewing key from spending key
+      const { spendingPrivateKey } = deriveSolanaStealthKeys({ mnemonic: TEST_MNEMONIC })
+      const viewingKey = generateViewingKeyFromSpending(spendingPrivateKey, 'Wallet Key')
+
+      // Create transaction data
+      const txData: SolanaTransactionData = {
+        sender: 'SenderPubkey11111111111111111111111111111111',
+        recipient: 'StealthAddress1111111111111111111111111111111',
+        amount: '5000000',
+        mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        timestamp: Date.now(),
+        memo: 'Private USDC transfer',
+      }
+
+      // Encrypt
+      const encrypted = encryptForViewing(txData, viewingKey)
+
+      // Store
+      const storage = createMemoryStorage()
+      await storage.save(viewingKey)
+
+      // Load
+      const loaded = await storage.load(viewingKey.hash)
+      expect(loaded).not.toBeNull()
+
+      // Decrypt
+      const decrypted = decryptWithViewing(encrypted, loaded!)
+
+      expect(decrypted.amount).toBe(txData.amount)
+      expect(decrypted.memo).toBe(txData.memo)
+    })
+
+    it('should support hierarchical key derivation for compliance', async () => {
+      const { spendingPrivateKey } = deriveSolanaStealthKeys({ mnemonic: TEST_MNEMONIC })
+      const masterKey = generateViewingKeyFromSpending(spendingPrivateKey, 'Master')
+
+      // Derive department-specific keys
+      const auditKey = deriveChildViewingKey(masterKey, 'audit/2024', 'Audit 2024')
+      const accountingKey = deriveChildViewingKey(masterKey, 'accounting', 'Accounting')
+
+      // Encrypt with master key
+      const txData: SolanaTransactionData = {
+        sender: 'sender',
+        recipient: 'recipient',
+        amount: '1000',
+        mint: null,
+        timestamp: 12345,
+      }
+      const encrypted = encryptForViewing(txData, masterKey)
+
+      // Only master key can decrypt (not child keys)
+      expect(() => decryptWithViewing(encrypted, masterKey)).not.toThrow()
+      expect(() => decryptWithViewing(encrypted, auditKey)).toThrow()
+      expect(() => decryptWithViewing(encrypted, accountingKey)).toThrow()
+
+      // Each child key can only decrypt its own data
+      const auditData = encryptForViewing(txData, auditKey)
+      expect(() => decryptWithViewing(auditData, auditKey)).not.toThrow()
+      expect(() => decryptWithViewing(auditData, masterKey)).toThrow()
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,6 +329,12 @@ importers:
       '@scure/base':
         specifier: ^2.0.0
         version: 2.0.0
+      '@scure/bip32':
+        specifier: ^2.0.1
+        version: 2.0.1
+      '@scure/bip39':
+        specifier: ^2.0.1
+        version: 2.0.1
       '@sip-protocol/types':
         specifier: ^0.2.1
         version: link:../types
@@ -2801,9 +2807,21 @@ packages:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  /@noble/curves@2.0.1:
+    resolution: {integrity: sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==}
+    engines: {node: '>= 20.19.0'}
+    dependencies:
+      '@noble/hashes': 2.0.1
+    dev: false
+
   /@noble/hashes@1.8.0:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  /@noble/hashes@2.0.1:
+    resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+    engines: {node: '>= 20.19.0'}
+    dev: false
 
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3848,6 +3866,21 @@ packages:
 
   /@scure/base@2.0.0:
     resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
+    dev: false
+
+  /@scure/bip32@2.0.1:
+    resolution: {integrity: sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA==}
+    dependencies:
+      '@noble/curves': 2.0.1
+      '@noble/hashes': 2.0.1
+      '@scure/base': 2.0.0
+    dev: false
+
+  /@scure/bip39@2.0.1:
+    resolution: {integrity: sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==}
+    dependencies:
+      '@noble/hashes': 2.0.1
+      '@scure/base': 2.0.0
     dev: false
 
   /@sentry/core@10.33.0:


### PR DESCRIPTION
## Summary

Implements the core cryptographic infrastructure for Solana same-chain privacy (M17-SOL SDK Foundation batch):

- **Stealth address generation** using ed25519 curve - One-time addresses for unlinkable transfers (#240)
- **BIP39/SLIP-0010 key derivation** from Solana seed phrases - Standard wallet compatibility (#246)
- **Pedersen commitments** for SPL token amount hiding (#251)
  - Cofactor clearing to ensure correct homomorphic properties (L*H = identity)
  - Full verification, addition, and subtraction operations
- **Comprehensive viewing key management** (#257)
  - Generation from spending keys with domain separation
  - Export/import in standard JSON format
  - XChaCha20-Poly1305 authenticated encryption for compliance
  - Hierarchical derivation for organizational key management
  - Pluggable storage interface

## Technical Details

### Ed25519 Cofactor Handling
Ed25519 has cofactor 8, meaning hash-derived points may have order 2L, 4L, or 8L instead of L. Without cofactor clearing, the homomorphic property fails: `(r1+r2)*H ≠ r1*H + r2*H`. The implementation multiplies hash-derived H by 8 to project it into the prime-order subgroup.

### Security Properties
- **Hiding**: Commitments reveal nothing about the value
- **Binding**: Cannot open to a different value
- **Homomorphic**: `C(v1) + C(v2) = C(v1 + v2)` when blindings sum

## Test Plan
- [x] Run Solana chain tests: 284 tests passing
- [x] TypeScript type check passes
- [x] Verify deterministic key derivation matches existing patterns
- [x] Verify homomorphic commitment operations

## New Files
- `packages/sdk/src/chains/solana/commitment.ts` - Pedersen commitments
- `packages/sdk/src/chains/solana/key-derivation.ts` - BIP39/SLIP-0010
- `packages/sdk/src/chains/solana/viewing-key.ts` - Viewing key management
- `packages/sdk/tests/chains/solana/commitment.test.ts` - 38 tests
- `packages/sdk/tests/chains/solana/key-derivation.test.ts` - 35 tests
- `packages/sdk/tests/chains/solana/viewing-key.test.ts` - 39 tests

**Closes #240, #246, #251, #257**