### PR TITLE
fix(sdk): add missing ShadowWire token addresses

### DIFF
--- a/packages/sdk/src/privacy-backends/shadowwire.ts
+++ b/packages/sdk/src/privacy-backends/shadowwire.ts
@@ -72,6 +72,10 @@ export const SHADOWWIRE_TOKEN_MINTS: Record<TokenSymbol, string> = {
   BLACKCOIN: 'BLACKexampleaddress111111111111111111111', // Placeholder
   GIL: 'GILexampleaddress11111111111111111111111111', // Placeholder
   ANON: 'ANONexampleaddress1111111111111111111111111', // Placeholder
+  WLFI: 'WLFIexampleaddress1111111111111111111111111', // Placeholder - World Liberty Financial
+  USD1: 'USD1exampleaddress1111111111111111111111111', // Placeholder - USD1 stablecoin
+  AOL: 'AOLexampleaddress11111111111111111111111111', // Placeholder
+  IQLABS: 'IQLABSexampleaddress111111111111111111111', // Placeholder - IQ Labs token
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add WLFI, USD1, AOL, IQLABS tokens to `SHADOWWIRE_TOKEN_MINTS`
- Fixes build failure after `@radr/shadowwire` v1.1.2 update (from minor-and-patch #694)

## Context
The minor-and-patch dependency update bumped `@radr/shadowwire` to v1.1.2 which added 4 new tokens to the `TokenSymbol` type. Our `SHADOWWIRE_TOKEN_MINTS` Record was missing these, causing TypeScript build failures.

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (4,460 tests)