### PR TITLE
feat(sdk): implement proof format converters (#285)

### DIFF
--- a/packages/sdk/src/proofs/converters/halo2.ts
+++ b/packages/sdk/src/proofs/converters/halo2.ts
@@ -1,0 +1,452 @@
+/**
+ * Halo2 Proof Format Converter
+ *
+ * Converts between Halo2 native proof format and SIP unified format.
+ *
+ * @packageDocumentation
+ */
+
+import type {
+  SingleProof,
+  ProofMetadata,
+  HexString,
+} from '@sip-protocol/types'
+
+import {
+  type ProofConverter,
+  type Halo2NativeProof,
+  type ConversionOptions,
+  type ConversionResult,
+  type ConversionMetadata,
+  type ValidationResult,
+  type ValidationError,
+  DEFAULT_CONVERSION_OPTIONS,
+  ProofConversionError,
+  InvalidProofError,
+  UnsupportedVersionError,
+} from './interface'
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/** Converter version */
+const CONVERTER_VERSION = '1.0.0'
+
+/** Supported Halo2 versions */
+const SUPPORTED_HALO2_VERSIONS = ['0.2', '0.3', '1.0']
+
+/** Minimum k value for valid Halo2 proofs */
+const MIN_K_VALUE = 4
+
+/** Maximum k value for valid Halo2 proofs */
+const MAX_K_VALUE = 28
+
+// ─── Utility Functions ───────────────────────────────────────────────────────
+
+/**
+ * Convert Uint8Array to hex string
+ */
+function bytesToHex(bytes: Uint8Array): HexString {
+  return ('0x' + Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')) as HexString
+}
+
+/**
+ * Convert hex string to Uint8Array
+ */
+function hexToBytes(hex: HexString): Uint8Array {
+  const cleanHex = hex.startsWith('0x') ? hex.slice(2) : hex
+  const bytes = new Uint8Array(cleanHex.length / 2)
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(cleanHex.slice(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
+/**
+ * Check if a Halo2 version is supported
+ */
+function isSupportedHalo2Version(version: string): boolean {
+  const majorMinor = version.split('.').slice(0, 2).join('.')
+  return SUPPORTED_HALO2_VERSIONS.some(v => majorMinor.startsWith(v))
+}
+
+// ─── Halo2 Proof Converter ───────────────────────────────────────────────────
+
+/**
+ * Converter for Halo2 proofs
+ *
+ * Halo2 is a zkSNARK proving system used by Zcash and other projects.
+ * It uses the PLONK arithmetization with custom gates.
+ *
+ * @example
+ * ```typescript
+ * const converter = new Halo2ProofConverter()
+ *
+ * // Convert to SIP format
+ * const result = converter.toSIP(halo2Proof)
+ * if (result.success) {
+ *   console.log('SIP Proof:', result.result)
+ * }
+ * ```
+ */
+export class Halo2ProofConverter implements ProofConverter<Halo2NativeProof> {
+  readonly system = 'halo2' as const
+  readonly version = CONVERTER_VERSION
+
+  /**
+   * Convert Halo2 native proof to SIP unified format
+   */
+  toSIP(
+    nativeProof: Halo2NativeProof,
+    options: ConversionOptions = {},
+  ): ConversionResult<SingleProof> {
+    const opts = { ...DEFAULT_CONVERSION_OPTIONS, ...options }
+    const startTime = Date.now()
+
+    try {
+      // Validate if requested
+      if (opts.validateBeforeConversion) {
+        const validation = this.validateNative(nativeProof)
+        if (!validation.valid) {
+          return this._createErrorResult(
+            new InvalidProofError('halo2', 'sip', validation.errors),
+            startTime,
+            nativeProof.proofData.length,
+          )
+        }
+      }
+
+      // Check version support
+      if (nativeProof.halo2Version && !isSupportedHalo2Version(nativeProof.halo2Version)) {
+        return this._createErrorResult(
+          new UnsupportedVersionError('halo2', nativeProof.halo2Version, SUPPORTED_HALO2_VERSIONS),
+          startTime,
+          nativeProof.proofData.length,
+        )
+      }
+
+      // Convert proof data to hex
+      const proofHex = bytesToHex(nativeProof.proofData)
+
+      // Convert public inputs to hex format
+      const publicInputsHex = nativeProof.publicInputs.map(input => {
+        if (input.startsWith('0x')) {
+          return input as HexString
+        }
+        const bigInt = BigInt(input)
+        return ('0x' + bigInt.toString(16).padStart(64, '0')) as HexString
+      })
+
+      // Convert verification key if present
+      const verificationKey = opts.includeVerificationKey && nativeProof.verificationKey
+        ? (typeof nativeProof.verificationKey === 'string'
+          ? nativeProof.verificationKey as HexString
+          : bytesToHex(nativeProof.verificationKey))
+        : undefined
+
+      // Build circuit identifier from k value and commitment
+      const circuitId = nativeProof.provingKeyCommitment
+        ? `halo2-k${nativeProof.k || 'unknown'}-${nativeProof.provingKeyCommitment.slice(0, 16)}`
+        : `halo2-k${nativeProof.k || 'unknown'}`
+
+      // Build metadata
+      const metadata: ProofMetadata = {
+        system: 'halo2',
+        systemVersion: nativeProof.halo2Version || 'unknown',
+        circuitId,
+        circuitVersion: nativeProof.provingKeyCommitment || 'unknown',
+        generatedAt: Date.now(),
+        proofSizeBytes: nativeProof.proofData.length,
+        targetChainId: opts.targetChainId || undefined,
+      }
+
+      // Build SIP proof
+      const sipProof: SingleProof = {
+        id: opts.idGenerator(),
+        proof: proofHex,
+        publicInputs: publicInputsHex,
+        verificationKey,
+        metadata,
+      }
+
+      const outputSize = proofHex.length / 2 - 1
+
+      return {
+        success: true,
+        result: sipProof,
+        lossless: true,
+        warnings: this._collectWarnings(nativeProof),
+        conversionMetadata: this._createConversionMetadata(
+          'halo2',
+          'sip',
+          startTime,
+          nativeProof.proofData.length,
+          outputSize,
+        ),
+      }
+    } catch (error) {
+      return this._createErrorResult(
+        error instanceof ProofConversionError
+          ? error
+          : new ProofConversionError(
+            'UNKNOWN_ERROR',
+            error instanceof Error ? error.message : 'Unknown conversion error',
+            'halo2',
+            'sip',
+            error instanceof Error ? error : undefined,
+          ),
+        startTime,
+        nativeProof.proofData.length,
+      )
+    }
+  }
+
+  /**
+   * Convert SIP unified format to Halo2 native proof
+   */
+  fromSIP(
+    sipProof: SingleProof,
+    options: ConversionOptions = {},
+  ): ConversionResult<Halo2NativeProof> {
+    const opts = { ...DEFAULT_CONVERSION_OPTIONS, ...options }
+    const startTime = Date.now()
+    const inputSize = sipProof.proof.length / 2 - 1
+
+    try {
+      // Check if this is a Halo2 proof
+      if (!this.canConvertFromSIP(sipProof)) {
+        return this._createErrorResult(
+          new ProofConversionError(
+            'INVALID_INPUT',
+            `Cannot convert proof from system: ${sipProof.metadata.system}`,
+            sipProof.metadata.system,
+            'halo2',
+          ),
+          startTime,
+          inputSize,
+        )
+      }
+
+      // Convert proof hex to bytes
+      const proofData = hexToBytes(sipProof.proof)
+
+      // Convert public inputs from hex to field element strings
+      const publicInputs = sipProof.publicInputs.map(hex => {
+        const bigInt = BigInt(hex)
+        return bigInt.toString()
+      })
+
+      // Convert verification key if present
+      const verificationKey = sipProof.verificationKey
+        ? hexToBytes(sipProof.verificationKey)
+        : undefined
+
+      // Extract k value from circuit ID if present
+      const kMatch = sipProof.metadata.circuitId.match(/k(\d+)/)
+      const k = kMatch ? parseInt(kMatch[1], 10) : undefined
+
+      // Build native proof
+      const nativeProof: Halo2NativeProof = {
+        system: 'halo2',
+        proofData,
+        publicInputs,
+        verificationKey,
+        provingKeyCommitment: sipProof.metadata.circuitVersion !== 'unknown'
+          ? sipProof.metadata.circuitVersion as HexString
+          : undefined,
+        k,
+        halo2Version: sipProof.metadata.systemVersion,
+        nativeMetadata: opts.preserveNativeMetadata ? {
+          sipProofId: sipProof.id,
+          originalMetadata: sipProof.metadata,
+        } : undefined,
+      }
+
+      return {
+        success: true,
+        result: nativeProof,
+        lossless: true,
+        warnings: [],
+        conversionMetadata: this._createConversionMetadata(
+          'sip' as any,
+          'halo2',
+          startTime,
+          inputSize,
+          proofData.length,
+        ),
+      }
+    } catch (error) {
+      return this._createErrorResult(
+        error instanceof ProofConversionError
+          ? error
+          : new ProofConversionError(
+            'UNKNOWN_ERROR',
+            error instanceof Error ? error.message : 'Unknown conversion error',
+            'halo2',
+            'sip',
+            error instanceof Error ? error : undefined,
+          ),
+        startTime,
+        inputSize,
+      )
+    }
+  }
+
+  /**
+   * Validate a Halo2 native proof structure
+   */
+  validateNative(nativeProof: Halo2NativeProof): ValidationResult {
+    const errors: ValidationError[] = []
+    const warnings: string[] = []
+
+    // Check required fields
+    if (!nativeProof.proofData || nativeProof.proofData.length === 0) {
+      errors.push({
+        field: 'proofData',
+        message: 'Proof data is required and must not be empty',
+        code: 'REQUIRED_FIELD',
+      })
+    }
+
+    if (!nativeProof.publicInputs) {
+      errors.push({
+        field: 'publicInputs',
+        message: 'Public inputs array is required',
+        code: 'REQUIRED_FIELD',
+      })
+    }
+
+    // Validate k value if present
+    if (nativeProof.k !== undefined) {
+      if (nativeProof.k < MIN_K_VALUE || nativeProof.k > MAX_K_VALUE) {
+        errors.push({
+          field: 'k',
+          message: `k value must be between ${MIN_K_VALUE} and ${MAX_K_VALUE}, got ${nativeProof.k}`,
+          code: 'INVALID_VALUE',
+        })
+      }
+    }
+
+    // Validate public inputs format
+    if (nativeProof.publicInputs) {
+      for (let i = 0; i < nativeProof.publicInputs.length; i++) {
+        const input = nativeProof.publicInputs[i]
+        try {
+          if (input.startsWith('0x')) {
+            BigInt(input)
+          } else {
+            BigInt(input)
+          }
+        } catch {
+          errors.push({
+            field: `publicInputs[${i}]`,
+            message: `Invalid field element format: ${input}`,
+            code: 'INVALID_FORMAT',
+          })
+        }
+      }
+    }
+
+    // Version warnings
+    if (nativeProof.halo2Version && !isSupportedHalo2Version(nativeProof.halo2Version)) {
+      warnings.push(`Halo2 version ${nativeProof.halo2Version} may not be fully supported`)
+    }
+
+    // Missing optional field warnings
+    if (!nativeProof.k) {
+      warnings.push('No k value specified - circuit parameters unknown')
+    }
+
+    if (!nativeProof.provingKeyCommitment) {
+      warnings.push('No proving key commitment - proof may not be fully traceable')
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+      warnings,
+    }
+  }
+
+  /**
+   * Check if a SIP proof can be converted to Halo2 format
+   */
+  canConvertFromSIP(sipProof: SingleProof): boolean {
+    return sipProof.metadata.system === 'halo2'
+  }
+
+  /**
+   * Get supported Halo2 versions
+   */
+  getSupportedVersions(): string[] {
+    return [...SUPPORTED_HALO2_VERSIONS]
+  }
+
+  // ─── Private Helpers ─────────────────────────────────────────────────────────
+
+  private _createConversionMetadata(
+    sourceSystem: 'halo2' | 'sip',
+    targetSystem: 'halo2' | 'sip',
+    startTime: number,
+    originalSize: number,
+    convertedSize: number,
+  ): ConversionMetadata {
+    return {
+      sourceSystem: sourceSystem === 'sip' ? 'halo2' : sourceSystem,
+      targetSystem,
+      convertedAt: Date.now(),
+      converterVersion: this.version,
+      conversionTimeMs: Date.now() - startTime,
+      originalSize,
+      convertedSize,
+    }
+  }
+
+  private _createErrorResult<T>(
+    error: ProofConversionError,
+    startTime: number,
+    inputSize: number,
+  ): ConversionResult<T> {
+    return {
+      success: false,
+      error: error.message,
+      errorCode: error.code,
+      lossless: false,
+      conversionMetadata: this._createConversionMetadata(
+        error.sourceSystem as any,
+        error.targetSystem as any,
+        startTime,
+        inputSize,
+        0,
+      ),
+    }
+  }
+
+  private _collectWarnings(nativeProof: Halo2NativeProof): string[] {
+    const warnings: string[] = []
+
+    if (!nativeProof.halo2Version) {
+      warnings.push('No Halo2 version specified - using unknown')
+    }
+
+    if (!nativeProof.k) {
+      warnings.push('No k value - circuit degree unknown')
+    }
+
+    if (!nativeProof.provingKeyCommitment) {
+      warnings.push('No proving key commitment - traceability limited')
+    }
+
+    return warnings
+  }
+}
+
+// ─── Factory Function ────────────────────────────────────────────────────────
+
+/**
+ * Create a new Halo2 proof converter instance
+ */
+export function createHalo2Converter(): Halo2ProofConverter {
+  return new Halo2ProofConverter()
+}

--- a/packages/sdk/src/proofs/converters/index.ts
+++ b/packages/sdk/src/proofs/converters/index.ts
@@ -1,0 +1,208 @@
+/**
+ * Proof Format Converters
+ *
+ * Module for converting proofs between native formats (Noir, Halo2, Kimchi)
+ * and the unified SIP proof format.
+ *
+ * @packageDocumentation
+ * @module converters
+ */
+
+// ─── Interface and Types ─────────────────────────────────────────────────────
+
+export type {
+  NativeProofFormat,
+  NoirNativeProof,
+  Halo2NativeProof,
+  KimchiNativeProof,
+  ConversionOptions,
+  ConversionResult,
+  ConversionMetadata,
+  ConversionErrorCode,
+  ProofConverter,
+  ValidationResult,
+  ValidationError,
+  AnyNativeProof,
+  ProofSystemToNativeMap,
+} from './interface'
+
+export {
+  ProofConversionError,
+  InvalidProofError,
+  UnsupportedVersionError,
+  DEFAULT_CONVERSION_OPTIONS,
+} from './interface'
+
+// ─── Noir Converter ──────────────────────────────────────────────────────────
+
+export { NoirProofConverter, createNoirConverter } from './noir'
+
+// ─── Halo2 Converter ─────────────────────────────────────────────────────────
+
+export { Halo2ProofConverter, createHalo2Converter } from './halo2'
+
+// ─── Kimchi Converter ────────────────────────────────────────────────────────
+
+export { KimchiProofConverter, createKimchiConverter } from './kimchi'
+
+// ─── Unified Converter Factory ───────────────────────────────────────────────
+
+import type { ProofSystem, SingleProof } from '@sip-protocol/types'
+import type {
+  ProofConverter,
+  AnyNativeProof,
+  ConversionResult,
+  ConversionOptions,
+} from './interface'
+import { NoirProofConverter } from './noir'
+import { Halo2ProofConverter } from './halo2'
+import { KimchiProofConverter } from './kimchi'
+
+/**
+ * Unified converter that routes to the appropriate system-specific converter
+ *
+ * @example
+ * ```typescript
+ * const converter = new UnifiedProofConverter()
+ *
+ * // Convert any native proof to SIP format
+ * const noirResult = converter.toSIP(noirProof)
+ * const halo2Result = converter.toSIP(halo2Proof)
+ * const kimchiResult = converter.toSIP(kimchiProof)
+ *
+ * // Convert SIP proof back to native format
+ * const nativeResult = converter.fromSIP(sipProof)
+ * ```
+ */
+export class UnifiedProofConverter {
+  private _converters: Map<ProofSystem, ProofConverter<AnyNativeProof>>
+
+  constructor() {
+    this._converters = new Map()
+    this._converters.set('noir', new NoirProofConverter() as ProofConverter<AnyNativeProof>)
+    this._converters.set('halo2', new Halo2ProofConverter() as ProofConverter<AnyNativeProof>)
+    this._converters.set('kimchi', new KimchiProofConverter() as ProofConverter<AnyNativeProof>)
+  }
+
+  /**
+   * Convert a native proof to SIP unified format
+   */
+  toSIP(
+    nativeProof: AnyNativeProof,
+    options?: ConversionOptions,
+  ): ConversionResult<SingleProof> {
+    const converter = this._converters.get(nativeProof.system)
+    if (!converter) {
+      return {
+        success: false,
+        error: `Unsupported proof system: ${nativeProof.system}`,
+        errorCode: 'INVALID_INPUT',
+        lossless: false,
+        conversionMetadata: {
+          sourceSystem: nativeProof.system,
+          targetSystem: 'sip',
+          convertedAt: Date.now(),
+          converterVersion: '1.0.0',
+          conversionTimeMs: 0,
+          originalSize: 0,
+          convertedSize: 0,
+        },
+      }
+    }
+
+    return converter.toSIP(nativeProof, options)
+  }
+
+  /**
+   * Convert a SIP proof to native format
+   */
+  fromSIP(
+    sipProof: SingleProof,
+    options?: ConversionOptions,
+  ): ConversionResult<AnyNativeProof> {
+    const system = sipProof.metadata.system
+    const converter = this._converters.get(system)
+
+    if (!converter) {
+      return {
+        success: false,
+        error: `Unsupported proof system: ${system}`,
+        errorCode: 'INVALID_INPUT',
+        lossless: false,
+        conversionMetadata: {
+          sourceSystem: system,
+          targetSystem: system,
+          convertedAt: Date.now(),
+          converterVersion: '1.0.0',
+          conversionTimeMs: 0,
+          originalSize: 0,
+          convertedSize: 0,
+        },
+      }
+    }
+
+    return converter.fromSIP(sipProof, options)
+  }
+
+  /**
+   * Get converter for a specific proof system
+   */
+  getConverter(system: ProofSystem): ProofConverter<AnyNativeProof> | undefined {
+    return this._converters.get(system)
+  }
+
+  /**
+   * Get all supported proof systems
+   */
+  getSupportedSystems(): ProofSystem[] {
+    return Array.from(this._converters.keys())
+  }
+
+  /**
+   * Check if a proof system is supported
+   */
+  isSystemSupported(system: ProofSystem): boolean {
+    return this._converters.has(system)
+  }
+
+  /**
+   * Register a custom converter for a proof system
+   */
+  registerConverter(
+    system: ProofSystem,
+    converter: ProofConverter<AnyNativeProof>,
+  ): void {
+    this._converters.set(system, converter)
+  }
+}
+
+/**
+ * Create a unified proof converter
+ */
+export function createUnifiedConverter(): UnifiedProofConverter {
+  return new UnifiedProofConverter()
+}
+
+// ─── Convenience Functions ───────────────────────────────────────────────────
+
+/**
+ * Convert a native proof to SIP format (convenience function)
+ */
+export function convertToSIP(
+  nativeProof: AnyNativeProof,
+  options?: ConversionOptions,
+): ConversionResult<SingleProof> {
+  const converter = createUnifiedConverter()
+  return converter.toSIP(nativeProof, options)
+}
+
+/**
+ * Convert a SIP proof to native format (convenience function)
+ */
+export function convertFromSIP(
+  sipProof: SingleProof,
+  options?: ConversionOptions,
+): ConversionResult<AnyNativeProof> {
+  const converter = createUnifiedConverter()
+  return converter.fromSIP(sipProof, options)
+}

--- a/packages/sdk/src/proofs/converters/interface.ts
+++ b/packages/sdk/src/proofs/converters/interface.ts
@@ -1,0 +1,363 @@
+/**
+ * Proof Format Converter Interface
+ *
+ * Defines the interface for converting proofs between native formats
+ * (Noir, Halo2, Kimchi) and the unified SIP proof format.
+ *
+ * @packageDocumentation
+ */
+
+import type {
+  ProofSystem,
+  SingleProof,
+  HexString,
+} from '@sip-protocol/types'
+
+// ─── Native Proof Formats ────────────────────────────────────────────────────
+
+/**
+ * Base interface for native proof formats
+ */
+export interface NativeProofFormat {
+  /** The proof system this format belongs to */
+  readonly system: ProofSystem
+  /** Raw proof bytes/data */
+  proofData: Uint8Array | HexString
+  /** Public inputs in native format */
+  publicInputs: unknown[]
+  /** System-specific verification key */
+  verificationKey?: Uint8Array | HexString
+  /** Native metadata specific to the proof system */
+  nativeMetadata?: Record<string, unknown>
+}
+
+/**
+ * Noir native proof format
+ */
+export interface NoirNativeProof extends NativeProofFormat {
+  readonly system: 'noir'
+  /** Noir proof bytes (Barretenberg format) */
+  proofData: Uint8Array
+  /** Public inputs as field elements */
+  publicInputs: string[]
+  /** ACIR circuit artifact hash */
+  circuitHash?: string
+  /** Noir version that generated this proof */
+  noirVersion?: string
+  /** Backend version (Barretenberg) */
+  backendVersion?: string
+}
+
+/**
+ * Halo2 native proof format
+ */
+export interface Halo2NativeProof extends NativeProofFormat {
+  readonly system: 'halo2'
+  /** Halo2 proof transcript */
+  proofData: Uint8Array
+  /** Public inputs as field elements */
+  publicInputs: string[]
+  /** Proving key commitment */
+  provingKeyCommitment?: HexString
+  /** Circuit degree (k value) */
+  k?: number
+  /** Halo2 library version */
+  halo2Version?: string
+}
+
+/**
+ * Kimchi native proof format (Mina Protocol)
+ */
+export interface KimchiNativeProof extends NativeProofFormat {
+  readonly system: 'kimchi'
+  /** Kimchi proof data */
+  proofData: Uint8Array
+  /** Public inputs as Pasta field elements */
+  publicInputs: string[]
+  /** SRS (Structured Reference String) hash */
+  srsHash?: HexString
+  /** Kimchi/o1js version */
+  kimchiVersion?: string
+  /** Verifier index commitment */
+  verifierIndexCommitment?: HexString
+}
+
+// ─── Conversion Types ────────────────────────────────────────────────────────
+
+/**
+ * Options for proof conversion
+ */
+export interface ConversionOptions {
+  /** Preserve all native metadata in the output */
+  preserveNativeMetadata?: boolean
+  /** Validate proof structure before conversion */
+  validateBeforeConversion?: boolean
+  /** Include verification key in output */
+  includeVerificationKey?: boolean
+  /** Target chain ID for the converted proof */
+  targetChainId?: string
+  /** Custom ID generator for the output proof */
+  idGenerator?: () => string
+}
+
+/**
+ * Result of a conversion operation
+ */
+export interface ConversionResult<T> {
+  /** Whether conversion was successful */
+  success: boolean
+  /** The converted proof (if successful) */
+  result?: T
+  /** Error message (if failed) */
+  error?: string
+  /** Detailed error code for programmatic handling */
+  errorCode?: ConversionErrorCode
+  /** Warnings generated during conversion */
+  warnings?: string[]
+  /** Whether the conversion was lossless */
+  lossless: boolean
+  /** Metadata about the conversion process */
+  conversionMetadata: ConversionMetadata
+}
+
+/**
+ * Metadata about the conversion process
+ */
+export interface ConversionMetadata {
+  /** Source format/system */
+  sourceSystem: ProofSystem
+  /** Target format/system */
+  targetSystem: ProofSystem | 'sip'
+  /** Conversion timestamp */
+  convertedAt: number
+  /** Converter version */
+  converterVersion: string
+  /** Time taken for conversion (ms) */
+  conversionTimeMs: number
+  /** Original proof size (bytes) */
+  originalSize: number
+  /** Converted proof size (bytes) */
+  convertedSize: number
+}
+
+/**
+ * Error codes for conversion failures
+ */
+export type ConversionErrorCode =
+  | 'INVALID_INPUT'
+  | 'UNSUPPORTED_VERSION'
+  | 'MISSING_REQUIRED_FIELD'
+  | 'VALIDATION_FAILED'
+  | 'ENCODING_ERROR'
+  | 'DECODING_ERROR'
+  | 'METADATA_ERROR'
+  | 'UNKNOWN_ERROR'
+
+// ─── Converter Interface ─────────────────────────────────────────────────────
+
+/**
+ * Interface for proof format converters
+ *
+ * Converters transform proofs between native formats and the unified SIP format.
+ * All converters should:
+ * - Be pure functions (no side effects)
+ * - Preserve proof validity
+ * - Handle version differences gracefully
+ * - Provide detailed error information
+ *
+ * @example
+ * ```typescript
+ * const converter = new NoirProofConverter()
+ *
+ * // Convert Noir proof to SIP format
+ * const result = converter.toSIP(noirProof, {
+ *   preserveNativeMetadata: true,
+ * })
+ *
+ * if (result.success) {
+ *   const sipProof = result.result!
+ *   console.log('Converted proof:', sipProof.id)
+ * }
+ * ```
+ */
+export interface ProofConverter<TNative extends NativeProofFormat> {
+  /** The proof system this converter handles */
+  readonly system: ProofSystem
+
+  /** Converter version for tracking */
+  readonly version: string
+
+  /**
+   * Convert from native format to SIP unified format
+   *
+   * @param nativeProof - The native proof to convert
+   * @param options - Conversion options
+   * @returns Conversion result with SIP proof
+   */
+  toSIP(
+    nativeProof: TNative,
+    options?: ConversionOptions,
+  ): ConversionResult<SingleProof>
+
+  /**
+   * Convert from SIP unified format to native format
+   *
+   * @param sipProof - The SIP proof to convert
+   * @param options - Conversion options
+   * @returns Conversion result with native proof
+   */
+  fromSIP(
+    sipProof: SingleProof,
+    options?: ConversionOptions,
+  ): ConversionResult<TNative>
+
+  /**
+   * Validate a native proof structure without converting
+   *
+   * @param nativeProof - The native proof to validate
+   * @returns Validation result
+   */
+  validateNative(nativeProof: TNative): ValidationResult
+
+  /**
+   * Check if a SIP proof can be converted to this native format
+   *
+   * @param sipProof - The SIP proof to check
+   * @returns Whether conversion is possible
+   */
+  canConvertFromSIP(sipProof: SingleProof): boolean
+
+  /**
+   * Get supported versions for this converter
+   *
+   * @returns List of supported system versions
+   */
+  getSupportedVersions(): string[]
+}
+
+/**
+ * Validation result for proof structure
+ */
+export interface ValidationResult {
+  /** Whether the proof is valid */
+  valid: boolean
+  /** Validation errors (if any) */
+  errors: ValidationError[]
+  /** Validation warnings */
+  warnings: string[]
+}
+
+/**
+ * Validation error details
+ */
+export interface ValidationError {
+  /** Field that failed validation */
+  field: string
+  /** Error message */
+  message: string
+  /** Error code */
+  code: string
+}
+
+// ─── Error Classes ───────────────────────────────────────────────────────────
+
+/**
+ * Base error class for conversion errors
+ */
+export class ProofConversionError extends Error {
+  readonly code: ConversionErrorCode
+  readonly sourceSystem: ProofSystem
+  readonly targetSystem: ProofSystem | 'sip'
+  readonly cause?: Error
+
+  constructor(
+    code: ConversionErrorCode,
+    message: string,
+    sourceSystem: ProofSystem,
+    targetSystem: ProofSystem | 'sip',
+    cause?: Error,
+  ) {
+    super(message)
+    this.name = 'ProofConversionError'
+    this.code = code
+    this.sourceSystem = sourceSystem
+    this.targetSystem = targetSystem
+    this.cause = cause
+  }
+}
+
+/**
+ * Error for invalid input proofs
+ */
+export class InvalidProofError extends ProofConversionError {
+  readonly validationErrors: ValidationError[]
+
+  constructor(
+    sourceSystem: ProofSystem,
+    targetSystem: ProofSystem | 'sip',
+    validationErrors: ValidationError[],
+  ) {
+    const errorSummary = validationErrors.map(e => `${e.field}: ${e.message}`).join('; ')
+    super(
+      'INVALID_INPUT',
+      `Invalid proof structure: ${errorSummary}`,
+      sourceSystem,
+      targetSystem,
+    )
+    this.name = 'InvalidProofError'
+    this.validationErrors = validationErrors
+  }
+}
+
+/**
+ * Error for unsupported proof system versions
+ */
+export class UnsupportedVersionError extends ProofConversionError {
+  readonly providedVersion: string
+  readonly supportedVersions: string[]
+
+  constructor(
+    sourceSystem: ProofSystem,
+    providedVersion: string,
+    supportedVersions: string[],
+  ) {
+    super(
+      'UNSUPPORTED_VERSION',
+      `Version ${providedVersion} is not supported. Supported: ${supportedVersions.join(', ')}`,
+      sourceSystem,
+      'sip',
+    )
+    this.name = 'UnsupportedVersionError'
+    this.providedVersion = providedVersion
+    this.supportedVersions = supportedVersions
+  }
+}
+
+// ─── Utility Types ───────────────────────────────────────────────────────────
+
+/**
+ * Union type of all native proof formats
+ */
+export type AnyNativeProof = NoirNativeProof | Halo2NativeProof | KimchiNativeProof
+
+/**
+ * Map of proof systems to their native proof types
+ */
+export interface ProofSystemToNativeMap {
+  noir: NoirNativeProof
+  halo2: Halo2NativeProof
+  kimchi: KimchiNativeProof
+  groth16: NativeProofFormat
+  plonk: NativeProofFormat
+}
+
+/**
+ * Default conversion options
+ */
+export const DEFAULT_CONVERSION_OPTIONS: Required<ConversionOptions> = {
+  preserveNativeMetadata: true,
+  validateBeforeConversion: true,
+  includeVerificationKey: true,
+  targetChainId: '',
+  idGenerator: () => `proof-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
+}

--- a/packages/sdk/src/proofs/converters/kimchi.ts
+++ b/packages/sdk/src/proofs/converters/kimchi.ts
@@ -1,0 +1,462 @@
+/**
+ * Kimchi Proof Format Converter
+ *
+ * Converts between Kimchi native proof format (Mina Protocol) and SIP unified format.
+ *
+ * @packageDocumentation
+ */
+
+import type {
+  SingleProof,
+  ProofMetadata,
+  HexString,
+} from '@sip-protocol/types'
+
+import {
+  type ProofConverter,
+  type KimchiNativeProof,
+  type ConversionOptions,
+  type ConversionResult,
+  type ConversionMetadata,
+  type ValidationResult,
+  type ValidationError,
+  DEFAULT_CONVERSION_OPTIONS,
+  ProofConversionError,
+  InvalidProofError,
+  UnsupportedVersionError,
+} from './interface'
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/** Converter version */
+const CONVERTER_VERSION = '1.0.0'
+
+/** Supported Kimchi/o1js versions */
+const SUPPORTED_KIMCHI_VERSIONS = ['0.15', '0.16', '0.17', '0.18', '1.0', '1.1', '1.2']
+
+/** Pasta curve field modulus (Pallas) */
+const PALLAS_MODULUS = BigInt('0x40000000000000000000000000000000224698fc094cf91b992d30ed00000001')
+
+// ─── Utility Functions ───────────────────────────────────────────────────────
+
+/**
+ * Convert Uint8Array to hex string
+ */
+function bytesToHex(bytes: Uint8Array): HexString {
+  return ('0x' + Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')) as HexString
+}
+
+/**
+ * Convert hex string to Uint8Array
+ */
+function hexToBytes(hex: HexString): Uint8Array {
+  const cleanHex = hex.startsWith('0x') ? hex.slice(2) : hex
+  const bytes = new Uint8Array(cleanHex.length / 2)
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(cleanHex.slice(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
+/**
+ * Check if a Kimchi version is supported
+ */
+function isSupportedKimchiVersion(version: string): boolean {
+  const majorMinor = version.split('.').slice(0, 2).join('.')
+  return SUPPORTED_KIMCHI_VERSIONS.some(v => majorMinor.startsWith(v))
+}
+
+/**
+ * Validate a Pasta field element (check if < field modulus)
+ */
+function isValidPastaFieldElement(value: string): boolean {
+  try {
+    const bigInt = value.startsWith('0x') ? BigInt(value) : BigInt(value)
+    return bigInt >= 0n && bigInt < PALLAS_MODULUS
+  } catch {
+    return false
+  }
+}
+
+// ─── Kimchi Proof Converter ──────────────────────────────────────────────────
+
+/**
+ * Converter for Kimchi proofs (Mina Protocol)
+ *
+ * Kimchi is the proving system used by Mina Protocol, using Pasta curves
+ * (Pallas and Vesta) for efficient recursive composition.
+ *
+ * @example
+ * ```typescript
+ * const converter = new KimchiProofConverter()
+ *
+ * // Convert to SIP format
+ * const result = converter.toSIP(kimchiProof)
+ * if (result.success) {
+ *   console.log('SIP Proof:', result.result)
+ * }
+ * ```
+ */
+export class KimchiProofConverter implements ProofConverter<KimchiNativeProof> {
+  readonly system = 'kimchi' as const
+  readonly version = CONVERTER_VERSION
+
+  /**
+   * Convert Kimchi native proof to SIP unified format
+   */
+  toSIP(
+    nativeProof: KimchiNativeProof,
+    options: ConversionOptions = {},
+  ): ConversionResult<SingleProof> {
+    const opts = { ...DEFAULT_CONVERSION_OPTIONS, ...options }
+    const startTime = Date.now()
+
+    try {
+      // Validate if requested
+      if (opts.validateBeforeConversion) {
+        const validation = this.validateNative(nativeProof)
+        if (!validation.valid) {
+          return this._createErrorResult(
+            new InvalidProofError('kimchi', 'sip', validation.errors),
+            startTime,
+            nativeProof.proofData.length,
+          )
+        }
+      }
+
+      // Check version support
+      if (nativeProof.kimchiVersion && !isSupportedKimchiVersion(nativeProof.kimchiVersion)) {
+        return this._createErrorResult(
+          new UnsupportedVersionError('kimchi', nativeProof.kimchiVersion, SUPPORTED_KIMCHI_VERSIONS),
+          startTime,
+          nativeProof.proofData.length,
+        )
+      }
+
+      // Convert proof data to hex
+      const proofHex = bytesToHex(nativeProof.proofData)
+
+      // Convert public inputs to hex format
+      // Kimchi uses Pasta field elements, ensure proper encoding
+      const publicInputsHex = nativeProof.publicInputs.map(input => {
+        if (input.startsWith('0x')) {
+          return input as HexString
+        }
+        const bigInt = BigInt(input)
+        // Pad to 64 chars (32 bytes) for consistency
+        return ('0x' + bigInt.toString(16).padStart(64, '0')) as HexString
+      })
+
+      // Convert verification key if present
+      const verificationKey = opts.includeVerificationKey && nativeProof.verificationKey
+        ? (typeof nativeProof.verificationKey === 'string'
+          ? nativeProof.verificationKey as HexString
+          : bytesToHex(nativeProof.verificationKey))
+        : undefined
+
+      // Build circuit identifier
+      const circuitId = nativeProof.verifierIndexCommitment
+        ? `kimchi-${nativeProof.verifierIndexCommitment.slice(0, 16)}`
+        : 'kimchi-unknown'
+
+      // Build metadata
+      const metadata: ProofMetadata = {
+        system: 'kimchi',
+        systemVersion: nativeProof.kimchiVersion || 'unknown',
+        circuitId,
+        circuitVersion: nativeProof.srsHash || 'unknown',
+        generatedAt: Date.now(),
+        proofSizeBytes: nativeProof.proofData.length,
+        targetChainId: opts.targetChainId || undefined,
+      }
+
+      // Build SIP proof
+      const sipProof: SingleProof = {
+        id: opts.idGenerator(),
+        proof: proofHex,
+        publicInputs: publicInputsHex,
+        verificationKey,
+        metadata,
+      }
+
+      const outputSize = proofHex.length / 2 - 1
+
+      return {
+        success: true,
+        result: sipProof,
+        lossless: true,
+        warnings: this._collectWarnings(nativeProof),
+        conversionMetadata: this._createConversionMetadata(
+          'kimchi',
+          'sip',
+          startTime,
+          nativeProof.proofData.length,
+          outputSize,
+        ),
+      }
+    } catch (error) {
+      return this._createErrorResult(
+        error instanceof ProofConversionError
+          ? error
+          : new ProofConversionError(
+            'UNKNOWN_ERROR',
+            error instanceof Error ? error.message : 'Unknown conversion error',
+            'kimchi',
+            'sip',
+            error instanceof Error ? error : undefined,
+          ),
+        startTime,
+        nativeProof.proofData.length,
+      )
+    }
+  }
+
+  /**
+   * Convert SIP unified format to Kimchi native proof
+   */
+  fromSIP(
+    sipProof: SingleProof,
+    options: ConversionOptions = {},
+  ): ConversionResult<KimchiNativeProof> {
+    const opts = { ...DEFAULT_CONVERSION_OPTIONS, ...options }
+    const startTime = Date.now()
+    const inputSize = sipProof.proof.length / 2 - 1
+
+    try {
+      // Check if this is a Kimchi proof
+      if (!this.canConvertFromSIP(sipProof)) {
+        return this._createErrorResult(
+          new ProofConversionError(
+            'INVALID_INPUT',
+            `Cannot convert proof from system: ${sipProof.metadata.system}`,
+            sipProof.metadata.system,
+            'kimchi',
+          ),
+          startTime,
+          inputSize,
+        )
+      }
+
+      // Convert proof hex to bytes
+      const proofData = hexToBytes(sipProof.proof)
+
+      // Convert public inputs from hex to field element strings
+      const publicInputs = sipProof.publicInputs.map(hex => {
+        const bigInt = BigInt(hex)
+        return bigInt.toString()
+      })
+
+      // Convert verification key if present
+      const verificationKey = sipProof.verificationKey
+        ? hexToBytes(sipProof.verificationKey)
+        : undefined
+
+      // Extract verifier index from circuit ID if present
+      const verifierMatch = sipProof.metadata.circuitId.match(/kimchi-(.+)/)
+      const verifierIndexCommitment = verifierMatch && verifierMatch[1] !== 'unknown'
+        ? ('0x' + verifierMatch[1]) as HexString
+        : undefined
+
+      // Build native proof
+      const nativeProof: KimchiNativeProof = {
+        system: 'kimchi',
+        proofData,
+        publicInputs,
+        verificationKey,
+        srsHash: sipProof.metadata.circuitVersion !== 'unknown'
+          ? sipProof.metadata.circuitVersion as HexString
+          : undefined,
+        kimchiVersion: sipProof.metadata.systemVersion,
+        verifierIndexCommitment,
+        nativeMetadata: opts.preserveNativeMetadata ? {
+          sipProofId: sipProof.id,
+          originalMetadata: sipProof.metadata,
+        } : undefined,
+      }
+
+      return {
+        success: true,
+        result: nativeProof,
+        lossless: true,
+        warnings: [],
+        conversionMetadata: this._createConversionMetadata(
+          'sip' as any,
+          'kimchi',
+          startTime,
+          inputSize,
+          proofData.length,
+        ),
+      }
+    } catch (error) {
+      return this._createErrorResult(
+        error instanceof ProofConversionError
+          ? error
+          : new ProofConversionError(
+            'UNKNOWN_ERROR',
+            error instanceof Error ? error.message : 'Unknown conversion error',
+            'kimchi',
+            'sip',
+            error instanceof Error ? error : undefined,
+          ),
+        startTime,
+        inputSize,
+      )
+    }
+  }
+
+  /**
+   * Validate a Kimchi native proof structure
+   */
+  validateNative(nativeProof: KimchiNativeProof): ValidationResult {
+    const errors: ValidationError[] = []
+    const warnings: string[] = []
+
+    // Check required fields
+    if (!nativeProof.proofData || nativeProof.proofData.length === 0) {
+      errors.push({
+        field: 'proofData',
+        message: 'Proof data is required and must not be empty',
+        code: 'REQUIRED_FIELD',
+      })
+    }
+
+    if (!nativeProof.publicInputs) {
+      errors.push({
+        field: 'publicInputs',
+        message: 'Public inputs array is required',
+        code: 'REQUIRED_FIELD',
+      })
+    }
+
+    // Validate public inputs are valid Pasta field elements
+    if (nativeProof.publicInputs) {
+      for (let i = 0; i < nativeProof.publicInputs.length; i++) {
+        const input = nativeProof.publicInputs[i]
+        if (!isValidPastaFieldElement(input)) {
+          errors.push({
+            field: `publicInputs[${i}]`,
+            message: `Invalid Pasta field element: ${input}`,
+            code: 'INVALID_FIELD_ELEMENT',
+          })
+        }
+      }
+    }
+
+    // Validate SRS hash format if present
+    if (nativeProof.srsHash) {
+      const cleanHash = nativeProof.srsHash.startsWith('0x')
+        ? nativeProof.srsHash.slice(2)
+        : nativeProof.srsHash
+      if (!/^[0-9a-fA-F]+$/.test(cleanHash)) {
+        errors.push({
+          field: 'srsHash',
+          message: 'SRS hash must be a valid hex string',
+          code: 'INVALID_FORMAT',
+        })
+      }
+    }
+
+    // Version warnings
+    if (nativeProof.kimchiVersion && !isSupportedKimchiVersion(nativeProof.kimchiVersion)) {
+      warnings.push(`Kimchi version ${nativeProof.kimchiVersion} may not be fully supported`)
+    }
+
+    // Missing optional field warnings
+    if (!nativeProof.srsHash) {
+      warnings.push('No SRS hash provided - proof may not be verifiable without matching SRS')
+    }
+
+    if (!nativeProof.verifierIndexCommitment) {
+      warnings.push('No verifier index commitment - proof traceability limited')
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+      warnings,
+    }
+  }
+
+  /**
+   * Check if a SIP proof can be converted to Kimchi format
+   */
+  canConvertFromSIP(sipProof: SingleProof): boolean {
+    return sipProof.metadata.system === 'kimchi'
+  }
+
+  /**
+   * Get supported Kimchi versions
+   */
+  getSupportedVersions(): string[] {
+    return [...SUPPORTED_KIMCHI_VERSIONS]
+  }
+
+  // ─── Private Helpers ─────────────────────────────────────────────────────────
+
+  private _createConversionMetadata(
+    sourceSystem: 'kimchi' | 'sip',
+    targetSystem: 'kimchi' | 'sip',
+    startTime: number,
+    originalSize: number,
+    convertedSize: number,
+  ): ConversionMetadata {
+    return {
+      sourceSystem: sourceSystem === 'sip' ? 'kimchi' : sourceSystem,
+      targetSystem,
+      convertedAt: Date.now(),
+      converterVersion: this.version,
+      conversionTimeMs: Date.now() - startTime,
+      originalSize,
+      convertedSize,
+    }
+  }
+
+  private _createErrorResult<T>(
+    error: ProofConversionError,
+    startTime: number,
+    inputSize: number,
+  ): ConversionResult<T> {
+    return {
+      success: false,
+      error: error.message,
+      errorCode: error.code,
+      lossless: false,
+      conversionMetadata: this._createConversionMetadata(
+        error.sourceSystem as any,
+        error.targetSystem as any,
+        startTime,
+        inputSize,
+        0,
+      ),
+    }
+  }
+
+  private _collectWarnings(nativeProof: KimchiNativeProof): string[] {
+    const warnings: string[] = []
+
+    if (!nativeProof.kimchiVersion) {
+      warnings.push('No Kimchi version specified - using unknown')
+    }
+
+    if (!nativeProof.srsHash) {
+      warnings.push('No SRS hash - verification may require external SRS')
+    }
+
+    if (!nativeProof.verifierIndexCommitment) {
+      warnings.push('No verifier index commitment - traceability limited')
+    }
+
+    return warnings
+  }
+}
+
+// ─── Factory Function ────────────────────────────────────────────────────────
+
+/**
+ * Create a new Kimchi proof converter instance
+ */
+export function createKimchiConverter(): KimchiProofConverter {
+  return new KimchiProofConverter()
+}

--- a/packages/sdk/src/proofs/converters/noir.ts
+++ b/packages/sdk/src/proofs/converters/noir.ts
@@ -1,0 +1,451 @@
+/**
+ * Noir Proof Format Converter
+ *
+ * Converts between Noir native proof format (Barretenberg) and SIP unified format.
+ *
+ * @packageDocumentation
+ */
+
+import type {
+  SingleProof,
+  ProofMetadata,
+  HexString,
+} from '@sip-protocol/types'
+
+import {
+  type ProofConverter,
+  type NoirNativeProof,
+  type ConversionOptions,
+  type ConversionResult,
+  type ConversionMetadata,
+  type ValidationResult,
+  type ValidationError,
+  DEFAULT_CONVERSION_OPTIONS,
+  ProofConversionError,
+  InvalidProofError,
+  UnsupportedVersionError,
+} from './interface'
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/** Converter version */
+const CONVERTER_VERSION = '1.0.0'
+
+/** Supported Noir versions */
+const SUPPORTED_NOIR_VERSIONS = ['0.30', '0.31', '0.32', '0.33', '0.34', '0.35', '1.0']
+
+/** Supported Barretenberg versions */
+const SUPPORTED_BB_VERSIONS = ['0.47', '0.48', '0.49', '0.50', '0.51', '0.52', '0.53']
+
+// ─── Utility Functions ───────────────────────────────────────────────────────
+
+/**
+ * Convert Uint8Array to hex string
+ */
+function bytesToHex(bytes: Uint8Array): HexString {
+  return ('0x' + Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')) as HexString
+}
+
+/**
+ * Convert hex string to Uint8Array
+ */
+function hexToBytes(hex: HexString): Uint8Array {
+  const cleanHex = hex.startsWith('0x') ? hex.slice(2) : hex
+  const bytes = new Uint8Array(cleanHex.length / 2)
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(cleanHex.slice(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
+/**
+ * Check if a Noir version is supported
+ */
+function isSupportedNoirVersion(version: string): boolean {
+  const majorMinor = version.split('.').slice(0, 2).join('.')
+  return SUPPORTED_NOIR_VERSIONS.some(v => majorMinor.startsWith(v))
+}
+
+/**
+ * Check if a Barretenberg version is supported
+ */
+function isSupportedBBVersion(version: string): boolean {
+  const majorMinor = version.split('.').slice(0, 2).join('.')
+  return SUPPORTED_BB_VERSIONS.some(v => majorMinor.startsWith(v))
+}
+
+// ─── Noir Proof Converter ────────────────────────────────────────────────────
+
+/**
+ * Converter for Noir proofs (Barretenberg backend)
+ *
+ * @example
+ * ```typescript
+ * const converter = new NoirProofConverter()
+ *
+ * // Convert to SIP format
+ * const result = converter.toSIP(noirProof)
+ * if (result.success) {
+ *   console.log('SIP Proof:', result.result)
+ * }
+ *
+ * // Convert back to Noir format
+ * const nativeResult = converter.fromSIP(sipProof)
+ * if (nativeResult.success) {
+ *   console.log('Noir Proof:', nativeResult.result)
+ * }
+ * ```
+ */
+export class NoirProofConverter implements ProofConverter<NoirNativeProof> {
+  readonly system = 'noir' as const
+  readonly version = CONVERTER_VERSION
+
+  /**
+   * Convert Noir native proof to SIP unified format
+   */
+  toSIP(
+    nativeProof: NoirNativeProof,
+    options: ConversionOptions = {},
+  ): ConversionResult<SingleProof> {
+    const opts = { ...DEFAULT_CONVERSION_OPTIONS, ...options }
+    const startTime = Date.now()
+
+    try {
+      // Validate if requested
+      if (opts.validateBeforeConversion) {
+        const validation = this.validateNative(nativeProof)
+        if (!validation.valid) {
+          return this._createErrorResult(
+            new InvalidProofError('noir', 'sip', validation.errors),
+            startTime,
+            nativeProof.proofData.length,
+          )
+        }
+      }
+
+      // Check version support
+      if (nativeProof.noirVersion && !isSupportedNoirVersion(nativeProof.noirVersion)) {
+        return this._createErrorResult(
+          new UnsupportedVersionError('noir', nativeProof.noirVersion, SUPPORTED_NOIR_VERSIONS),
+          startTime,
+          nativeProof.proofData.length,
+        )
+      }
+
+      // Convert proof data to hex
+      const proofHex = bytesToHex(nativeProof.proofData)
+
+      // Convert public inputs to hex format
+      const publicInputsHex = nativeProof.publicInputs.map(input => {
+        // If already hex, ensure proper format
+        if (input.startsWith('0x')) {
+          return input as HexString
+        }
+        // Convert decimal/field element to hex
+        const bigInt = BigInt(input)
+        return ('0x' + bigInt.toString(16).padStart(64, '0')) as HexString
+      })
+
+      // Convert verification key if present
+      const verificationKey = opts.includeVerificationKey && nativeProof.verificationKey
+        ? (typeof nativeProof.verificationKey === 'string'
+          ? nativeProof.verificationKey as HexString
+          : bytesToHex(nativeProof.verificationKey))
+        : undefined
+
+      // Build metadata
+      const metadata: ProofMetadata = {
+        system: 'noir',
+        systemVersion: nativeProof.noirVersion || 'unknown',
+        circuitId: nativeProof.circuitHash || 'unknown',
+        circuitVersion: nativeProof.backendVersion || 'unknown',
+        generatedAt: Date.now(),
+        proofSizeBytes: nativeProof.proofData.length,
+        targetChainId: opts.targetChainId || undefined,
+      }
+
+      // Build SIP proof
+      const sipProof: SingleProof = {
+        id: opts.idGenerator(),
+        proof: proofHex,
+        publicInputs: publicInputsHex,
+        verificationKey,
+        metadata,
+      }
+
+      // Calculate output size
+      const outputSize = proofHex.length / 2 - 1 // Hex chars / 2 minus 0x
+
+      return {
+        success: true,
+        result: sipProof,
+        lossless: true,
+        warnings: this._collectWarnings(nativeProof),
+        conversionMetadata: this._createConversionMetadata(
+          'noir',
+          'sip',
+          startTime,
+          nativeProof.proofData.length,
+          outputSize,
+        ),
+      }
+    } catch (error) {
+      return this._createErrorResult(
+        error instanceof ProofConversionError
+          ? error
+          : new ProofConversionError(
+            'UNKNOWN_ERROR',
+            error instanceof Error ? error.message : 'Unknown conversion error',
+            'noir',
+            'sip',
+            error instanceof Error ? error : undefined,
+          ),
+        startTime,
+        nativeProof.proofData.length,
+      )
+    }
+  }
+
+  /**
+   * Convert SIP unified format to Noir native proof
+   */
+  fromSIP(
+    sipProof: SingleProof,
+    options: ConversionOptions = {},
+  ): ConversionResult<NoirNativeProof> {
+    const opts = { ...DEFAULT_CONVERSION_OPTIONS, ...options }
+    const startTime = Date.now()
+    const inputSize = sipProof.proof.length / 2 - 1
+
+    try {
+      // Check if this is a Noir proof
+      if (!this.canConvertFromSIP(sipProof)) {
+        return this._createErrorResult(
+          new ProofConversionError(
+            'INVALID_INPUT',
+            `Cannot convert proof from system: ${sipProof.metadata.system}`,
+            sipProof.metadata.system,
+            'noir',
+          ),
+          startTime,
+          inputSize,
+        )
+      }
+
+      // Convert proof hex to bytes
+      const proofData = hexToBytes(sipProof.proof)
+
+      // Convert public inputs from hex to field element strings
+      const publicInputs = sipProof.publicInputs.map(hex => {
+        const bigInt = BigInt(hex)
+        return bigInt.toString()
+      })
+
+      // Convert verification key if present
+      const verificationKey = sipProof.verificationKey
+        ? hexToBytes(sipProof.verificationKey)
+        : undefined
+
+      // Build native proof
+      const nativeProof: NoirNativeProof = {
+        system: 'noir',
+        proofData,
+        publicInputs,
+        verificationKey,
+        circuitHash: sipProof.metadata.circuitId,
+        noirVersion: sipProof.metadata.systemVersion,
+        backendVersion: sipProof.metadata.circuitVersion,
+        nativeMetadata: opts.preserveNativeMetadata ? {
+          sipProofId: sipProof.id,
+          originalMetadata: sipProof.metadata,
+        } : undefined,
+      }
+
+      return {
+        success: true,
+        result: nativeProof,
+        lossless: true,
+        warnings: [],
+        conversionMetadata: this._createConversionMetadata(
+          'sip' as any,
+          'noir',
+          startTime,
+          inputSize,
+          proofData.length,
+        ),
+      }
+    } catch (error) {
+      return this._createErrorResult(
+        error instanceof ProofConversionError
+          ? error
+          : new ProofConversionError(
+            'UNKNOWN_ERROR',
+            error instanceof Error ? error.message : 'Unknown conversion error',
+            'noir',
+            'sip',
+            error instanceof Error ? error : undefined,
+          ),
+        startTime,
+        inputSize,
+      )
+    }
+  }
+
+  /**
+   * Validate a Noir native proof structure
+   */
+  validateNative(nativeProof: NoirNativeProof): ValidationResult {
+    const errors: ValidationError[] = []
+    const warnings: string[] = []
+
+    // Check required fields
+    if (!nativeProof.proofData || nativeProof.proofData.length === 0) {
+      errors.push({
+        field: 'proofData',
+        message: 'Proof data is required and must not be empty',
+        code: 'REQUIRED_FIELD',
+      })
+    }
+
+    if (!nativeProof.publicInputs) {
+      errors.push({
+        field: 'publicInputs',
+        message: 'Public inputs array is required',
+        code: 'REQUIRED_FIELD',
+      })
+    }
+
+    // Validate proof data format (basic structure check)
+    if (nativeProof.proofData && nativeProof.proofData.length < 32) {
+      errors.push({
+        field: 'proofData',
+        message: 'Proof data is too short (minimum 32 bytes)',
+        code: 'INVALID_FORMAT',
+      })
+    }
+
+    // Validate public inputs format
+    if (nativeProof.publicInputs) {
+      for (let i = 0; i < nativeProof.publicInputs.length; i++) {
+        const input = nativeProof.publicInputs[i]
+        try {
+          // Try to parse as BigInt (hex or decimal)
+          if (input.startsWith('0x')) {
+            BigInt(input)
+          } else {
+            BigInt(input)
+          }
+        } catch {
+          errors.push({
+            field: `publicInputs[${i}]`,
+            message: `Invalid field element format: ${input}`,
+            code: 'INVALID_FORMAT',
+          })
+        }
+      }
+    }
+
+    // Version warnings
+    if (nativeProof.noirVersion && !isSupportedNoirVersion(nativeProof.noirVersion)) {
+      warnings.push(`Noir version ${nativeProof.noirVersion} may not be fully supported`)
+    }
+
+    if (nativeProof.backendVersion && !isSupportedBBVersion(nativeProof.backendVersion)) {
+      warnings.push(`Barretenberg version ${nativeProof.backendVersion} may not be fully supported`)
+    }
+
+    // Missing optional field warnings
+    if (!nativeProof.circuitHash) {
+      warnings.push('No circuit hash provided - proof may not be fully traceable')
+    }
+
+    if (!nativeProof.verificationKey) {
+      warnings.push('No verification key included - may need external key for verification')
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+      warnings,
+    }
+  }
+
+  /**
+   * Check if a SIP proof can be converted to Noir format
+   */
+  canConvertFromSIP(sipProof: SingleProof): boolean {
+    return sipProof.metadata.system === 'noir'
+  }
+
+  /**
+   * Get supported Noir versions
+   */
+  getSupportedVersions(): string[] {
+    return [...SUPPORTED_NOIR_VERSIONS]
+  }
+
+  // ─── Private Helpers ─────────────────────────────────────────────────────────
+
+  private _createConversionMetadata(
+    sourceSystem: 'noir' | 'sip',
+    targetSystem: 'noir' | 'sip',
+    startTime: number,
+    originalSize: number,
+    convertedSize: number,
+  ): ConversionMetadata {
+    return {
+      sourceSystem: sourceSystem === 'sip' ? 'noir' : sourceSystem,
+      targetSystem,
+      convertedAt: Date.now(),
+      converterVersion: this.version,
+      conversionTimeMs: Date.now() - startTime,
+      originalSize,
+      convertedSize,
+    }
+  }
+
+  private _createErrorResult<T>(
+    error: ProofConversionError,
+    startTime: number,
+    inputSize: number,
+  ): ConversionResult<T> {
+    return {
+      success: false,
+      error: error.message,
+      errorCode: error.code,
+      lossless: false,
+      conversionMetadata: this._createConversionMetadata(
+        error.sourceSystem as any,
+        error.targetSystem as any,
+        startTime,
+        inputSize,
+        0,
+      ),
+    }
+  }
+
+  private _collectWarnings(nativeProof: NoirNativeProof): string[] {
+    const warnings: string[] = []
+
+    if (!nativeProof.noirVersion) {
+      warnings.push('No Noir version specified - using unknown')
+    }
+
+    if (!nativeProof.circuitHash) {
+      warnings.push('No circuit hash - traceability limited')
+    }
+
+    return warnings
+  }
+}
+
+// ─── Factory Function ────────────────────────────────────────────────────────
+
+/**
+ * Create a new Noir proof converter instance
+ */
+export function createNoirConverter(): NoirProofConverter {
+  return new NoirProofConverter()
+}

--- a/packages/sdk/src/proofs/index.ts
+++ b/packages/sdk/src/proofs/index.ts
@@ -204,6 +204,43 @@ export type {
   KimchiCircuitConfig,
 } from './providers'
 
+// ─── Proof Format Converters (M20-08) ────────────────────────────────────────
+
+// Converter classes and factory functions
+export {
+  NoirProofConverter,
+  createNoirConverter,
+  Halo2ProofConverter,
+  createHalo2Converter,
+  KimchiProofConverter,
+  createKimchiConverter,
+  UnifiedProofConverter,
+  createUnifiedConverter,
+  convertToSIP,
+  convertFromSIP,
+  ProofConversionError,
+  InvalidProofError,
+  UnsupportedVersionError,
+  DEFAULT_CONVERSION_OPTIONS,
+} from './converters'
+
+// Converter types
+export type {
+  NativeProofFormat,
+  NoirNativeProof,
+  Halo2NativeProof,
+  KimchiNativeProof,
+  ConversionOptions,
+  ConversionResult as ConverterConversionResult,
+  ConversionMetadata,
+  ConversionErrorCode,
+  ProofConverter,
+  ValidationResult,
+  ValidationError,
+  AnyNativeProof,
+  ProofSystemToNativeMap,
+} from './converters'
+
 // Composer SDK types
 export type {
   ProofProviderRegistration,

--- a/packages/sdk/tests/proofs/converters.test.ts
+++ b/packages/sdk/tests/proofs/converters.test.ts
@@ -1,0 +1,700 @@
+/**
+ * Proof Format Converters Tests
+ *
+ * Tests for M20-08: Implement proof format converters
+ * - ProofConverter implementations
+ * - Noir, Halo2, Kimchi converters
+ * - UnifiedProofConverter
+ * - Error handling and validation
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { SingleProof, ProofMetadata, HexString } from '@sip-protocol/types'
+import {
+  NoirProofConverter,
+  Halo2ProofConverter,
+  KimchiProofConverter,
+  UnifiedProofConverter,
+  createNoirConverter,
+  createHalo2Converter,
+  createKimchiConverter,
+  createUnifiedConverter,
+  convertToSIP,
+  convertFromSIP,
+  ProofConversionError,
+  InvalidProofError,
+  UnsupportedVersionError,
+  DEFAULT_CONVERSION_OPTIONS,
+  type NoirNativeProof,
+  type Halo2NativeProof,
+  type KimchiNativeProof,
+} from '../../src/proofs/converters'
+
+// ─── Test Helpers ─────────────────────────────────────────────────────────────
+
+function createSampleNoirProof(): NoirNativeProof {
+  return {
+    system: 'noir',
+    proofData: new Uint8Array(128).fill(0x42),
+    publicInputs: ['12345', '67890'],
+    verificationKey: new Uint8Array(64).fill(0xaa),
+    circuitHash: 'test-circuit-hash',
+    noirVersion: '0.33.0',
+    backendVersion: '0.51.0',
+  }
+}
+
+function createSampleHalo2Proof(): Halo2NativeProof {
+  return {
+    system: 'halo2',
+    proofData: new Uint8Array(256).fill(0x55),
+    publicInputs: ['98765', '43210'],
+    verificationKey: new Uint8Array(128).fill(0xbb),
+    provingKeyCommitment: '0x1234567890abcdef' as HexString,
+    k: 14,
+    halo2Version: '0.3.0',
+  }
+}
+
+function createSampleKimchiProof(): KimchiNativeProof {
+  return {
+    system: 'kimchi',
+    proofData: new Uint8Array(512).fill(0x77),
+    publicInputs: ['111222', '333444'],
+    verificationKey: new Uint8Array(256).fill(0xcc),
+    srsHash: '0xfedcba0987654321' as HexString,
+    kimchiVersion: '1.0.0',
+    verifierIndexCommitment: '0xdeadbeef' as HexString,
+  }
+}
+
+function createSampleSIPProof(system: 'noir' | 'halo2' | 'kimchi'): SingleProof {
+  const metadata: ProofMetadata = {
+    system,
+    systemVersion: '1.0.0',
+    circuitId: `${system}-test-circuit`,
+    circuitVersion: '1.0.0',
+    generatedAt: Date.now(),
+    proofSizeBytes: 128,
+    verificationCost: 100n,
+  }
+
+  return {
+    id: `test-proof-${Date.now()}`,
+    proof: '0x' + 'ab'.repeat(64) as HexString,
+    publicInputs: [
+      '0x0000000000000000000000000000000000000000000000000000000000003039' as HexString,
+      '0x0000000000000000000000000000000000000000000000000000000000010932' as HexString,
+    ],
+    verificationKey: '0x' + 'cd'.repeat(32) as HexString,
+    metadata,
+  }
+}
+
+// ─── Noir Converter Tests ────────────────────────────────────────────────────
+
+describe('NoirProofConverter', () => {
+  let converter: NoirProofConverter
+
+  beforeEach(() => {
+    converter = new NoirProofConverter()
+  })
+
+  describe('constructor', () => {
+    it('should have correct system and version', () => {
+      expect(converter.system).toBe('noir')
+      expect(converter.version).toBe('1.0.0')
+    })
+  })
+
+  describe('toSIP', () => {
+    it('should convert Noir proof to SIP format', () => {
+      const noirProof = createSampleNoirProof()
+      const result = converter.toSIP(noirProof)
+
+      expect(result.success).toBe(true)
+      expect(result.result).toBeDefined()
+      expect(result.result?.metadata.system).toBe('noir')
+      expect(result.result?.metadata.systemVersion).toBe('0.33.0')
+      expect(result.lossless).toBe(true)
+    })
+
+    it('should convert public inputs to hex format', () => {
+      const noirProof = createSampleNoirProof()
+      const result = converter.toSIP(noirProof)
+
+      expect(result.success).toBe(true)
+      expect(result.result?.publicInputs).toHaveLength(2)
+      expect(result.result?.publicInputs[0]).toMatch(/^0x[0-9a-f]+$/i)
+    })
+
+    it('should include verification key when requested', () => {
+      const noirProof = createSampleNoirProof()
+      const result = converter.toSIP(noirProof, { includeVerificationKey: true })
+
+      expect(result.success).toBe(true)
+      expect(result.result?.verificationKey).toBeDefined()
+      expect(result.result?.verificationKey).toMatch(/^0x[0-9a-f]+$/i)
+    })
+
+    it('should exclude verification key when not requested', () => {
+      const noirProof = createSampleNoirProof()
+      const result = converter.toSIP(noirProof, { includeVerificationKey: false })
+
+      expect(result.success).toBe(true)
+      expect(result.result?.verificationKey).toBeUndefined()
+    })
+
+    it('should include conversion metadata', () => {
+      const noirProof = createSampleNoirProof()
+      const result = converter.toSIP(noirProof)
+
+      expect(result.conversionMetadata).toBeDefined()
+      expect(result.conversionMetadata.sourceSystem).toBe('noir')
+      expect(result.conversionMetadata.targetSystem).toBe('sip')
+      expect(result.conversionMetadata.converterVersion).toBe('1.0.0')
+    })
+
+    it('should validate proof when validation enabled', () => {
+      const invalidProof: NoirNativeProof = {
+        system: 'noir',
+        proofData: new Uint8Array(0), // Empty - invalid
+        publicInputs: [],
+      }
+
+      const result = converter.toSIP(invalidProof, { validateBeforeConversion: true })
+
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('INVALID_INPUT')
+    })
+
+    it('should warn about unsupported Noir version', () => {
+      const noirProof = createSampleNoirProof()
+      noirProof.noirVersion = '0.20.0' // Old version
+
+      const result = converter.toSIP(noirProof)
+
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('UNSUPPORTED_VERSION')
+    })
+
+    it('should use custom ID generator', () => {
+      const noirProof = createSampleNoirProof()
+      const customId = 'custom-proof-id-123'
+      const result = converter.toSIP(noirProof, {
+        idGenerator: () => customId,
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.result?.id).toBe(customId)
+    })
+  })
+
+  describe('fromSIP', () => {
+    it('should convert SIP proof to Noir format', () => {
+      const sipProof = createSampleSIPProof('noir')
+      const result = converter.fromSIP(sipProof)
+
+      expect(result.success).toBe(true)
+      expect(result.result).toBeDefined()
+      expect(result.result?.system).toBe('noir')
+      expect(result.lossless).toBe(true)
+    })
+
+    it('should convert public inputs from hex', () => {
+      const sipProof = createSampleSIPProof('noir')
+      const result = converter.fromSIP(sipProof)
+
+      expect(result.success).toBe(true)
+      expect(result.result?.publicInputs).toHaveLength(2)
+      // Should be decimal strings
+      expect(result.result?.publicInputs[0]).toMatch(/^\d+$/)
+    })
+
+    it('should reject non-Noir proofs', () => {
+      const sipProof = createSampleSIPProof('halo2')
+      const result = converter.fromSIP(sipProof)
+
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('INVALID_INPUT')
+    })
+
+    it('should preserve native metadata when requested', () => {
+      const sipProof = createSampleSIPProof('noir')
+      const result = converter.fromSIP(sipProof, { preserveNativeMetadata: true })
+
+      expect(result.success).toBe(true)
+      expect(result.result?.nativeMetadata).toBeDefined()
+      expect(result.result?.nativeMetadata?.sipProofId).toBe(sipProof.id)
+    })
+  })
+
+  describe('validateNative', () => {
+    it('should validate valid proof', () => {
+      const noirProof = createSampleNoirProof()
+      const result = converter.validateNative(noirProof)
+
+      expect(result.valid).toBe(true)
+      expect(result.errors).toHaveLength(0)
+    })
+
+    it('should detect empty proof data', () => {
+      const invalidProof: NoirNativeProof = {
+        system: 'noir',
+        proofData: new Uint8Array(0),
+        publicInputs: ['123'],
+      }
+
+      const result = converter.validateNative(invalidProof)
+
+      expect(result.valid).toBe(false)
+      expect(result.errors.some(e => e.field === 'proofData')).toBe(true)
+    })
+
+    it('should detect invalid public input format', () => {
+      const invalidProof: NoirNativeProof = {
+        system: 'noir',
+        proofData: new Uint8Array(64).fill(0x42),
+        publicInputs: ['invalid-not-a-number'],
+      }
+
+      const result = converter.validateNative(invalidProof)
+
+      expect(result.valid).toBe(false)
+      expect(result.errors.some(e => e.field.includes('publicInputs'))).toBe(true)
+    })
+
+    it('should include warnings for missing optional fields', () => {
+      const minimalProof: NoirNativeProof = {
+        system: 'noir',
+        proofData: new Uint8Array(64).fill(0x42),
+        publicInputs: ['123'],
+      }
+
+      const result = converter.validateNative(minimalProof)
+
+      expect(result.valid).toBe(true)
+      expect(result.warnings.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('canConvertFromSIP', () => {
+    it('should return true for Noir proofs', () => {
+      const sipProof = createSampleSIPProof('noir')
+      expect(converter.canConvertFromSIP(sipProof)).toBe(true)
+    })
+
+    it('should return false for non-Noir proofs', () => {
+      const sipProof = createSampleSIPProof('halo2')
+      expect(converter.canConvertFromSIP(sipProof)).toBe(false)
+    })
+  })
+
+  describe('getSupportedVersions', () => {
+    it('should return list of supported versions', () => {
+      const versions = converter.getSupportedVersions()
+      expect(versions.length).toBeGreaterThan(0)
+      expect(versions).toContain('0.33')
+    })
+  })
+})
+
+// ─── Halo2 Converter Tests ───────────────────────────────────────────────────
+
+describe('Halo2ProofConverter', () => {
+  let converter: Halo2ProofConverter
+
+  beforeEach(() => {
+    converter = new Halo2ProofConverter()
+  })
+
+  describe('constructor', () => {
+    it('should have correct system and version', () => {
+      expect(converter.system).toBe('halo2')
+      expect(converter.version).toBe('1.0.0')
+    })
+  })
+
+  describe('toSIP', () => {
+    it('should convert Halo2 proof to SIP format', () => {
+      const halo2Proof = createSampleHalo2Proof()
+      const result = converter.toSIP(halo2Proof)
+
+      expect(result.success).toBe(true)
+      expect(result.result).toBeDefined()
+      expect(result.result?.metadata.system).toBe('halo2')
+      expect(result.lossless).toBe(true)
+    })
+
+    it('should include k value in circuit ID', () => {
+      const halo2Proof = createSampleHalo2Proof()
+      const result = converter.toSIP(halo2Proof)
+
+      expect(result.success).toBe(true)
+      expect(result.result?.metadata.circuitId).toContain('k14')
+    })
+  })
+
+  describe('fromSIP', () => {
+    it('should convert SIP proof to Halo2 format', () => {
+      const sipProof = createSampleSIPProof('halo2')
+      sipProof.metadata.circuitId = 'halo2-k14-abcd1234' // Include k value
+      const result = converter.fromSIP(sipProof)
+
+      expect(result.success).toBe(true)
+      expect(result.result?.system).toBe('halo2')
+      expect(result.result?.k).toBe(14)
+    })
+
+    it('should reject non-Halo2 proofs', () => {
+      const sipProof = createSampleSIPProof('noir')
+      const result = converter.fromSIP(sipProof)
+
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('INVALID_INPUT')
+    })
+  })
+
+  describe('validateNative', () => {
+    it('should validate valid proof', () => {
+      const halo2Proof = createSampleHalo2Proof()
+      const result = converter.validateNative(halo2Proof)
+
+      expect(result.valid).toBe(true)
+    })
+
+    it('should detect invalid k value', () => {
+      const invalidProof = createSampleHalo2Proof()
+      invalidProof.k = 2 // Too small
+
+      const result = converter.validateNative(invalidProof)
+
+      expect(result.valid).toBe(false)
+      expect(result.errors.some(e => e.field === 'k')).toBe(true)
+    })
+  })
+})
+
+// ─── Kimchi Converter Tests ──────────────────────────────────────────────────
+
+describe('KimchiProofConverter', () => {
+  let converter: KimchiProofConverter
+
+  beforeEach(() => {
+    converter = new KimchiProofConverter()
+  })
+
+  describe('constructor', () => {
+    it('should have correct system and version', () => {
+      expect(converter.system).toBe('kimchi')
+      expect(converter.version).toBe('1.0.0')
+    })
+  })
+
+  describe('toSIP', () => {
+    it('should convert Kimchi proof to SIP format', () => {
+      const kimchiProof = createSampleKimchiProof()
+      const result = converter.toSIP(kimchiProof)
+
+      expect(result.success).toBe(true)
+      expect(result.result).toBeDefined()
+      expect(result.result?.metadata.system).toBe('kimchi')
+      expect(result.lossless).toBe(true)
+    })
+  })
+
+  describe('fromSIP', () => {
+    it('should convert SIP proof to Kimchi format', () => {
+      const sipProof = createSampleSIPProof('kimchi')
+      const result = converter.fromSIP(sipProof)
+
+      expect(result.success).toBe(true)
+      expect(result.result?.system).toBe('kimchi')
+    })
+
+    it('should reject non-Kimchi proofs', () => {
+      const sipProof = createSampleSIPProof('noir')
+      const result = converter.fromSIP(sipProof)
+
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('validateNative', () => {
+    it('should validate valid proof', () => {
+      const kimchiProof = createSampleKimchiProof()
+      const result = converter.validateNative(kimchiProof)
+
+      expect(result.valid).toBe(true)
+    })
+
+    it('should validate Pasta field elements', () => {
+      const invalidProof = createSampleKimchiProof()
+      // Very large value that exceeds Pallas modulus
+      invalidProof.publicInputs = ['115792089237316195423570985008687907853269984665640564039457584007913129639935']
+
+      const result = converter.validateNative(invalidProof)
+
+      expect(result.valid).toBe(false)
+      expect(result.errors.some(e => e.code === 'INVALID_FIELD_ELEMENT')).toBe(true)
+    })
+  })
+})
+
+// ─── Unified Converter Tests ─────────────────────────────────────────────────
+
+describe('UnifiedProofConverter', () => {
+  let converter: UnifiedProofConverter
+
+  beforeEach(() => {
+    converter = new UnifiedProofConverter()
+  })
+
+  describe('toSIP', () => {
+    it('should route Noir proofs to Noir converter', () => {
+      const noirProof = createSampleNoirProof()
+      const result = converter.toSIP(noirProof)
+
+      expect(result.success).toBe(true)
+      expect(result.result?.metadata.system).toBe('noir')
+    })
+
+    it('should route Halo2 proofs to Halo2 converter', () => {
+      const halo2Proof = createSampleHalo2Proof()
+      const result = converter.toSIP(halo2Proof)
+
+      expect(result.success).toBe(true)
+      expect(result.result?.metadata.system).toBe('halo2')
+    })
+
+    it('should route Kimchi proofs to Kimchi converter', () => {
+      const kimchiProof = createSampleKimchiProof()
+      const result = converter.toSIP(kimchiProof)
+
+      expect(result.success).toBe(true)
+      expect(result.result?.metadata.system).toBe('kimchi')
+    })
+  })
+
+  describe('fromSIP', () => {
+    it('should route to appropriate converter based on proof system', () => {
+      const noirSipProof = createSampleSIPProof('noir')
+      const noirResult = converter.fromSIP(noirSipProof)
+      expect(noirResult.success).toBe(true)
+      expect(noirResult.result?.system).toBe('noir')
+
+      const halo2SipProof = createSampleSIPProof('halo2')
+      const halo2Result = converter.fromSIP(halo2SipProof)
+      expect(halo2Result.success).toBe(true)
+      expect(halo2Result.result?.system).toBe('halo2')
+
+      const kimchiSipProof = createSampleSIPProof('kimchi')
+      const kimchiResult = converter.fromSIP(kimchiSipProof)
+      expect(kimchiResult.success).toBe(true)
+      expect(kimchiResult.result?.system).toBe('kimchi')
+    })
+  })
+
+  describe('getSupportedSystems', () => {
+    it('should return all supported systems', () => {
+      const systems = converter.getSupportedSystems()
+      expect(systems).toContain('noir')
+      expect(systems).toContain('halo2')
+      expect(systems).toContain('kimchi')
+    })
+  })
+
+  describe('isSystemSupported', () => {
+    it('should return true for supported systems', () => {
+      expect(converter.isSystemSupported('noir')).toBe(true)
+      expect(converter.isSystemSupported('halo2')).toBe(true)
+      expect(converter.isSystemSupported('kimchi')).toBe(true)
+    })
+
+    it('should return false for unsupported systems', () => {
+      expect(converter.isSystemSupported('groth16')).toBe(false)
+      expect(converter.isSystemSupported('plonk')).toBe(false)
+    })
+  })
+})
+
+// ─── Factory Functions Tests ─────────────────────────────────────────────────
+
+describe('Factory Functions', () => {
+  describe('createNoirConverter', () => {
+    it('should create NoirProofConverter instance', () => {
+      const converter = createNoirConverter()
+      expect(converter).toBeInstanceOf(NoirProofConverter)
+    })
+  })
+
+  describe('createHalo2Converter', () => {
+    it('should create Halo2ProofConverter instance', () => {
+      const converter = createHalo2Converter()
+      expect(converter).toBeInstanceOf(Halo2ProofConverter)
+    })
+  })
+
+  describe('createKimchiConverter', () => {
+    it('should create KimchiProofConverter instance', () => {
+      const converter = createKimchiConverter()
+      expect(converter).toBeInstanceOf(KimchiProofConverter)
+    })
+  })
+
+  describe('createUnifiedConverter', () => {
+    it('should create UnifiedProofConverter instance', () => {
+      const converter = createUnifiedConverter()
+      expect(converter).toBeInstanceOf(UnifiedProofConverter)
+    })
+  })
+})
+
+// ─── Convenience Functions Tests ─────────────────────────────────────────────
+
+describe('Convenience Functions', () => {
+  describe('convertToSIP', () => {
+    it('should convert native proof to SIP format', () => {
+      const noirProof = createSampleNoirProof()
+      const result = convertToSIP(noirProof)
+
+      expect(result.success).toBe(true)
+      expect(result.result?.metadata.system).toBe('noir')
+    })
+  })
+
+  describe('convertFromSIP', () => {
+    it('should convert SIP proof to native format', () => {
+      const sipProof = createSampleSIPProof('halo2')
+      const result = convertFromSIP(sipProof)
+
+      expect(result.success).toBe(true)
+      expect(result.result?.system).toBe('halo2')
+    })
+  })
+})
+
+// ─── Error Classes Tests ─────────────────────────────────────────────────────
+
+describe('Error Classes', () => {
+  describe('ProofConversionError', () => {
+    it('should create with all properties', () => {
+      const error = new ProofConversionError(
+        'INVALID_INPUT',
+        'Test error message',
+        'noir',
+        'sip',
+      )
+
+      expect(error.name).toBe('ProofConversionError')
+      expect(error.code).toBe('INVALID_INPUT')
+      expect(error.message).toBe('Test error message')
+      expect(error.sourceSystem).toBe('noir')
+      expect(error.targetSystem).toBe('sip')
+    })
+
+    it('should include cause when provided', () => {
+      const cause = new Error('Underlying error')
+      const error = new ProofConversionError(
+        'UNKNOWN_ERROR',
+        'Wrapper error',
+        'halo2',
+        'sip',
+        cause,
+      )
+
+      expect(error.cause).toBe(cause)
+    })
+  })
+
+  describe('InvalidProofError', () => {
+    it('should create with validation errors', () => {
+      const validationErrors = [
+        { field: 'proofData', message: 'Empty', code: 'REQUIRED' },
+      ]
+      const error = new InvalidProofError('noir', 'sip', validationErrors)
+
+      expect(error.name).toBe('InvalidProofError')
+      expect(error.code).toBe('INVALID_INPUT')
+      expect(error.validationErrors).toEqual(validationErrors)
+    })
+  })
+
+  describe('UnsupportedVersionError', () => {
+    it('should create with version info', () => {
+      const error = new UnsupportedVersionError('noir', '0.10.0', ['0.30', '0.31'])
+
+      expect(error.name).toBe('UnsupportedVersionError')
+      expect(error.code).toBe('UNSUPPORTED_VERSION')
+      expect(error.providedVersion).toBe('0.10.0')
+      expect(error.supportedVersions).toContain('0.30')
+    })
+  })
+})
+
+// ─── Default Options Tests ───────────────────────────────────────────────────
+
+describe('DEFAULT_CONVERSION_OPTIONS', () => {
+  it('should have all required fields', () => {
+    expect(DEFAULT_CONVERSION_OPTIONS.preserveNativeMetadata).toBe(true)
+    expect(DEFAULT_CONVERSION_OPTIONS.validateBeforeConversion).toBe(true)
+    expect(DEFAULT_CONVERSION_OPTIONS.includeVerificationKey).toBe(true)
+    expect(DEFAULT_CONVERSION_OPTIONS.targetChainId).toBe('')
+    expect(typeof DEFAULT_CONVERSION_OPTIONS.idGenerator).toBe('function')
+  })
+
+  it('should generate unique IDs', () => {
+    const id1 = DEFAULT_CONVERSION_OPTIONS.idGenerator()
+    const id2 = DEFAULT_CONVERSION_OPTIONS.idGenerator()
+    expect(id1).not.toBe(id2)
+    expect(id1).toMatch(/^proof-\d+-[a-z0-9]+$/)
+  })
+})
+
+// ─── Round-Trip Tests ────────────────────────────────────────────────────────
+
+describe('Round-Trip Conversion', () => {
+  it('should preserve Noir proof data through round-trip', () => {
+    const converter = createNoirConverter()
+    const original = createSampleNoirProof()
+
+    // Convert to SIP
+    const sipResult = converter.toSIP(original)
+    expect(sipResult.success).toBe(true)
+
+    // Convert back to Noir
+    const nativeResult = converter.fromSIP(sipResult.result!)
+    expect(nativeResult.success).toBe(true)
+
+    // Verify data matches
+    expect(nativeResult.result?.proofData).toEqual(original.proofData)
+    expect(nativeResult.result?.publicInputs.length).toBe(original.publicInputs.length)
+  })
+
+  it('should preserve Halo2 proof data through round-trip', () => {
+    const converter = createHalo2Converter()
+    const original = createSampleHalo2Proof()
+
+    const sipResult = converter.toSIP(original)
+    expect(sipResult.success).toBe(true)
+
+    const nativeResult = converter.fromSIP(sipResult.result!)
+    expect(nativeResult.success).toBe(true)
+
+    expect(nativeResult.result?.proofData).toEqual(original.proofData)
+    expect(nativeResult.result?.k).toBe(original.k)
+  })
+
+  it('should preserve Kimchi proof data through round-trip', () => {
+    const converter = createKimchiConverter()
+    const original = createSampleKimchiProof()
+
+    const sipResult = converter.toSIP(original)
+    expect(sipResult.success).toBe(true)
+
+    const nativeResult = converter.fromSIP(sipResult.result!)
+    expect(nativeResult.success).toBe(true)
+
+    expect(nativeResult.result?.proofData).toEqual(original.proofData)
+  })
+})


### PR DESCRIPTION
## Summary
- Implements M20-08: Proof format converters
- Adds converters for transforming between native proof formats (Noir, Halo2, Kimchi) and unified SIP format
- Enables seamless interoperability across proof systems

## Converters Added

### ProofConverter Interface
- `toSIP()` - Convert native proof to SIP format
- `fromSIP()` - Convert SIP proof back to native format
- `validateNative()` - Validate native proof structure
- `canConvertFromSIP()` - Check if SIP proof can be converted
- `getSupportedVersions()` - Get supported system versions

### NoirProofConverter
- Supports Noir versions 0.30-1.0+
- Handles Barretenberg backend proofs
- Preserves circuit hash and version metadata

### Halo2ProofConverter
- Supports Halo2 versions 0.2-1.0+
- Preserves k-value and proving key commitment
- Validates circuit degree constraints (k=4-28)

### KimchiProofConverter
- Supports Kimchi/o1js versions 0.15-1.2+
- Validates Pasta field elements
- Preserves SRS hash and verifier index

### UnifiedProofConverter
- Automatic routing based on proof system
- Supports custom converter registration
- Convenience functions: `convertToSIP()`, `convertFromSIP()`

## Test Plan
- [x] 55 unit tests for all converters
- [x] NoirProofConverter tests (toSIP, fromSIP, validation)
- [x] Halo2ProofConverter tests (toSIP, fromSIP, validation)
- [x] KimchiProofConverter tests (toSIP, fromSIP, validation)
- [x] UnifiedProofConverter routing tests
- [x] Round-trip conversion tests
- [x] Error handling tests
- [x] Full SDK test suite passes

## Files Changed
- `packages/sdk/src/proofs/converters/interface.ts` - ProofConverter interface
- `packages/sdk/src/proofs/converters/noir.ts` - Noir converter
- `packages/sdk/src/proofs/converters/halo2.ts` - Halo2 converter
- `packages/sdk/src/proofs/converters/kimchi.ts` - Kimchi converter
- `packages/sdk/src/proofs/converters/index.ts` - Module exports
- `packages/sdk/src/proofs/index.ts` - Added converter exports
- `packages/sdk/tests/proofs/converters.test.ts` - Tests (55 tests)

Closes #285