### PR TITLE
feat(sdk): add lazy proof generation support (#319)

### DIFF
--- a/packages/sdk/src/proofs/index.ts
+++ b/packages/sdk/src/proofs/index.ts
@@ -228,6 +228,66 @@ export type {
   ProofTelemetryMetrics,
 } from './composer'
 
+// ─── Lazy Proof Generation (M20-14) ─────────────────────────────────────────
+
+// Lazy Proof
+export {
+  LazyProof,
+  createLazyProof,
+  DEFAULT_LAZY_CONFIG,
+} from './lazy'
+
+export type {
+  LazyProofStatus,
+  ProofTrigger,
+  ProofPriority,
+  LazyProofConfig,
+  ProofGenerator,
+  LazyProofEventType,
+  LazyProofEvent,
+  LazyProofEventListener,
+  SerializedLazyProof,
+} from './lazy'
+
+// Proof Generation Queue
+export {
+  ProofGenerationQueue,
+  createProofQueue,
+  DEFAULT_QUEUE_CONFIG,
+} from './lazy'
+
+export type {
+  ProofQueueConfig,
+  QueueStats,
+} from './lazy'
+
+// Lazy Verification Keys
+export {
+  LazyVerificationKey,
+  VerificationKeyRegistry,
+  createVKRegistry,
+} from './lazy'
+
+// Speculative Prefetching
+export {
+  SpeculativePrefetcher,
+  createPrefetcher,
+  DEFAULT_PREFETCH_CONFIG,
+} from './lazy'
+
+export type {
+  PrefetchConfig,
+} from './lazy'
+
+// Error handling
+export {
+  LazyProofError,
+} from './lazy'
+
+export type {
+  LazyProofErrorCode,
+} from './lazy'
+
 // Re-export base types from @sip-protocol/types for convenience
 export {
   ProofAggregationStrategy,

--- a/packages/sdk/src/proofs/lazy.ts
+++ b/packages/sdk/src/proofs/lazy.ts
@@ -1,0 +1,1004 @@
+/**
+ * Lazy Proof Generation
+ *
+ * @module proofs/lazy
+ * @description Deferred proof generation with cancellation and priority queue
+ *
+ * M20-14: Add lazy proof generation support (#319)
+ *
+ * ## Overview
+ *
+ * Lazy proofs defer computation until absolutely necessary, improving:
+ * - Perceived performance (don't block on proof generation)
+ * - Resource usage (only generate proofs that are actually needed)
+ * - User experience (can cancel unnecessary proof generation)
+ *
+ * ## Usage
+ *
+ * ```typescript
+ * import { LazyProof, ProofGenerationQueue } from '@sip-protocol/sdk'
+ *
+ * // Create a lazy proof
+ * const lazy = new LazyProof(async (signal) => {
+ *   return await provider.generateProof(inputs, signal)
+ * })
+ *
+ * // Proof is NOT generated yet
+ * console.log(lazy.status) // 'pending'
+ *
+ * // Trigger generation when needed
+ * const proof = await lazy.resolve()
+ *
+ * // Or cancel if no longer needed
+ * lazy.cancel()
+ * ```
+ */
+
+import type { SingleProof, ProofSystem } from '@sip-protocol/types'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/**
+ * Status of a lazy proof
+ */
+export type LazyProofStatus =
+  | 'pending'      // Not yet started
+  | 'generating'   // Currently being generated
+  | 'resolved'     // Successfully generated
+  | 'cancelled'    // Generation was cancelled
+  | 'failed'       // Generation failed
+
+/**
+ * Trigger for automatic proof generation
+ */
+export type ProofTrigger =
+  | 'manual'       // Only on explicit resolve()
+  | 'on-verify'    // When verification is requested
+  | 'on-serialize' // When serialization is requested
+  | 'immediate'    // Start immediately (eager)
+
+/**
+ * Priority level for proof generation
+ */
+export type ProofPriority = 'low' | 'normal' | 'high' | 'critical'
+
+/**
+ * Configuration for lazy proof
+ */
+export interface LazyProofConfig {
+  /** When to trigger proof generation */
+  readonly trigger: ProofTrigger
+  /** Priority in the generation queue */
+  readonly priority: ProofPriority
+  /** Timeout in milliseconds (0 = no timeout) */
+  readonly timeoutMs: number
+  /** Retry attempts on failure */
+  readonly maxRetries: number
+  /** Delay between retries in milliseconds */
+  readonly retryDelayMs: number
+  /** Enable speculative prefetching */
+  readonly prefetch: boolean
+}
+
+/**
+ * Default lazy proof configuration
+ */
+export const DEFAULT_LAZY_CONFIG: LazyProofConfig = {
+  trigger: 'manual',
+  priority: 'normal',
+  timeoutMs: 60000, // 1 minute
+  maxRetries: 2,
+  retryDelayMs: 1000,
+  prefetch: false,
+}
+
+/**
+ * Proof generator function type
+ */
+export type ProofGenerator<T = SingleProof> = (
+  signal: AbortSignal
+) => Promise<T>
+
+/**
+ * Event types for lazy proof
+ */
+export type LazyProofEventType =
+  | 'start'
+  | 'progress'
+  | 'complete'
+  | 'cancel'
+  | 'error'
+  | 'retry'
+
+/**
+ * Lazy proof event
+ */
+export interface LazyProofEvent {
+  readonly type: LazyProofEventType
+  readonly timestamp: number
+  readonly data?: {
+    readonly progress?: number
+    readonly error?: Error
+    readonly attempt?: number
+  }
+}
+
+/**
+ * Event listener for lazy proof
+ */
+export type LazyProofEventListener = (event: LazyProofEvent) => void
+
+/**
+ * Serialized lazy proof (for persistence)
+ */
+export interface SerializedLazyProof<T = SingleProof> {
+  readonly status: LazyProofStatus
+  readonly proof?: T
+  readonly error?: string
+  readonly config: LazyProofConfig
+  readonly metadata?: {
+    readonly system?: ProofSystem
+    readonly circuitId?: string
+    readonly createdAt: number
+    readonly resolvedAt?: number
+  }
+}
+
+// ─── LazyProof Class ──────────────────────────────────────────────────────────
+
+/**
+ * A lazy proof that defers generation until needed
+ */
+export class LazyProof<T = SingleProof> {
+  private _status: LazyProofStatus = 'pending'
+  private _proof: T | null = null
+  private _error: Error | null = null
+  private _promise: Promise<T> | null = null
+  private _abortController: AbortController | null = null
+  private _retryCount = 0
+  private _createdAt = Date.now()
+  private _resolvedAt: number | null = null
+  private readonly _listeners = new Set<LazyProofEventListener>()
+
+  readonly config: LazyProofConfig
+
+  constructor(
+    private readonly generator: ProofGenerator<T>,
+    config: Partial<LazyProofConfig> = {},
+    private readonly metadata?: {
+      system?: ProofSystem
+      circuitId?: string
+    }
+  ) {
+    this.config = { ...DEFAULT_LAZY_CONFIG, ...config }
+    // Start immediately if configured
+    if (this.config.trigger === 'immediate') {
+      this.resolve().catch(() => {})
+    }
+  }
+
+  /**
+   * Get the current status
+   */
+  get status(): LazyProofStatus {
+    return this._status
+  }
+
+  /**
+   * Check if the proof is resolved
+   */
+  get isResolved(): boolean {
+    return this._status === 'resolved'
+  }
+
+  /**
+   * Check if generation is in progress
+   */
+  get isGenerating(): boolean {
+    return this._status === 'generating'
+  }
+
+  /**
+   * Check if cancelled
+   */
+  get isCancelled(): boolean {
+    return this._status === 'cancelled'
+  }
+
+  /**
+   * Check if failed
+   */
+  get isFailed(): boolean {
+    return this._status === 'failed'
+  }
+
+  /**
+   * Get the proof (throws if not resolved)
+   */
+  get proof(): T {
+    if (!this._proof) {
+      throw new LazyProofError(
+        'Proof not yet resolved. Call resolve() first.',
+        'NOT_RESOLVED'
+      )
+    }
+    return this._proof
+  }
+
+  /**
+   * Get the proof if available (doesn't throw)
+   */
+  get proofOrNull(): T | null {
+    return this._proof
+  }
+
+  /**
+   * Get the error if failed
+   */
+  get error(): Error | null {
+    return this._error
+  }
+
+  /**
+   * Resolve (generate) the proof
+   */
+  async resolve(): Promise<T> {
+    // Already resolved
+    if (this._status === 'resolved' && this._proof) {
+      return this._proof
+    }
+
+    // Already generating - return existing promise
+    if (this._status === 'generating' && this._promise) {
+      return this._promise
+    }
+
+    // Cannot resolve cancelled proof
+    if (this._status === 'cancelled') {
+      throw new LazyProofError('Proof generation was cancelled', 'CANCELLED')
+    }
+
+    // Start generation
+    this._promise = this._generate()
+    return this._promise
+  }
+
+  /**
+   * Cancel proof generation
+   */
+  cancel(): boolean {
+    if (this._status === 'resolved' || this._status === 'cancelled') {
+      return false
+    }
+
+    this._status = 'cancelled'
+    this._abortController?.abort()
+    this._emit({ type: 'cancel', timestamp: Date.now() })
+    return true
+  }
+
+  /**
+   * Reset to pending state (allows re-generation)
+   */
+  reset(): void {
+    if (this._status === 'generating') {
+      this.cancel()
+    }
+
+    this._status = 'pending'
+    this._proof = null
+    this._error = null
+    this._promise = null
+    this._retryCount = 0
+  }
+
+  /**
+   * Add an event listener
+   */
+  addEventListener(listener: LazyProofEventListener): void {
+    this._listeners.add(listener)
+  }
+
+  /**
+   * Remove an event listener
+   */
+  removeEventListener(listener: LazyProofEventListener): void {
+    this._listeners.delete(listener)
+  }
+
+  /**
+   * Serialize the lazy proof
+   */
+  serialize(): SerializedLazyProof<T> {
+    // Trigger generation if configured
+    if (this.config.trigger === 'on-serialize' && this._status === 'pending') {
+      this.resolve().catch(() => {})
+    }
+
+    return {
+      status: this._status,
+      proof: this._proof ?? undefined,
+      error: this._error?.message,
+      config: this.config,
+      metadata: {
+        system: this.metadata?.system,
+        circuitId: this.metadata?.circuitId,
+        createdAt: this._createdAt,
+        resolvedAt: this._resolvedAt ?? undefined,
+      },
+    }
+  }
+
+  /**
+   * Create from serialized state
+   */
+  static deserialize<T = SingleProof>(
+    data: SerializedLazyProof<T>,
+    generator: ProofGenerator<T>
+  ): LazyProof<T> {
+    const lazy = new LazyProof<T>(generator, data.config, {
+      system: data.metadata?.system,
+      circuitId: data.metadata?.circuitId,
+    })
+
+    if (data.status === 'resolved' && data.proof) {
+      lazy._status = 'resolved'
+      lazy._proof = data.proof
+      lazy._resolvedAt = data.metadata?.resolvedAt ?? null
+    } else if (data.status === 'failed' && data.error) {
+      lazy._status = 'failed'
+      lazy._error = new Error(data.error)
+    } else if (data.status === 'cancelled') {
+      lazy._status = 'cancelled'
+    }
+
+    return lazy
+  }
+
+  // ─── Private Methods ────────────────────────────────────────────────────────
+
+  private async _generate(): Promise<T> {
+    this._status = 'generating'
+    this._abortController = new AbortController()
+    this._emit({ type: 'start', timestamp: Date.now() })
+
+    const { timeoutMs, maxRetries, retryDelayMs } = this.config
+
+    while (this._retryCount <= maxRetries) {
+      try {
+        // Create timeout if configured
+        const timeoutId = timeoutMs > 0
+          ? setTimeout(() => this._abortController?.abort(), timeoutMs)
+          : null
+
+        try {
+          const proof = await this.generator(this._abortController.signal)
+
+          // Success!
+          this._proof = proof
+          this._status = 'resolved'
+          this._resolvedAt = Date.now()
+          this._emit({ type: 'complete', timestamp: Date.now() })
+          return proof
+        } finally {
+          if (timeoutId) clearTimeout(timeoutId)
+        }
+      } catch (err) {
+        // Check if cancelled (cast needed - cancel() can be called concurrently)
+        if (this._abortController.signal.aborted) {
+          if ((this._status as LazyProofStatus) === 'cancelled') {
+            throw new LazyProofError('Proof generation was cancelled', 'CANCELLED')
+          }
+          throw new LazyProofError('Proof generation timed out', 'TIMEOUT')
+        }
+
+        // Retry logic
+        this._retryCount++
+        const error = err instanceof Error ? err : new Error(String(err))
+
+        if (this._retryCount <= maxRetries) {
+          this._emit({
+            type: 'retry',
+            timestamp: Date.now(),
+            data: { attempt: this._retryCount, error },
+          })
+          await this._delay(retryDelayMs)
+          // Create new abort controller for retry
+          this._abortController = new AbortController()
+        } else {
+          // Max retries exceeded
+          this._status = 'failed'
+          this._error = error
+          this._emit({ type: 'error', timestamp: Date.now(), data: { error } })
+          throw error
+        }
+      }
+    }
+
+    // Should never reach here
+    throw new LazyProofError('Unexpected error in proof generation', 'INTERNAL')
+  }
+
+  private _emit(event: LazyProofEvent): void {
+    for (const listener of this._listeners) {
+      try {
+        listener(event)
+      } catch {
+        // Ignore listener errors
+      }
+    }
+  }
+
+  private _delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+  }
+}
+
+// ─── Proof Generation Queue ───────────────────────────────────────────────────
+
+/**
+ * Queue item for proof generation
+ */
+interface QueueItem<T = SingleProof> {
+  readonly id: string
+  readonly lazy: LazyProof<T>
+  readonly priority: ProofPriority
+  readonly addedAt: number
+}
+
+/**
+ * Priority values for sorting
+ */
+const PRIORITY_VALUES: Record<ProofPriority, number> = {
+  critical: 4,
+  high: 3,
+  normal: 2,
+  low: 1,
+}
+
+/**
+ * Configuration for proof generation queue
+ */
+export interface ProofQueueConfig {
+  /** Maximum concurrent proof generations */
+  readonly maxConcurrent: number
+  /** Maximum queue size (0 = unlimited) */
+  readonly maxQueueSize: number
+  /** Enable automatic processing */
+  readonly autoProcess: boolean
+}
+
+/**
+ * Default queue configuration
+ */
+export const DEFAULT_QUEUE_CONFIG: ProofQueueConfig = {
+  maxConcurrent: 2,
+  maxQueueSize: 100,
+  autoProcess: true,
+}
+
+/**
+ * Queue statistics
+ */
+export interface QueueStats {
+  readonly queued: number
+  readonly processing: number
+  readonly completed: number
+  readonly failed: number
+  readonly cancelled: number
+}
+
+/**
+ * Priority queue for proof generation
+ */
+export class ProofGenerationQueue<T = SingleProof> {
+  private readonly queue: QueueItem<T>[] = []
+  private readonly processing = new Map<string, LazyProof<T>>()
+  private readonly config: ProofQueueConfig
+  private _completed = 0
+  private _failed = 0
+  private _cancelled = 0
+  private _idCounter = 0
+  private _isProcessing = false
+
+  constructor(config: Partial<ProofQueueConfig> = {}) {
+    this.config = { ...DEFAULT_QUEUE_CONFIG, ...config }
+  }
+
+  /**
+   * Add a lazy proof to the queue
+   */
+  enqueue(lazy: LazyProof<T>, priority?: ProofPriority): string {
+    if (
+      this.config.maxQueueSize > 0 &&
+      this.queue.length >= this.config.maxQueueSize
+    ) {
+      throw new LazyProofError('Queue is full', 'QUEUE_FULL')
+    }
+
+    const id = `proof-${++this._idCounter}`
+    const item: QueueItem<T> = {
+      id,
+      lazy,
+      priority: priority ?? lazy.config.priority,
+      addedAt: Date.now(),
+    }
+
+    // Insert in priority order
+    const insertIndex = this.queue.findIndex(
+      (q) => PRIORITY_VALUES[q.priority] < PRIORITY_VALUES[item.priority]
+    )
+
+    if (insertIndex === -1) {
+      this.queue.push(item)
+    } else {
+      this.queue.splice(insertIndex, 0, item)
+    }
+
+    // Auto-process if enabled
+    if (this.config.autoProcess) {
+      this._processNext()
+    }
+
+    return id
+  }
+
+  /**
+   * Remove a proof from the queue
+   */
+  dequeue(id: string): boolean {
+    const index = this.queue.findIndex((q) => q.id === id)
+    if (index !== -1) {
+      const [item] = this.queue.splice(index, 1)
+      item.lazy.cancel()
+      this._cancelled++
+      return true
+    }
+
+    // Check if currently processing
+    const processing = this.processing.get(id)
+    if (processing) {
+      processing.cancel()
+      this.processing.delete(id)
+      this._cancelled++
+      return true
+    }
+
+    return false
+  }
+
+  /**
+   * Process the queue manually
+   */
+  async process(): Promise<void> {
+    if (this._isProcessing) return
+
+    this._isProcessing = true
+
+    try {
+      while (this.queue.length > 0 || this.processing.size > 0) {
+        await this._processNext()
+        // Small delay to prevent tight loop
+        await new Promise((r) => setTimeout(r, 10))
+      }
+    } finally {
+      this._isProcessing = false
+    }
+  }
+
+  /**
+   * Cancel all pending and processing proofs
+   */
+  cancelAll(): number {
+    let cancelled = 0
+
+    // Cancel queued
+    for (const item of this.queue) {
+      item.lazy.cancel()
+      cancelled++
+    }
+    this.queue.length = 0
+
+    // Cancel processing
+    for (const [id, lazy] of this.processing) {
+      lazy.cancel()
+      this.processing.delete(id)
+      cancelled++
+    }
+
+    this._cancelled += cancelled
+    return cancelled
+  }
+
+  /**
+   * Get queue statistics
+   */
+  getStats(): QueueStats {
+    return {
+      queued: this.queue.length,
+      processing: this.processing.size,
+      completed: this._completed,
+      failed: this._failed,
+      cancelled: this._cancelled,
+    }
+  }
+
+  /**
+   * Get the current queue size
+   */
+  get size(): number {
+    return this.queue.length + this.processing.size
+  }
+
+  /**
+   * Check if queue is empty
+   */
+  get isEmpty(): boolean {
+    return this.queue.length === 0 && this.processing.size === 0
+  }
+
+  // ─── Private Methods ────────────────────────────────────────────────────────
+
+  private async _processNext(): Promise<void> {
+    // Check if we can process more
+    if (this.processing.size >= this.config.maxConcurrent) {
+      return
+    }
+
+    // Get next item
+    const item = this.queue.shift()
+    if (!item) return
+
+    // Start processing
+    this.processing.set(item.id, item.lazy)
+
+    try {
+      await item.lazy.resolve()
+      this._completed++
+    } catch {
+      if (item.lazy.isCancelled) {
+        this._cancelled++
+      } else {
+        this._failed++
+      }
+    } finally {
+      this.processing.delete(item.id)
+    }
+
+    // Process next if auto-process enabled
+    if (this.config.autoProcess && this.queue.length > 0) {
+      this._processNext()
+    }
+  }
+}
+
+// ─── Lazy Verification Key Loading ────────────────────────────────────────────
+
+/**
+ * A lazy-loaded verification key
+ */
+export class LazyVerificationKey {
+  private _vk: string | null = null
+  private _promise: Promise<string> | null = null
+  private _status: 'pending' | 'loading' | 'loaded' | 'failed' = 'pending'
+
+  constructor(
+    private readonly loader: () => Promise<string>,
+    private readonly _system: ProofSystem,
+    private readonly _circuitId: string
+  ) {}
+
+  /**
+   * Get the proof system this key belongs to
+   */
+  get system(): ProofSystem {
+    return this._system
+  }
+
+  /**
+   * Get the circuit ID
+   */
+  get circuitId(): string {
+    return this._circuitId
+  }
+
+  /**
+   * Get the verification key (loads if necessary)
+   */
+  async get(): Promise<string> {
+    if (this._vk) return this._vk
+
+    if (this._promise) return this._promise
+
+    this._status = 'loading'
+    this._promise = this._load()
+    return this._promise
+  }
+
+  /**
+   * Get the verification key synchronously (null if not loaded)
+   */
+  getSync(): string | null {
+    return this._vk
+  }
+
+  /**
+   * Check if loaded
+   */
+  get isLoaded(): boolean {
+    return this._status === 'loaded'
+  }
+
+  /**
+   * Preload the verification key
+   */
+  preload(): void {
+    if (this._status === 'pending') {
+      this.get().catch(() => {})
+    }
+  }
+
+  private async _load(): Promise<string> {
+    try {
+      this._vk = await this.loader()
+      this._status = 'loaded'
+      return this._vk
+    } catch (err) {
+      this._status = 'failed'
+      throw err
+    }
+  }
+}
+
+/**
+ * Registry for lazy verification keys
+ */
+export class VerificationKeyRegistry {
+  private readonly keys = new Map<string, LazyVerificationKey>()
+
+  /**
+   * Register a verification key loader
+   */
+  register(
+    system: ProofSystem,
+    circuitId: string,
+    loader: () => Promise<string>
+  ): void {
+    const key = this._makeKey(system, circuitId)
+    this.keys.set(key, new LazyVerificationKey(loader, system, circuitId))
+  }
+
+  /**
+   * Get a verification key
+   */
+  async get(system: ProofSystem, circuitId: string): Promise<string> {
+    const key = this._makeKey(system, circuitId)
+    const lazy = this.keys.get(key)
+
+    if (!lazy) {
+      throw new LazyProofError(
+        `No verification key registered for ${system}:${circuitId}`,
+        'VK_NOT_FOUND'
+      )
+    }
+
+    return lazy.get()
+  }
+
+  /**
+   * Preload verification keys for specified circuits
+   */
+  preload(circuits: Array<{ system: ProofSystem; circuitId: string }>): void {
+    for (const { system, circuitId } of circuits) {
+      const key = this._makeKey(system, circuitId)
+      this.keys.get(key)?.preload()
+    }
+  }
+
+  /**
+   * Preload all registered verification keys
+   */
+  preloadAll(): void {
+    for (const lazy of this.keys.values()) {
+      lazy.preload()
+    }
+  }
+
+  private _makeKey(system: ProofSystem, circuitId: string): string {
+    return `${system}:${circuitId}`
+  }
+}
+
+// ─── Speculative Prefetching ──────────────────────────────────────────────────
+
+/**
+ * Configuration for speculative prefetching
+ */
+export interface PrefetchConfig {
+  /** Maximum proofs to prefetch */
+  readonly maxPrefetch: number
+  /** Prefetch when likelihood exceeds this threshold (0-1) */
+  readonly likelihoodThreshold: number
+  /** Time window for access pattern analysis (ms) */
+  readonly analysisWindowMs: number
+}
+
+/**
+ * Default prefetch configuration
+ */
+export const DEFAULT_PREFETCH_CONFIG: PrefetchConfig = {
+  maxPrefetch: 5,
+  likelihoodThreshold: 0.7,
+  analysisWindowMs: 300000, // 5 minutes
+}
+
+/**
+ * Speculative prefetcher for proofs
+ */
+export class SpeculativePrefetcher<T = SingleProof> {
+  private readonly config: PrefetchConfig
+  private readonly accessHistory: Array<{
+    circuitId: string
+    timestamp: number
+  }> = []
+  private readonly prefetched = new Map<string, LazyProof<T>>()
+  private readonly generators = new Map<string, ProofGenerator<T>>()
+
+  constructor(config: Partial<PrefetchConfig> = {}) {
+    this.config = { ...DEFAULT_PREFETCH_CONFIG, ...config }
+  }
+
+  /**
+   * Register a proof generator for prefetching
+   */
+  register(circuitId: string, generator: ProofGenerator<T>): void {
+    this.generators.set(circuitId, generator)
+  }
+
+  /**
+   * Record an access and trigger prefetching
+   */
+  recordAccess(circuitId: string): void {
+    // Record access
+    this.accessHistory.push({ circuitId, timestamp: Date.now() })
+
+    // Trim old history
+    const cutoff = Date.now() - this.config.analysisWindowMs
+    while (this.accessHistory.length > 0 && this.accessHistory[0].timestamp < cutoff) {
+      this.accessHistory.shift()
+    }
+
+    // Analyze and prefetch
+    this._prefetchLikely()
+  }
+
+  /**
+   * Get a prefetched proof if available
+   */
+  getPrefetched(circuitId: string): LazyProof<T> | null {
+    return this.prefetched.get(circuitId) ?? null
+  }
+
+  /**
+   * Clear all prefetched proofs
+   */
+  clear(): void {
+    for (const lazy of this.prefetched.values()) {
+      lazy.cancel()
+    }
+    this.prefetched.clear()
+    this.accessHistory.length = 0
+  }
+
+  private _prefetchLikely(): void {
+    // Calculate access frequencies
+    const frequencies = new Map<string, number>()
+    for (const { circuitId } of this.accessHistory) {
+      frequencies.set(circuitId, (frequencies.get(circuitId) ?? 0) + 1)
+    }
+
+    // Calculate likelihoods
+    const total = this.accessHistory.length
+    const likelihoods: Array<{ circuitId: string; likelihood: number }> = []
+
+    for (const [circuitId, count] of frequencies) {
+      const likelihood = count / total
+      if (likelihood >= this.config.likelihoodThreshold) {
+        likelihoods.push({ circuitId, likelihood })
+      }
+    }
+
+    // Sort by likelihood
+    likelihoods.sort((a, b) => b.likelihood - a.likelihood)
+
+    // Prefetch top candidates (respecting maxPrefetch limit including existing)
+    for (const { circuitId } of likelihoods) {
+      // Check total prefetched count (existing + new)
+      if (this.prefetched.size >= this.config.maxPrefetch) break
+
+      // Skip if already prefetched
+      if (this.prefetched.has(circuitId)) continue
+
+      // Skip if no generator
+      const generator = this.generators.get(circuitId)
+      if (!generator) continue
+
+      // Create lazy proof with immediate trigger
+      const lazy = new LazyProof(generator, {
+        ...DEFAULT_LAZY_CONFIG,
+        trigger: 'immediate',
+        priority: 'low',
+      })
+
+      this.prefetched.set(circuitId, lazy)
+    }
+  }
+}
+
+// ─── Error Class ──────────────────────────────────────────────────────────────
+
+/**
+ * Error codes for lazy proof operations
+ */
+export type LazyProofErrorCode =
+  | 'NOT_RESOLVED'
+  | 'CANCELLED'
+  | 'TIMEOUT'
+  | 'QUEUE_FULL'
+  | 'VK_NOT_FOUND'
+  | 'INTERNAL'
+
+/**
+ * Error class for lazy proof operations
+ */
+export class LazyProofError extends Error {
+  constructor(
+    message: string,
+    public readonly code: LazyProofErrorCode
+  ) {
+    super(message)
+    this.name = 'LazyProofError'
+  }
+}
+
+// ─── Factory Functions ────────────────────────────────────────────────────────
+
+/**
+ * Create a lazy proof with default configuration
+ */
+export function createLazyProof<T = SingleProof>(
+  generator: ProofGenerator<T>,
+  config?: Partial<LazyProofConfig>,
+  metadata?: { system?: ProofSystem; circuitId?: string }
+): LazyProof<T> {
+  return new LazyProof<T>(
+    generator,
+    { ...DEFAULT_LAZY_CONFIG, ...config },
+    metadata
+  )
+}
+
+/**
+ * Create a proof generation queue
+ */
+export function createProofQueue<T = SingleProof>(
+  config?: Partial<ProofQueueConfig>
+): ProofGenerationQueue<T> {
+  return new ProofGenerationQueue<T>(config)
+}
+
+/**
+ * Create a verification key registry
+ */
+export function createVKRegistry(): VerificationKeyRegistry {
+  return new VerificationKeyRegistry()
+}
+
+/**
+ * Create a speculative prefetcher
+ */
+export function createPrefetcher<T = SingleProof>(
+  config?: Partial<PrefetchConfig>
+): SpeculativePrefetcher<T> {
+  return new SpeculativePrefetcher<T>(config)
+}

--- a/packages/sdk/tests/proofs/lazy.test.ts
+++ b/packages/sdk/tests/proofs/lazy.test.ts
@@ -1,0 +1,857 @@
+/**
+ * Tests for lazy proof generation
+ *
+ * M20-14: Add lazy proof generation support (#319)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { SingleProof } from '@sip-protocol/types'
+import {
+  LazyProof,
+  createLazyProof,
+  ProofGenerationQueue,
+  createProofQueue,
+  LazyVerificationKey,
+  VerificationKeyRegistry,
+  createVKRegistry,
+  SpeculativePrefetcher,
+  createPrefetcher,
+  LazyProofError,
+  DEFAULT_LAZY_CONFIG,
+  DEFAULT_QUEUE_CONFIG,
+  DEFAULT_PREFETCH_CONFIG,
+} from '../../src/proofs/lazy'
+
+// ─── Test Helpers ────────────────────────────────────────────────────────────
+
+const mockProof: SingleProof = {
+  id: 'test-proof-1',
+  proof: '0x1234',
+  publicInputs: ['0xabc'],
+  metadata: {
+    system: 'noir',
+    systemVersion: '1.0.0',
+    circuitId: 'test-circuit',
+    circuitVersion: '1.0.0',
+    generatedAt: Date.now(),
+    proofSizeBytes: 128,
+  },
+}
+
+function createMockGenerator(
+  proof: SingleProof = mockProof,
+  delay = 10
+): (signal: AbortSignal) => Promise<SingleProof> {
+  return async (signal: AbortSignal) => {
+    await new Promise((resolve, reject) => {
+      const timeout = setTimeout(resolve, delay)
+      signal.addEventListener('abort', () => {
+        clearTimeout(timeout)
+        reject(new Error('Aborted'))
+      })
+    })
+    return proof
+  }
+}
+
+function createFailingGenerator(
+  error: Error = new Error('Generation failed'),
+  delay = 10
+): (signal: AbortSignal) => Promise<SingleProof> {
+  return async (_signal: AbortSignal) => {
+    await new Promise((r) => setTimeout(r, delay))
+    throw error
+  }
+}
+
+// ─── LazyProof Tests ─────────────────────────────────────────────────────────
+
+describe('LazyProof', () => {
+  describe('construction', () => {
+    it('should start in pending state', () => {
+      const lazy = new LazyProof(createMockGenerator())
+      expect(lazy.status).toBe('pending')
+      expect(lazy.isResolved).toBe(false)
+      expect(lazy.isGenerating).toBe(false)
+    })
+
+    it('should use default config', () => {
+      const lazy = new LazyProof(createMockGenerator())
+      expect(lazy['config']).toEqual(DEFAULT_LAZY_CONFIG)
+    })
+
+    it('should merge custom config with defaults', () => {
+      const lazy = new LazyProof(createMockGenerator(), { priority: 'high' })
+      expect(lazy['config'].priority).toBe('high')
+      expect(lazy['config'].trigger).toBe(DEFAULT_LAZY_CONFIG.trigger)
+    })
+
+    it('should start immediately when trigger is immediate', async () => {
+      let called = false
+      const generator = async (signal: AbortSignal) => {
+        called = true
+        await new Promise((r) => setTimeout(r, 10))
+        return mockProof
+      }
+      const lazy = new LazyProof(generator, { trigger: 'immediate' })
+
+      // Wait a bit for the promise to start
+      await new Promise((r) => setTimeout(r, 5))
+      expect(called).toBe(true)
+
+      // Wait for completion
+      await lazy.resolve()
+      expect(lazy.status).toBe('resolved')
+    })
+  })
+
+  describe('resolve', () => {
+    it('should generate proof on resolve', async () => {
+      const lazy = new LazyProof(createMockGenerator())
+      expect(lazy.status).toBe('pending')
+
+      const proof = await lazy.resolve()
+      expect(proof).toEqual(mockProof)
+      expect(lazy.status).toBe('resolved')
+      expect(lazy.isResolved).toBe(true)
+      expect(lazy.proof).toEqual(mockProof)
+    })
+
+    it('should return cached proof on subsequent resolves', async () => {
+      const generator = vi.fn(createMockGenerator())
+      const lazy = new LazyProof(generator)
+
+      const proof1 = await lazy.resolve()
+      const proof2 = await lazy.resolve()
+
+      expect(proof1).toEqual(proof2)
+      expect(generator).toHaveBeenCalledTimes(1)
+    })
+
+    it('should return same proof when called multiple times during generation', async () => {
+      const lazy = new LazyProof(createMockGenerator(mockProof, 50))
+
+      // Start two resolves in parallel
+      const [proof1, proof2] = await Promise.all([lazy.resolve(), lazy.resolve()])
+
+      // Both should return the same proof
+      expect(proof1).toEqual(proof2)
+      expect(lazy.status).toBe('resolved')
+    })
+
+    it('should throw when accessing proof before resolve', () => {
+      const lazy = new LazyProof(createMockGenerator())
+      expect(() => lazy.proof).toThrow(LazyProofError)
+      expect(() => lazy.proof).toThrow('Proof not yet resolved')
+    })
+
+    it('should return null from proofOrNull before resolve', () => {
+      const lazy = new LazyProof(createMockGenerator())
+      expect(lazy.proofOrNull).toBeNull()
+    })
+  })
+
+  describe('cancellation', () => {
+    it('should cancel pending proof', () => {
+      const lazy = new LazyProof(createMockGenerator())
+      const cancelled = lazy.cancel()
+
+      expect(cancelled).toBe(true)
+      expect(lazy.status).toBe('cancelled')
+      expect(lazy.isCancelled).toBe(true)
+    })
+
+    it('should cancel generating proof', async () => {
+      const lazy = new LazyProof(createMockGenerator(mockProof, 1000))
+      const promise = lazy.resolve()
+
+      // Wait for generation to start
+      await new Promise((r) => setTimeout(r, 10))
+      expect(lazy.status).toBe('generating')
+
+      const cancelled = lazy.cancel()
+      expect(cancelled).toBe(true)
+
+      await expect(promise).rejects.toThrow('cancelled')
+      expect(lazy.status).toBe('cancelled')
+    })
+
+    it('should not cancel resolved proof', async () => {
+      const lazy = new LazyProof(createMockGenerator())
+      await lazy.resolve()
+
+      const cancelled = lazy.cancel()
+      expect(cancelled).toBe(false)
+      expect(lazy.status).toBe('resolved')
+    })
+
+    it('should not cancel already cancelled proof', () => {
+      const lazy = new LazyProof(createMockGenerator())
+      lazy.cancel()
+
+      const cancelled = lazy.cancel()
+      expect(cancelled).toBe(false)
+    })
+
+    it('should throw when resolving cancelled proof', async () => {
+      const lazy = new LazyProof(createMockGenerator())
+      lazy.cancel()
+
+      await expect(lazy.resolve()).rejects.toThrow('cancelled')
+    })
+  })
+
+  describe('reset', () => {
+    it('should reset resolved proof to pending', async () => {
+      const lazy = new LazyProof(createMockGenerator())
+      await lazy.resolve()
+      expect(lazy.status).toBe('resolved')
+
+      lazy.reset()
+      expect(lazy.status).toBe('pending')
+      expect(lazy.proofOrNull).toBeNull()
+    })
+
+    it('should cancel and reset generating proof', async () => {
+      const lazy = new LazyProof(createMockGenerator(mockProof, 1000))
+      lazy.resolve().catch(() => {})
+
+      await new Promise((r) => setTimeout(r, 10))
+      expect(lazy.status).toBe('generating')
+
+      lazy.reset()
+      expect(lazy.status).toBe('pending')
+    })
+
+    it('should allow re-generation after reset', async () => {
+      const generator = vi.fn(createMockGenerator())
+      const lazy = new LazyProof(generator)
+
+      await lazy.resolve()
+      lazy.reset()
+      await lazy.resolve()
+
+      expect(generator).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('retry logic', () => {
+    it('should retry on failure', async () => {
+      let attempts = 0
+      const generator = async (signal: AbortSignal) => {
+        attempts++
+        if (attempts < 3) {
+          throw new Error('Temporary failure')
+        }
+        return mockProof
+      }
+
+      const lazy = new LazyProof(generator, {
+        maxRetries: 2,
+        retryDelayMs: 10,
+      })
+
+      const proof = await lazy.resolve()
+      expect(proof).toEqual(mockProof)
+      expect(attempts).toBe(3) // 1 initial + 2 retries
+    })
+
+    it('should fail after max retries exceeded', async () => {
+      const generator = createFailingGenerator(new Error('Permanent failure'), 5)
+      const lazy = new LazyProof(generator, {
+        maxRetries: 1,
+        retryDelayMs: 5,
+      })
+
+      await expect(lazy.resolve()).rejects.toThrow('Permanent failure')
+      expect(lazy.status).toBe('failed')
+      expect(lazy.isFailed).toBe(true)
+      expect(lazy.error?.message).toBe('Permanent failure')
+    })
+  })
+
+  describe('timeout', () => {
+    it('should timeout when generation takes too long', async () => {
+      const lazy = new LazyProof(createMockGenerator(mockProof, 1000), {
+        timeoutMs: 50,
+        maxRetries: 0,
+      })
+
+      await expect(lazy.resolve()).rejects.toThrow('timed out')
+    })
+  })
+
+  describe('events', () => {
+    it('should emit start event', async () => {
+      const listener = vi.fn()
+      const lazy = new LazyProof(createMockGenerator())
+      lazy.addEventListener(listener)
+
+      await lazy.resolve()
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'start' })
+      )
+    })
+
+    it('should emit complete event', async () => {
+      const listener = vi.fn()
+      const lazy = new LazyProof(createMockGenerator())
+      lazy.addEventListener(listener)
+
+      await lazy.resolve()
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'complete' })
+      )
+    })
+
+    it('should emit cancel event', () => {
+      const listener = vi.fn()
+      const lazy = new LazyProof(createMockGenerator())
+      lazy.addEventListener(listener)
+
+      lazy.cancel()
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'cancel' })
+      )
+    })
+
+    it('should emit retry event', async () => {
+      let attempts = 0
+      const generator = async (signal: AbortSignal) => {
+        attempts++
+        if (attempts < 2) throw new Error('Fail')
+        return mockProof
+      }
+
+      const listener = vi.fn()
+      const lazy = new LazyProof(generator, {
+        maxRetries: 1,
+        retryDelayMs: 5,
+      })
+      lazy.addEventListener(listener)
+
+      await lazy.resolve()
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'retry', data: expect.objectContaining({ attempt: 1 }) })
+      )
+    })
+
+    it('should emit error event on failure', async () => {
+      const listener = vi.fn()
+      const lazy = new LazyProof(createFailingGenerator(), {
+        maxRetries: 0,
+      })
+      lazy.addEventListener(listener)
+
+      await lazy.resolve().catch(() => {})
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error' })
+      )
+    })
+
+    it('should remove event listener', async () => {
+      const listener = vi.fn()
+      const lazy = new LazyProof(createMockGenerator())
+      lazy.addEventListener(listener)
+      lazy.removeEventListener(listener)
+
+      await lazy.resolve()
+
+      expect(listener).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('serialization', () => {
+    it('should serialize pending proof', () => {
+      const lazy = new LazyProof(createMockGenerator())
+      const serialized = lazy.serialize()
+
+      expect(serialized.status).toBe('pending')
+      expect(serialized.proof).toBeUndefined()
+      expect(serialized.config).toEqual(DEFAULT_LAZY_CONFIG)
+    })
+
+    it('should serialize resolved proof', async () => {
+      const lazy = new LazyProof(createMockGenerator(), undefined, {
+        system: 'noir',
+        circuitId: 'test',
+      })
+      await lazy.resolve()
+      const serialized = lazy.serialize()
+
+      expect(serialized.status).toBe('resolved')
+      expect(serialized.proof).toEqual(mockProof)
+      expect(serialized.metadata?.system).toBe('noir')
+      expect(serialized.metadata?.circuitId).toBe('test')
+    })
+
+    it('should deserialize resolved proof', async () => {
+      const lazy = new LazyProof(createMockGenerator())
+      await lazy.resolve()
+      const serialized = lazy.serialize()
+
+      const restored = LazyProof.deserialize(serialized, createMockGenerator())
+      expect(restored.status).toBe('resolved')
+      expect(restored.proof).toEqual(mockProof)
+    })
+
+    it('should trigger generation on serialize when configured', async () => {
+      let called = false
+      const generator = async (_signal: AbortSignal) => {
+        called = true
+        await new Promise((r) => setTimeout(r, 10))
+        return mockProof
+      }
+      const lazy = new LazyProof(generator, { trigger: 'on-serialize' })
+
+      lazy.serialize()
+
+      // Wait a tick for the promise to start
+      await new Promise((r) => setTimeout(r, 5))
+      expect(called).toBe(true)
+    })
+  })
+})
+
+// ─── Factory Function Tests ──────────────────────────────────────────────────
+
+describe('createLazyProof', () => {
+  it('should create lazy proof with defaults', () => {
+    const lazy = createLazyProof(createMockGenerator())
+    expect(lazy).toBeInstanceOf(LazyProof)
+    expect(lazy.status).toBe('pending')
+  })
+
+  it('should create lazy proof with custom config', () => {
+    const lazy = createLazyProof(createMockGenerator(), { priority: 'critical' })
+    expect(lazy['config'].priority).toBe('critical')
+  })
+})
+
+// ─── ProofGenerationQueue Tests ──────────────────────────────────────────────
+
+describe('ProofGenerationQueue', () => {
+  describe('construction', () => {
+    it('should use default config', () => {
+      const queue = new ProofGenerationQueue()
+      expect(queue['config']).toEqual(DEFAULT_QUEUE_CONFIG)
+    })
+
+    it('should merge custom config', () => {
+      const queue = new ProofGenerationQueue({ maxConcurrent: 4 })
+      expect(queue['config'].maxConcurrent).toBe(4)
+      expect(queue['config'].maxQueueSize).toBe(DEFAULT_QUEUE_CONFIG.maxQueueSize)
+    })
+  })
+
+  describe('enqueue', () => {
+    it('should add proof to queue', () => {
+      const queue = new ProofGenerationQueue({ autoProcess: false })
+      const lazy = new LazyProof(createMockGenerator())
+
+      const id = queue.enqueue(lazy)
+      expect(id).toMatch(/^proof-\d+$/)
+      expect(queue.size).toBe(1)
+    })
+
+    it('should order by priority', () => {
+      const queue = new ProofGenerationQueue({ autoProcess: false })
+      const low = new LazyProof(createMockGenerator(), { priority: 'low' })
+      const high = new LazyProof(createMockGenerator(), { priority: 'high' })
+      const critical = new LazyProof(createMockGenerator(), { priority: 'critical' })
+
+      queue.enqueue(low)
+      queue.enqueue(high)
+      queue.enqueue(critical)
+
+      // Critical should be first
+      expect(queue['queue'][0].lazy).toBe(critical)
+      expect(queue['queue'][1].lazy).toBe(high)
+      expect(queue['queue'][2].lazy).toBe(low)
+    })
+
+    it('should override priority when specified', () => {
+      const queue = new ProofGenerationQueue({ autoProcess: false })
+      const lazy = new LazyProof(createMockGenerator(), { priority: 'low' })
+
+      queue.enqueue(lazy, 'critical')
+      expect(queue['queue'][0].priority).toBe('critical')
+    })
+
+    it('should throw when queue is full', () => {
+      const queue = new ProofGenerationQueue({ maxQueueSize: 2, autoProcess: false })
+      queue.enqueue(new LazyProof(createMockGenerator()))
+      queue.enqueue(new LazyProof(createMockGenerator()))
+
+      expect(() => queue.enqueue(new LazyProof(createMockGenerator()))).toThrow('Queue is full')
+    })
+  })
+
+  describe('dequeue', () => {
+    it('should remove proof from queue', () => {
+      const queue = new ProofGenerationQueue({ autoProcess: false })
+      const lazy = new LazyProof(createMockGenerator())
+      const id = queue.enqueue(lazy)
+
+      const removed = queue.dequeue(id)
+      expect(removed).toBe(true)
+      expect(queue.size).toBe(0)
+      expect(lazy.isCancelled).toBe(true)
+    })
+
+    it('should return false for non-existent id', () => {
+      const queue = new ProofGenerationQueue()
+      expect(queue.dequeue('non-existent')).toBe(false)
+    })
+  })
+
+  describe('processing', () => {
+    it('should auto-process when enabled', async () => {
+      const queue = new ProofGenerationQueue({ autoProcess: true })
+      const lazy = new LazyProof(createMockGenerator(mockProof, 10))
+
+      queue.enqueue(lazy)
+      await new Promise((r) => setTimeout(r, 50))
+
+      expect(lazy.status).toBe('resolved')
+    })
+
+    it('should respect maxConcurrent', async () => {
+      const queue = new ProofGenerationQueue({ maxConcurrent: 2, autoProcess: true })
+      const lazy1 = new LazyProof(createMockGenerator(mockProof, 100))
+      const lazy2 = new LazyProof(createMockGenerator(mockProof, 100))
+      const lazy3 = new LazyProof(createMockGenerator(mockProof, 100))
+
+      queue.enqueue(lazy1)
+      queue.enqueue(lazy2)
+      queue.enqueue(lazy3)
+
+      await new Promise((r) => setTimeout(r, 20))
+
+      // Only 2 should be processing, 1 should be pending
+      const stats = queue.getStats()
+      expect(stats.processing).toBeLessThanOrEqual(2)
+    })
+
+    it('should process manually when autoProcess is false', async () => {
+      const queue = new ProofGenerationQueue({ autoProcess: false })
+      const lazy = new LazyProof(createMockGenerator(mockProof, 10))
+
+      queue.enqueue(lazy)
+      expect(lazy.status).toBe('pending')
+
+      await queue.process()
+      expect(lazy.status).toBe('resolved')
+    })
+  })
+
+  describe('cancelAll', () => {
+    it('should cancel all queued and processing proofs', async () => {
+      const queue = new ProofGenerationQueue({ autoProcess: true, maxConcurrent: 1 })
+      const lazy1 = new LazyProof(createMockGenerator(mockProof, 1000))
+      const lazy2 = new LazyProof(createMockGenerator(mockProof, 1000))
+
+      queue.enqueue(lazy1)
+      queue.enqueue(lazy2)
+
+      await new Promise((r) => setTimeout(r, 10))
+      const cancelled = queue.cancelAll()
+
+      expect(cancelled).toBeGreaterThanOrEqual(1)
+      expect(queue.isEmpty).toBe(true)
+    })
+  })
+
+  describe('stats', () => {
+    it('should track statistics', async () => {
+      const queue = new ProofGenerationQueue({ autoProcess: false })
+      queue.enqueue(new LazyProof(createMockGenerator(mockProof, 5)))
+      queue.enqueue(new LazyProof(createFailingGenerator(new Error('fail'), 5), { maxRetries: 0 }))
+
+      await queue.process()
+      const stats = queue.getStats()
+
+      expect(stats.completed).toBe(1)
+      expect(stats.failed).toBe(1)
+    })
+  })
+})
+
+describe('createProofQueue', () => {
+  it('should create queue with defaults', () => {
+    const queue = createProofQueue()
+    expect(queue).toBeInstanceOf(ProofGenerationQueue)
+  })
+})
+
+// ─── LazyVerificationKey Tests ───────────────────────────────────────────────
+
+describe('LazyVerificationKey', () => {
+  it('should start in pending state', () => {
+    const vk = new LazyVerificationKey(
+      async () => '0xvk123',
+      'noir',
+      'test-circuit'
+    )
+    expect(vk.isLoaded).toBe(false)
+    expect(vk.getSync()).toBeNull()
+  })
+
+  it('should expose system and circuitId', () => {
+    const vk = new LazyVerificationKey(
+      async () => '0xvk123',
+      'noir',
+      'test-circuit'
+    )
+    expect(vk.system).toBe('noir')
+    expect(vk.circuitId).toBe('test-circuit')
+  })
+
+  it('should load on get', async () => {
+    const vk = new LazyVerificationKey(
+      async () => '0xvk123',
+      'noir',
+      'test-circuit'
+    )
+
+    const key = await vk.get()
+    expect(key).toBe('0xvk123')
+    expect(vk.isLoaded).toBe(true)
+    expect(vk.getSync()).toBe('0xvk123')
+  })
+
+  it('should return cached value on subsequent gets', async () => {
+    const loader = vi.fn(async () => '0xvk123')
+    const vk = new LazyVerificationKey(loader, 'noir', 'test-circuit')
+
+    await vk.get()
+    await vk.get()
+
+    expect(loader).toHaveBeenCalledTimes(1)
+  })
+
+  it('should preload without waiting', async () => {
+    const loader = vi.fn(async () => {
+      await new Promise((r) => setTimeout(r, 10))
+      return '0xvk123'
+    })
+    const vk = new LazyVerificationKey(loader, 'noir', 'test-circuit')
+
+    vk.preload()
+    expect(loader).toHaveBeenCalled()
+    expect(vk.isLoaded).toBe(false)
+
+    await new Promise((r) => setTimeout(r, 20))
+    expect(vk.isLoaded).toBe(true)
+  })
+})
+
+// ─── VerificationKeyRegistry Tests ───────────────────────────────────────────
+
+describe('VerificationKeyRegistry', () => {
+  it('should register and retrieve keys', async () => {
+    const registry = new VerificationKeyRegistry()
+    registry.register('noir', 'circuit1', async () => '0xvk1')
+    registry.register('halo2', 'circuit2', async () => '0xvk2')
+
+    const vk1 = await registry.get('noir', 'circuit1')
+    const vk2 = await registry.get('halo2', 'circuit2')
+
+    expect(vk1).toBe('0xvk1')
+    expect(vk2).toBe('0xvk2')
+  })
+
+  it('should throw for unregistered key', async () => {
+    const registry = new VerificationKeyRegistry()
+    await expect(registry.get('noir', 'unknown')).rejects.toThrow('No verification key registered')
+  })
+
+  it('should preload specific circuits', async () => {
+    const loader1 = vi.fn(async () => '0xvk1')
+    const loader2 = vi.fn(async () => '0xvk2')
+
+    const registry = new VerificationKeyRegistry()
+    registry.register('noir', 'circuit1', loader1)
+    registry.register('halo2', 'circuit2', loader2)
+
+    registry.preload([{ system: 'noir', circuitId: 'circuit1' }])
+
+    await new Promise((r) => setTimeout(r, 10))
+    expect(loader1).toHaveBeenCalled()
+    expect(loader2).not.toHaveBeenCalled()
+  })
+
+  it('should preload all keys', async () => {
+    const loader1 = vi.fn(async () => '0xvk1')
+    const loader2 = vi.fn(async () => '0xvk2')
+
+    const registry = new VerificationKeyRegistry()
+    registry.register('noir', 'circuit1', loader1)
+    registry.register('halo2', 'circuit2', loader2)
+
+    registry.preloadAll()
+
+    await new Promise((r) => setTimeout(r, 10))
+    expect(loader1).toHaveBeenCalled()
+    expect(loader2).toHaveBeenCalled()
+  })
+})
+
+describe('createVKRegistry', () => {
+  it('should create registry', () => {
+    const registry = createVKRegistry()
+    expect(registry).toBeInstanceOf(VerificationKeyRegistry)
+  })
+})
+
+// ─── SpeculativePrefetcher Tests ─────────────────────────────────────────────
+
+describe('SpeculativePrefetcher', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should use default config', () => {
+    const prefetcher = new SpeculativePrefetcher()
+    expect(prefetcher['config']).toEqual(DEFAULT_PREFETCH_CONFIG)
+  })
+
+  it('should register generators', () => {
+    const prefetcher = new SpeculativePrefetcher()
+    const generator = createMockGenerator()
+
+    prefetcher.register('circuit1', generator)
+    expect(prefetcher['generators'].has('circuit1')).toBe(true)
+  })
+
+  it('should prefetch based on access patterns', () => {
+    vi.useRealTimers()
+
+    const prefetcher = new SpeculativePrefetcher({
+      likelihoodThreshold: 0.5,
+      maxPrefetch: 2,
+    })
+
+    prefetcher.register('circuit1', createMockGenerator())
+    prefetcher.register('circuit2', createMockGenerator())
+
+    // Record enough accesses to trigger prefetch
+    for (let i = 0; i < 5; i++) {
+      prefetcher.recordAccess('circuit1')
+    }
+
+    const prefetched = prefetcher.getPrefetched('circuit1')
+    expect(prefetched).not.toBeNull()
+    expect(prefetched?.status).toBe('generating')
+  })
+
+  it('should not prefetch below threshold', () => {
+    vi.useRealTimers()
+
+    const prefetcher = new SpeculativePrefetcher({
+      likelihoodThreshold: 0.9,
+      maxPrefetch: 2,
+    })
+
+    // Only register one circuit, but also access an unregistered one
+    // This dilutes the likelihood below threshold
+    prefetcher.register('circuit1', createMockGenerator())
+
+    // Access circuit1 twice, and an unregistered "circuit2" 8 times
+    // circuit1 likelihood = 2/10 = 20% (below 90%)
+    prefetcher.recordAccess('circuit2') // unregistered
+    prefetcher.recordAccess('circuit2')
+    prefetcher.recordAccess('circuit2')
+    prefetcher.recordAccess('circuit2')
+    prefetcher.recordAccess('circuit1')
+    prefetcher.recordAccess('circuit2')
+    prefetcher.recordAccess('circuit2')
+    prefetcher.recordAccess('circuit2')
+    prefetcher.recordAccess('circuit1')
+    prefetcher.recordAccess('circuit2')
+
+    // circuit1 has 20% likelihood, below 90% threshold
+    expect(prefetcher.getPrefetched('circuit1')).toBeNull()
+  })
+
+  it('should clear prefetched proofs', () => {
+    vi.useRealTimers()
+
+    const prefetcher = new SpeculativePrefetcher({
+      likelihoodThreshold: 0.5,
+    })
+
+    prefetcher.register('circuit1', createMockGenerator())
+
+    // Trigger prefetch
+    for (let i = 0; i < 3; i++) {
+      prefetcher.recordAccess('circuit1')
+    }
+
+    expect(prefetcher.getPrefetched('circuit1')).not.toBeNull()
+
+    prefetcher.clear()
+
+    expect(prefetcher.getPrefetched('circuit1')).toBeNull()
+  })
+
+  it('should respect maxPrefetch limit', () => {
+    vi.useRealTimers()
+
+    // The prefetcher evaluates likelihood after EVERY access.
+    // With maxPrefetch=1, only 1 circuit should be prefetched even if multiple reach threshold.
+    const prefetcher = new SpeculativePrefetcher({
+      likelihoodThreshold: 0.5, // 50%
+      maxPrefetch: 1,
+    })
+
+    prefetcher.register('circuit1', createMockGenerator())
+    prefetcher.register('circuit2', createMockGenerator())
+
+    // First access: circuit1 = 100% → prefetched (maxPrefetch=1 reached)
+    prefetcher.recordAccess('circuit1')
+
+    // Second access: circuit1 = 50%, circuit2 = 50% → circuit2 meets threshold but limit reached
+    prefetcher.recordAccess('circuit2')
+
+    // More accesses to circuit2 to push its likelihood higher
+    prefetcher.recordAccess('circuit2')
+    prefetcher.recordAccess('circuit2')
+    // Now: circuit1 = 1/4 = 25%, circuit2 = 3/4 = 75%
+
+    // circuit1 was prefetched first (100% likelihood on first access)
+    // circuit2 is NOT prefetched despite higher likelihood because maxPrefetch=1
+    const prefetched1 = prefetcher.getPrefetched('circuit1')
+    const prefetched2 = prefetcher.getPrefetched('circuit2')
+
+    expect(prefetched1).not.toBeNull()
+    expect(prefetched2).toBeNull() // maxPrefetch limit prevents this
+  })
+})
+
+describe('createPrefetcher', () => {
+  it('should create prefetcher with defaults', () => {
+    const prefetcher = createPrefetcher()
+    expect(prefetcher).toBeInstanceOf(SpeculativePrefetcher)
+  })
+})
+
+// ─── LazyProofError Tests ────────────────────────────────────────────────────
+
+describe('LazyProofError', () => {
+  it('should have correct name and code', () => {
+    const error = new LazyProofError('Test error', 'CANCELLED')
+    expect(error.name).toBe('LazyProofError')
+    expect(error.code).toBe('CANCELLED')
+    expect(error.message).toBe('Test error')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds lazy proof generation support with deferred computation
- Implements proof generation queue with priority-based ordering
- Adds verification key lazy loading and registry
- Implements speculative prefetching based on access patterns

**M20-14: Add lazy proof generation support**

## Features

### LazyProof Class
- Status tracking (`pending`, `generating`, `resolved`, `cancelled`, `failed`)
- Resolution with AbortController-based cancellation
- Retry logic with configurable attempts and delays
- Timeout support
- Event system for lifecycle monitoring
- Serialization/deserialization for persistence

### ProofGenerationQueue
- Priority-based ordering (critical > high > normal > low)
- Configurable concurrency (`maxConcurrent`)
- Queue size limits (`maxQueueSize`)
- Auto-processing mode
- Statistics tracking (queued, processing, completed, failed, cancelled)

### LazyVerificationKey & VerificationKeyRegistry
- Lazy loading of verification keys
- Preload support for warming
- Circuit-specific key management

### SpeculativePrefetcher
- Access pattern analysis
- Likelihood-based prefetching
- Configurable threshold and limits

## Test plan

- [x] 64 new tests for lazy proof module
- [x] All 668 proof tests pass
- [x] TypeScript type checking passes

Closes #319

🔗 Related to M20: Proof Composition milestone