### PR TITLE
feat(sdk): add BNB Chain (BSC) support (M20-26)

### DIFF
--- a/contracts/sip-ethereum/foundry.toml
+++ b/contracts/sip-ethereum/foundry.toml
@@ -27,6 +27,9 @@ arbitrum = { key = "${ARBISCAN_API_KEY}" }
 arbitrum_sepolia = { key = "${ARBISCAN_API_KEY}" }
 optimism = { key = "${OPTIMISM_ETHERSCAN_API_KEY}" }
 optimism_sepolia = { key = "${OPTIMISM_ETHERSCAN_API_KEY}" }
+# BNB Chain (Alt L1 - 4.32M DAU, #1 by daily active wallets)
+bsc = { key = "${BSCSCAN_API_KEY}", url = "https://api.bscscan.com/api" }
+bsc_testnet = { key = "${BSCSCAN_API_KEY}", url = "https://api-testnet.bscscan.com/api" }
 
 [rpc_endpoints]
 # Mainnet
@@ -41,3 +44,6 @@ arbitrum_sepolia = "${ARBITRUM_SEPOLIA_RPC_URL}"
 # Optimism (6% TVL - High priority)
 optimism = "${OPTIMISM_RPC_URL}"
 optimism_sepolia = "${OPTIMISM_SEPOLIA_RPC_URL}"
+# BNB Chain (4.32M DAU - Highest daily active wallets)
+bsc = "${BSC_RPC_URL}"
+bsc_testnet = "${BSC_TESTNET_RPC_URL}"

--- a/packages/sdk/src/chains/ethereum/constants.ts
+++ b/packages/sdk/src/chains/ethereum/constants.ts
@@ -38,6 +38,8 @@ export type EthereumNetwork =
   | 'linea'
   | 'mantle'
   | 'blast'
+  | 'bsc'
+  | 'bsc-testnet'
   | 'localhost'
 
 /**
@@ -60,6 +62,8 @@ export const EVM_CHAIN_IDS: Record<EthereumNetwork, number> = {
   linea: 59144,
   mantle: 5000,
   blast: 81457,
+  bsc: 56,
+  'bsc-testnet': 97,
   localhost: 31337,
 } as const
 
@@ -84,6 +88,8 @@ export const ETHEREUM_RPC_ENDPOINTS: Record<EthereumNetwork, string> = {
   linea: getEnvVar('LINEA_MAINNET_RPC', 'https://rpc.linea.build'),
   mantle: getEnvVar('MANTLE_MAINNET_RPC', 'https://rpc.mantle.xyz'),
   blast: getEnvVar('BLAST_MAINNET_RPC', 'https://rpc.blast.io'),
+  bsc: getEnvVar('BSC_MAINNET_RPC', 'https://bsc-dataseed.binance.org'),
+  'bsc-testnet': getEnvVar('BSC_TESTNET_RPC', 'https://data-seed-prebsc-1-s1.binance.org:8545'),
   localhost: getEnvVar('ETH_LOCALHOST_RPC', 'http://localhost:8545'),
 } as const
 
@@ -107,6 +113,8 @@ export const ETHEREUM_EXPLORER_URLS: Record<EthereumNetwork, string> = {
   linea: 'https://lineascan.build',
   mantle: 'https://explorer.mantle.xyz',
   blast: 'https://blastscan.io',
+  bsc: 'https://bscscan.com',
+  'bsc-testnet': 'https://testnet.bscscan.com',
   localhost: 'http://localhost:8545',
 } as const
 
@@ -143,6 +151,80 @@ export const ETHEREUM_TOKEN_DECIMALS: Record<string, number> = {
   UNI: 18,
   AAVE: 18,
 }
+
+/**
+ * Common BEP-20 token addresses on BNB Chain (BSC) mainnet
+ */
+export const BSC_TOKEN_CONTRACTS = {
+  /** Wrapped BNB */
+  WBNB: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
+  /** Binance-Peg USD Coin */
+  USDC: '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
+  /** Binance-Peg Tether USD */
+  USDT: '0x55d398326f99059fF775485246999027B3197955',
+  /** Binance-Peg DAI */
+  DAI: '0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3',
+  /** Binance-Peg Chainlink */
+  LINK: '0xF8A0BF9cF54Bb92F17374d9e9A321E6a111a51bD',
+  /** PancakeSwap Token */
+  CAKE: '0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82',
+  /** Binance-Peg Ethereum */
+  ETH: '0x2170Ed0880ac9A755fd29B2688956BD959F933F8',
+  /** Binance-Peg BTCB */
+  BTCB: '0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c',
+} as const
+
+/**
+ * Token decimals for BNB Chain tokens
+ */
+export const BSC_TOKEN_DECIMALS: Record<string, number> = {
+  BNB: 18,
+  WBNB: 18,
+  USDC: 18, // Note: BSC USDC uses 18 decimals, not 6
+  USDT: 18, // Note: BSC USDT uses 18 decimals, not 6
+  DAI: 18,
+  LINK: 18,
+  CAKE: 18,
+  ETH: 18,
+  BTCB: 18,
+}
+
+/**
+ * PancakeSwap contract addresses on BNB Chain (BSC)
+ * PancakeSwap is the dominant DEX on BSC (like Uniswap on Ethereum)
+ */
+export const PANCAKESWAP_CONTRACTS = {
+  /** PancakeSwap V3 SmartRouter (preferred for best routing) */
+  SMART_ROUTER: '0x13f4EA83D0bd40E75C8222255bc855a974568Dd4',
+  /** PancakeSwap V3 Router */
+  V3_ROUTER: '0x1b81D678ffb9C0263b24A97847620C99d213eB14',
+  /** PancakeSwap V2 Router (legacy, still widely used) */
+  V2_ROUTER: '0x10ED43C718714eb63d5aA57B78B54704E256024E',
+  /** PancakeSwap V3 Factory */
+  V3_FACTORY: '0x0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865',
+  /** PancakeSwap V2 Factory */
+  V2_FACTORY: '0xcA143Ce32Fe78f1f7019d7d551a6402fC5350c73',
+  /** PancakeSwap Quoter V2 (for price quotes) */
+  QUOTER_V2: '0xB048Bbc1Ee6b733FFfCFb9e9CeF7375518e25997',
+} as const
+
+/**
+ * PancakeSwap contract addresses on BSC Testnet
+ */
+export const PANCAKESWAP_TESTNET_CONTRACTS = {
+  /** PancakeSwap V3 SmartRouter */
+  SMART_ROUTER: '0x9a489505a00cE272eAa5e07Dba6491314CaE3796',
+  /** PancakeSwap V3 Router */
+  V3_ROUTER: '0x1b81D678ffb9C0263b24A97847620C99d213eB14',
+  /** PancakeSwap V2 Router */
+  V2_ROUTER: '0xD99D1c33F9fC3444f8101754aBC46c52416550D1',
+  /** PancakeSwap V3 Factory */
+  V3_FACTORY: '0x0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865',
+  /** PancakeSwap V2 Factory */
+  V2_FACTORY: '0x6725F303b657a9451d8BA641348b6761A6CC7a17',
+  /** PancakeSwap Quoter V2 */
+  QUOTER_V2: '0xbC203d7f83677c7ed3F7acEc959963E7F4ECC5C2',
+} as const
 
 /**
  * EIP-5564 Stealth Address Announcer contract address
@@ -298,6 +380,7 @@ export function isTestnet(network: EthereumNetwork): boolean {
     network === 'optimism-sepolia' ||
     network === 'base-sepolia' ||
     network === 'polygon-mumbai' ||
+    network === 'bsc-testnet' ||
     network === 'localhost'
   )
 }
@@ -316,6 +399,13 @@ export function isL2Network(network: EthereumNetwork): boolean {
     network === 'polygon' ||
     network === 'polygon-mumbai'
   )
+}
+
+/**
+ * Check if a network is an alternative L1 (non-Ethereum mainnet EVM chain)
+ */
+export function isAltL1Network(network: EthereumNetwork): boolean {
+  return network === 'bsc' || network === 'bsc-testnet'
 }
 
 /**

--- a/packages/sdk/src/chains/ethereum/gas-estimation.ts
+++ b/packages/sdk/src/chains/ethereum/gas-estimation.ts
@@ -180,6 +180,8 @@ const NETWORK_GAS_PRICES: Record<EthereumNetwork, bigint> = {
   linea: ONE_GWEI / 10n,
   mantle: ONE_GWEI / 10n,
   blast: ONE_GWEI / 10n,
+  bsc: 3n * ONE_GWEI, // BSC mainnet ~3-5 gwei
+  'bsc-testnet': 1n * ONE_GWEI,
   localhost: 1n * ONE_GWEI,
 }
 

--- a/packages/sdk/tests/chains/ethereum/bsc.test.ts
+++ b/packages/sdk/tests/chains/ethereum/bsc.test.ts
@@ -1,0 +1,285 @@
+/**
+ * BNB Chain (BSC) Support Tests
+ *
+ * Tests for BNB Chain configuration, token addresses, and PancakeSwap integration.
+ *
+ * @see packages/sdk/src/chains/ethereum/constants.ts
+ * @see https://github.com/sip-protocol/sip-protocol/issues/425
+ *
+ * M20-26: BNB Chain support (reuse M18 Solidity contract)
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import {
+  EVM_CHAIN_IDS,
+  ETHEREUM_RPC_ENDPOINTS,
+  ETHEREUM_EXPLORER_URLS,
+  BSC_TOKEN_CONTRACTS,
+  BSC_TOKEN_DECIMALS,
+  PANCAKESWAP_CONTRACTS,
+  PANCAKESWAP_TESTNET_CONTRACTS,
+  ONE_GWEI,
+  getChainId,
+  getNetworkFromChainId,
+  isTestnet,
+  isL2Network,
+  isAltL1Network,
+  getExplorerUrl,
+  getAddressExplorerUrl,
+  isValidEthAddress,
+} from '../../../src/chains/ethereum/constants'
+
+import {
+  getGasPriceSuggestion,
+} from '../../../src/chains/ethereum/gas-estimation'
+
+// ─── Chain Configuration Tests ───────────────────────────────────────────────
+
+describe('BNB Chain Configuration', () => {
+  describe('Chain IDs', () => {
+    it('should have correct BSC mainnet chain ID', () => {
+      expect(EVM_CHAIN_IDS.bsc).toBe(56)
+    })
+
+    it('should have correct BSC testnet chain ID', () => {
+      expect(EVM_CHAIN_IDS['bsc-testnet']).toBe(97)
+    })
+
+    it('should resolve BSC network from chain ID', () => {
+      expect(getNetworkFromChainId(56)).toBe('bsc')
+      expect(getNetworkFromChainId(97)).toBe('bsc-testnet')
+    })
+
+    it('should get chain ID from network name', () => {
+      expect(getChainId('bsc')).toBe(56)
+      expect(getChainId('bsc-testnet')).toBe(97)
+    })
+  })
+
+  describe('RPC Endpoints', () => {
+    it('should have BSC mainnet RPC endpoint', () => {
+      expect(ETHEREUM_RPC_ENDPOINTS.bsc).toBeDefined()
+      expect(ETHEREUM_RPC_ENDPOINTS.bsc).toContain('binance')
+    })
+
+    it('should have BSC testnet RPC endpoint', () => {
+      expect(ETHEREUM_RPC_ENDPOINTS['bsc-testnet']).toBeDefined()
+      expect(ETHEREUM_RPC_ENDPOINTS['bsc-testnet']).toContain('binance')
+    })
+  })
+
+  describe('Explorer URLs', () => {
+    it('should have BSC mainnet explorer URL', () => {
+      expect(ETHEREUM_EXPLORER_URLS.bsc).toBe('https://bscscan.com')
+    })
+
+    it('should have BSC testnet explorer URL', () => {
+      expect(ETHEREUM_EXPLORER_URLS['bsc-testnet']).toBe('https://testnet.bscscan.com')
+    })
+
+    it('should generate correct transaction explorer URL', () => {
+      const txHash = '0x1234567890abcdef'
+      expect(getExplorerUrl(txHash, 'bsc')).toBe('https://bscscan.com/tx/0x1234567890abcdef')
+    })
+
+    it('should generate correct address explorer URL', () => {
+      const address = '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c'
+      expect(getAddressExplorerUrl(address, 'bsc')).toBe(
+        'https://bscscan.com/address/0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c'
+      )
+    })
+  })
+
+  describe('Network Type Detection', () => {
+    it('should identify BSC testnet as testnet', () => {
+      expect(isTestnet('bsc-testnet')).toBe(true)
+    })
+
+    it('should NOT identify BSC mainnet as testnet', () => {
+      expect(isTestnet('bsc')).toBe(false)
+    })
+
+    it('should NOT identify BSC as L2', () => {
+      expect(isL2Network('bsc')).toBe(false)
+      expect(isL2Network('bsc-testnet')).toBe(false)
+    })
+
+    it('should identify BSC as Alt L1', () => {
+      expect(isAltL1Network('bsc')).toBe(true)
+      expect(isAltL1Network('bsc-testnet')).toBe(true)
+    })
+
+    it('should NOT identify Ethereum mainnet as Alt L1', () => {
+      expect(isAltL1Network('mainnet')).toBe(false)
+    })
+  })
+})
+
+// ─── Token Configuration Tests ───────────────────────────────────────────────
+
+describe('BSC Token Configuration', () => {
+  describe('Token Addresses', () => {
+    it('should have valid WBNB address', () => {
+      expect(BSC_TOKEN_CONTRACTS.WBNB).toBe('0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c')
+      expect(isValidEthAddress(BSC_TOKEN_CONTRACTS.WBNB)).toBe(true)
+    })
+
+    it('should have valid USDC address', () => {
+      expect(BSC_TOKEN_CONTRACTS.USDC).toBe('0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d')
+      expect(isValidEthAddress(BSC_TOKEN_CONTRACTS.USDC)).toBe(true)
+    })
+
+    it('should have valid USDT address', () => {
+      expect(BSC_TOKEN_CONTRACTS.USDT).toBe('0x55d398326f99059fF775485246999027B3197955')
+      expect(isValidEthAddress(BSC_TOKEN_CONTRACTS.USDT)).toBe(true)
+    })
+
+    it('should have valid CAKE (PancakeSwap) address', () => {
+      expect(BSC_TOKEN_CONTRACTS.CAKE).toBe('0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82')
+      expect(isValidEthAddress(BSC_TOKEN_CONTRACTS.CAKE)).toBe(true)
+    })
+
+    it('should have valid ETH (Binance-Peg) address', () => {
+      expect(BSC_TOKEN_CONTRACTS.ETH).toBe('0x2170Ed0880ac9A755fd29B2688956BD959F933F8')
+      expect(isValidEthAddress(BSC_TOKEN_CONTRACTS.ETH)).toBe(true)
+    })
+
+    it('should have valid BTCB address', () => {
+      expect(BSC_TOKEN_CONTRACTS.BTCB).toBe('0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c')
+      expect(isValidEthAddress(BSC_TOKEN_CONTRACTS.BTCB)).toBe(true)
+    })
+  })
+
+  describe('Token Decimals', () => {
+    it('should have correct BNB decimals', () => {
+      expect(BSC_TOKEN_DECIMALS.BNB).toBe(18)
+    })
+
+    it('should have correct WBNB decimals', () => {
+      expect(BSC_TOKEN_DECIMALS.WBNB).toBe(18)
+    })
+
+    it('should have correct stablecoin decimals (18 on BSC)', () => {
+      // Note: BSC uses 18 decimals for stablecoins, unlike Ethereum's 6
+      expect(BSC_TOKEN_DECIMALS.USDC).toBe(18)
+      expect(BSC_TOKEN_DECIMALS.USDT).toBe(18)
+      expect(BSC_TOKEN_DECIMALS.DAI).toBe(18)
+    })
+
+    it('should have correct CAKE decimals', () => {
+      expect(BSC_TOKEN_DECIMALS.CAKE).toBe(18)
+    })
+  })
+})
+
+// ─── PancakeSwap Integration Tests ───────────────────────────────────────────
+
+describe('PancakeSwap Integration', () => {
+  describe('Mainnet Contracts', () => {
+    it('should have valid SmartRouter address', () => {
+      expect(PANCAKESWAP_CONTRACTS.SMART_ROUTER).toBe('0x13f4EA83D0bd40E75C8222255bc855a974568Dd4')
+      expect(isValidEthAddress(PANCAKESWAP_CONTRACTS.SMART_ROUTER)).toBe(true)
+    })
+
+    it('should have valid V3 Router address', () => {
+      expect(PANCAKESWAP_CONTRACTS.V3_ROUTER).toBeDefined()
+      expect(isValidEthAddress(PANCAKESWAP_CONTRACTS.V3_ROUTER)).toBe(true)
+    })
+
+    it('should have valid V2 Router address', () => {
+      expect(PANCAKESWAP_CONTRACTS.V2_ROUTER).toBe('0x10ED43C718714eb63d5aA57B78B54704E256024E')
+      expect(isValidEthAddress(PANCAKESWAP_CONTRACTS.V2_ROUTER)).toBe(true)
+    })
+
+    it('should have valid V3 Factory address', () => {
+      expect(PANCAKESWAP_CONTRACTS.V3_FACTORY).toBeDefined()
+      expect(isValidEthAddress(PANCAKESWAP_CONTRACTS.V3_FACTORY)).toBe(true)
+    })
+
+    it('should have valid V2 Factory address', () => {
+      expect(PANCAKESWAP_CONTRACTS.V2_FACTORY).toBe('0xcA143Ce32Fe78f1f7019d7d551a6402fC5350c73')
+      expect(isValidEthAddress(PANCAKESWAP_CONTRACTS.V2_FACTORY)).toBe(true)
+    })
+
+    it('should have valid Quoter V2 address', () => {
+      expect(PANCAKESWAP_CONTRACTS.QUOTER_V2).toBeDefined()
+      expect(isValidEthAddress(PANCAKESWAP_CONTRACTS.QUOTER_V2)).toBe(true)
+    })
+  })
+
+  describe('Testnet Contracts', () => {
+    it('should have valid testnet SmartRouter address', () => {
+      expect(PANCAKESWAP_TESTNET_CONTRACTS.SMART_ROUTER).toBeDefined()
+      expect(isValidEthAddress(PANCAKESWAP_TESTNET_CONTRACTS.SMART_ROUTER)).toBe(true)
+    })
+
+    it('should have valid testnet V2 Router address', () => {
+      expect(PANCAKESWAP_TESTNET_CONTRACTS.V2_ROUTER).toBe('0xD99D1c33F9fC3444f8101754aBC46c52416550D1')
+      expect(isValidEthAddress(PANCAKESWAP_TESTNET_CONTRACTS.V2_ROUTER)).toBe(true)
+    })
+
+    it('should have valid testnet V2 Factory address', () => {
+      expect(PANCAKESWAP_TESTNET_CONTRACTS.V2_FACTORY).toBe('0x6725F303b657a9451d8BA641348b6761A6CC7a17')
+      expect(isValidEthAddress(PANCAKESWAP_TESTNET_CONTRACTS.V2_FACTORY)).toBe(true)
+    })
+  })
+})
+
+// ─── Gas Estimation Tests ────────────────────────────────────────────────────
+
+describe('BSC Gas Estimation', () => {
+  // BSC base fee is ~3 gwei
+  const BSC_BASE_FEE = 3n * ONE_GWEI
+  // Ethereum base fee is ~30 gwei
+  const ETH_BASE_FEE = 30n * ONE_GWEI
+
+  it('should get gas price suggestion for BSC mainnet', () => {
+    const gasPrice = getGasPriceSuggestion(BSC_BASE_FEE, 'standard')
+
+    expect(gasPrice).toBeDefined()
+    expect(gasPrice.baseFeePerGas).toBe(BSC_BASE_FEE)
+    expect(gasPrice.maxFeePerGas).toBeGreaterThan(0n)
+    expect(gasPrice.maxPriorityFeePerGas).toBeGreaterThan(0n)
+  })
+
+  it('should get gas price suggestion for different speeds', () => {
+    const slowGas = getGasPriceSuggestion(BSC_BASE_FEE, 'slow')
+    const standardGas = getGasPriceSuggestion(BSC_BASE_FEE, 'standard')
+    const fastGas = getGasPriceSuggestion(BSC_BASE_FEE, 'fast')
+
+    // Fast should have higher priority fee than standard
+    expect(fastGas.maxPriorityFeePerGas).toBeGreaterThan(standardGas.maxPriorityFeePerGas)
+    // Standard should have higher priority fee than slow
+    expect(standardGas.maxPriorityFeePerGas).toBeGreaterThan(slowGas.maxPriorityFeePerGas)
+  })
+
+  it('should have lower gas price than Ethereum mainnet', () => {
+    const bscGas = getGasPriceSuggestion(BSC_BASE_FEE, 'standard')
+    const ethGas = getGasPriceSuggestion(ETH_BASE_FEE, 'standard')
+
+    // BSC gas should be significantly lower than Ethereum
+    expect(bscGas.baseFeePerGas).toBeLessThan(ethGas.baseFeePerGas)
+    expect(bscGas.maxFeePerGas).toBeLessThan(ethGas.maxFeePerGas)
+  })
+})
+
+// ─── Deployment Compatibility Tests ──────────────────────────────────────────
+
+describe('BSC Deployment Compatibility', () => {
+  it('should use EVM-compatible chain ID format', () => {
+    // Chain IDs should be positive integers
+    expect(typeof EVM_CHAIN_IDS.bsc).toBe('number')
+    expect(EVM_CHAIN_IDS.bsc).toBeGreaterThan(0)
+  })
+
+  it('should have compatible RPC endpoint format', () => {
+    // RPC endpoints should be valid URLs
+    expect(ETHEREUM_RPC_ENDPOINTS.bsc).toMatch(/^https?:\/\//)
+  })
+
+  it('should have compatible explorer API format', () => {
+    // Explorer URLs should support etherscan-compatible API
+    expect(ETHEREUM_EXPLORER_URLS.bsc).toContain('bscscan.com')
+  })
+})


### PR DESCRIPTION
## Summary
- Add BNB Chain (BSC) mainnet and testnet support to the EVM SDK
- Configure PancakeSwap router addresses for DEX integration
- Add BSC token contracts (WBNB, USDC, USDT, CAKE, BTCB, etc.)
- Update Foundry config for BSC contract deployment and verification

## Changes
- `packages/sdk/src/chains/ethereum/constants.ts` - BSC networks, tokens, PancakeSwap contracts, `isAltL1Network()` helper
- `packages/sdk/src/chains/ethereum/gas-estimation.ts` - BSC gas price baselines (3 gwei mainnet)
- `contracts/sip-ethereum/foundry.toml` - BSC RPC endpoints and BscScan API config
- `packages/sdk/tests/chains/ethereum/bsc.test.ts` - 40 tests for BSC configuration

## Test plan
- [x] All 6,492 tests pass including 40 new BSC-specific tests
- [x] TypeScript compilation succeeds
- [ ] CI passes

Closes #425