### PR TITLE
feat(sdk): add multi-language SDKs (Python, Rust, Go)

### DIFF
--- a/sdks/README.md
+++ b/sdks/README.md
@@ -1,0 +1,129 @@
+# SIP Protocol Multi-Language SDKs
+
+This directory contains SIP Protocol SDKs for multiple programming languages.
+
+## Available SDKs
+
+| Language | Package | Status | Registry |
+|----------|---------|--------|----------|
+| TypeScript | `@sip-protocol/sdk` | Production | [npm](https://www.npmjs.com/package/@sip-protocol/sdk) |
+| Python | `sip-protocol` | Beta | [PyPI](https://pypi.org/project/sip-protocol/) |
+| Rust | `sip-protocol` | Beta | [crates.io](https://crates.io/crates/sip-protocol) |
+| Go | `sip-protocol` | Beta | [pkg.go.dev](https://pkg.go.dev/github.com/sip-protocol/sip-protocol/sdks/go) |
+
+## API Consistency
+
+All SDKs provide the same core functionality with idiomatic APIs for each language:
+
+### Stealth Addresses (EIP-5564)
+
+```python
+# Python
+meta, spending_priv, viewing_priv = generate_stealth_meta_address("ethereum")
+stealth, _ = generate_stealth_address(meta)
+```
+
+```rust
+// Rust
+let (meta, spending_priv, viewing_priv) = generate_stealth_meta_address("ethereum");
+let (stealth, _) = generate_stealth_address(&meta)?;
+```
+
+```go
+// Go
+meta, spendingPriv, viewingPriv, _ := sip.GenerateStealthMetaAddress("ethereum")
+stealth, _, _ := sip.GenerateStealthAddress(meta)
+```
+
+### Pedersen Commitments
+
+```python
+# Python
+commitment, blinding = commit(100)
+valid = verify_opening(commitment, 100, blinding)
+```
+
+```rust
+// Rust
+let (commitment, blinding) = commit(100)?;
+let valid = verify_opening(&commitment, 100, &blinding)?;
+```
+
+```go
+// Go
+commitment, blinding, _ := sip.Commit(100)
+valid, _ := sip.VerifyOpening(commitment, 100, blinding)
+```
+
+### Viewing Keys
+
+```python
+# Python
+vk = generate_viewing_key("audit")
+payload = encrypt_for_viewing_key(vk.key, b"secret")
+plaintext = decrypt_with_viewing_key(vk.key, payload)
+```
+
+```rust
+// Rust
+let vk = generate_viewing_key(Some("audit"));
+let payload = encrypt_for_viewing_key(&vk.key, b"secret")?;
+let plaintext = decrypt_with_viewing_key(&vk.key, &payload)?;
+```
+
+```go
+// Go
+vk, _ := sip.GenerateViewingKey("audit")
+payload, _ := sip.EncryptForViewingKey(vk.Key, []byte("secret"))
+plaintext, _ := sip.DecryptWithViewingKey(vk.Key, payload)
+```
+
+## Features
+
+All SDKs implement:
+
+- **Stealth Addresses** (EIP-5564): Generate unlinkable one-time addresses
+- **Pedersen Commitments**: Hide amounts with homomorphic properties
+- **Viewing Keys**: Selective disclosure for compliance
+- **Privacy Levels**: Transparent, Shielded, Compliant
+- **Meta-Address Encoding**: `sip:<chain>:<spending>:<viewing>`
+- **Ethereum Address Derivation**: EIP-55 checksummed addresses
+
+## Cryptographic Libraries
+
+| Language | Elliptic Curves | Encryption |
+|----------|-----------------|------------|
+| TypeScript | @noble/curves | @noble/ciphers |
+| Python | coincurve, py_ecc | pycryptodome |
+| Rust | k256 | chacha20poly1305 |
+| Go | dcrd/dcrec/secp256k1 | golang.org/x/crypto |
+
+All implementations use secp256k1 for stealth addresses and XChaCha20-Poly1305 for encryption.
+
+## Development
+
+### Python
+
+```bash
+cd sdks/python
+pip install -e ".[dev]"
+pytest
+```
+
+### Rust
+
+```bash
+cd sdks/rust
+cargo test
+```
+
+### Go
+
+```bash
+cd sdks/go
+go test ./...
+```
+
+## License
+
+MIT License - see [LICENSE](../LICENSE) for details.

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -1,0 +1,162 @@
+# SIP Protocol Go SDK
+
+The privacy standard for Web3. Stealth addresses, Pedersen commitments, and viewing keys for compliant privacy.
+
+## Installation
+
+```bash
+go get github.com/sip-protocol/sip-protocol/sdks/go
+```
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/sip-protocol/sip-protocol/sdks/go/sip"
+)
+
+func main() {
+    // Generate stealth address keypair
+    meta, spendingPriv, viewingPriv, _ := sip.GenerateStealthMetaAddress("ethereum")
+    fmt.Printf("Spending key: %s\n", meta.SpendingKey)
+    fmt.Printf("Viewing key: %s\n", meta.ViewingKey)
+
+    // Generate one-time stealth address for payment
+    stealth, sharedSecret, _ := sip.GenerateStealthAddress(meta)
+    fmt.Printf("Stealth address: %s\n", stealth.Address)
+
+    // Recipient derives private key to spend
+    recovery, _ := sip.DeriveStealthPrivateKey(stealth, spendingPriv, viewingPriv)
+    fmt.Printf("Derived private key: %s\n", recovery.PrivateKey)
+}
+```
+
+## Features
+
+### Stealth Addresses (EIP-5564)
+
+Generate unlinkable one-time addresses for private payments:
+
+```go
+import "github.com/sip-protocol/sip-protocol/sdks/go/sip"
+
+// Recipient publishes their meta-address
+meta, spendingPriv, viewingPriv, _ := sip.GenerateStealthMetaAddress("ethereum")
+
+// Sender generates one-time stealth address
+stealth, _, _ := sip.GenerateStealthAddress(meta)
+
+// Convert to Ethereum address
+ethAddress, _ := sip.PublicKeyToEthAddress(stealth.Address)
+fmt.Printf("Send ETH to: %s\n", ethAddress)
+
+// Recipient scans for their payments
+isMine, _ := sip.CheckStealthAddress(stealth, spendingPriv, viewingPriv)
+```
+
+### Pedersen Commitments
+
+Hide amounts with homomorphic commitments:
+
+```go
+import "github.com/sip-protocol/sip-protocol/sdks/go/sip"
+
+// Create commitment to 100 tokens
+c1, b1, _ := sip.Commit(100)
+
+// Create commitment to 50 tokens
+c2, b2, _ := sip.Commit(50)
+
+// Add commitments homomorphically
+cSum, _ := sip.AddCommitments(c1, c2)
+bSum, _ := sip.AddBlindings(b1, b2)
+
+// Verify the sum
+valid, _ := sip.VerifyOpening(cSum, 150, bSum)
+// valid == true
+```
+
+### Viewing Keys
+
+Selective disclosure for compliance:
+
+```go
+import "github.com/sip-protocol/sip-protocol/sdks/go/sip"
+
+// Generate viewing key for auditor
+vk, _ := sip.GenerateViewingKey("tax-audit-2024")
+
+// Encrypt transaction details
+payload, _ := sip.EncryptForViewingKey(vk.Key, []byte("Transaction: 100 USDC to 0x..."))
+
+// Auditor decrypts with viewing key
+plaintext, _ := sip.DecryptWithViewingKey(vk.Key, payload)
+```
+
+## Privacy Levels
+
+```go
+import "github.com/sip-protocol/sip-protocol/sdks/go/sip"
+
+// PrivacyTransparent - No privacy, all data public
+// PrivacyShielded - Full privacy, sender/amount/recipient hidden
+// PrivacyCompliant - Privacy with viewing key for auditors
+```
+
+## API Reference
+
+### Stealth Addresses
+
+- `GenerateStealthMetaAddress(chain)` - Generate keypair
+- `GenerateStealthAddress(metaAddress)` - Generate one-time address
+- `DeriveStealthPrivateKey(stealth, spendingPriv, viewingPriv)` - Recover private key
+- `CheckStealthAddress(stealth, spendingPriv, viewingPriv)` - Check ownership
+- `PublicKeyToEthAddress(publicKey)` - Convert to ETH address
+- `EncodeStealthMetaAddress(meta)` - Encode to SIP format
+- `DecodeStealthMetaAddress(encoded)` - Decode from SIP format
+
+### Pedersen Commitments
+
+- `Commit(value)` - Create commitment
+- `VerifyOpening(commitment, value, blinding)` - Verify commitment
+- `AddCommitments(c1, c2)` - Homomorphic addition
+- `SubtractCommitments(c1, c2)` - Homomorphic subtraction
+- `AddBlindings(b1, b2)` - Add blinding factors
+- `SubtractBlindings(b1, b2)` - Subtract blinding factors
+- `GenerateBlinding()` - Generate random blinding
+
+### Viewing Keys
+
+- `GenerateViewingKey(label)` - Generate viewing key
+- `DeriveViewingKeyHash(viewingKey)` - Get key hash
+- `EncryptForViewingKey(viewingKey, plaintext)` - Encrypt data
+- `DecryptWithViewingKey(viewingKey, payload)` - Decrypt data
+
+## Development
+
+```bash
+# Run tests
+go test ./...
+
+# Run benchmarks
+go test -bench=. ./...
+
+# Build
+go build ./...
+```
+
+## License
+
+MIT License - see [LICENSE](../../LICENSE) for details.
+
+## Links
+
+- [Website](https://sip-protocol.org)
+- [Documentation](https://docs.sip-protocol.org)
+- [GitHub](https://github.com/sip-protocol/sip-protocol)
+- [TypeScript SDK](https://www.npmjs.com/package/@sip-protocol/sdk)
+- [Python SDK](https://pypi.org/project/sip-protocol/)
+- [Rust SDK](https://crates.io/crates/sip-protocol)

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -1,0 +1,8 @@
+module github.com/sip-protocol/sip-protocol/sdks/go
+
+go 1.21
+
+require (
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
+	golang.org/x/crypto v0.21.0
+)

--- a/sdks/go/sip/commitment.go
+++ b/sdks/go/sip/commitment.go
@@ -1,0 +1,306 @@
+package sip
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+)
+
+// Domain separation tag for H generation
+const hDomain = "SIP-PEDERSEN-GENERATOR-H-v1"
+
+var (
+	// curveOrder is the secp256k1 curve order
+	curveOrder = secp256k1.S256().N
+
+	// generatorG is the base generator
+	generatorG = secp256k1.Generator()
+
+	// generatorH is the independent generator (NUMS)
+	generatorH *secp256k1.JacobianPoint
+)
+
+func init() {
+	// Generate H using NUMS method
+	generatorH = generateH()
+}
+
+// generateH generates the independent generator H using NUMS method.
+func generateH() *secp256k1.JacobianPoint {
+	for counter := 0; counter < 256; counter++ {
+		// Create candidate x-coordinate
+		input := fmt.Sprintf("%s:%d", hDomain, counter)
+		hash := sha256.Sum256([]byte(input))
+
+		// Try to create a point from this x-coordinate (with even y)
+		pointBytes := make([]byte, 33)
+		pointBytes[0] = 0x02 // Compressed, even y
+		copy(pointBytes[1:], hash[:])
+
+		pubKey, err := secp256k1.ParsePubKey(pointBytes)
+		if err == nil {
+			var result secp256k1.JacobianPoint
+			pubKey.AsJacobian(&result)
+			return &result
+		}
+	}
+
+	panic("failed to generate H point - this should never happen")
+}
+
+// Commit creates a Pedersen commitment to a value.
+//
+// C = v*G + r*H
+//
+// Where:
+//   - v = value (the amount being committed)
+//   - r = blinding factor (random, keeps value hidden)
+//   - G = base generator
+//   - H = independent generator (NUMS)
+func Commit(value uint64) (HexString, HexString, error) {
+	// Generate random blinding factor
+	blinding := make([]byte, 32)
+	_, err := rand.Read(blinding)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to generate blinding: %w", err)
+	}
+
+	return CommitWithBlinding(value, blinding)
+}
+
+// CommitWithBlinding creates a Pedersen commitment with a specific blinding factor.
+func CommitWithBlinding(value uint64, blinding []byte) (HexString, HexString, error) {
+	if len(blinding) != 32 {
+		return "", "", errors.New("blinding must be 32 bytes")
+	}
+
+	// Convert to scalars
+	vScalar := new(secp256k1.ModNScalar)
+	vScalar.SetInt(uint32(value))
+
+	rScalar := new(secp256k1.ModNScalar)
+	rScalar.SetByteSlice(blinding)
+
+	if rScalar.IsZero() {
+		return "", "", errors.New("zero blinding scalar - investigate RNG")
+	}
+
+	// C = v*G + r*H
+	var vG, rH, commitment secp256k1.JacobianPoint
+
+	if value == 0 {
+		// Only blinding contributes: C = r*H
+		secp256k1.ScalarMultNonConst(rScalar, generatorH, &commitment)
+	} else {
+		// v*G
+		secp256k1.ScalarBaseMultNonConst(vScalar, &vG)
+		// r*H
+		secp256k1.ScalarMultNonConst(rScalar, generatorH, &rH)
+		// C = v*G + r*H
+		secp256k1.AddNonConst(&vG, &rH, &commitment)
+	}
+
+	commitment.ToAffine()
+	pubKey := secp256k1.NewPublicKey(&commitment.X, &commitment.Y)
+	commitmentBytes := pubKey.SerializeCompressed()
+
+	return BytesToHex(commitmentBytes), BytesToHex(blinding), nil
+}
+
+// VerifyOpening verifies that a commitment opens to a specific value.
+//
+// Recomputes C' = v*G + r*H and checks if C' == C
+func VerifyOpening(commitment HexString, value uint64, blinding HexString) (bool, error) {
+	commitmentBytes, err := HexToBytes(commitment)
+	if err != nil {
+		return false, fmt.Errorf("invalid commitment: %w", err)
+	}
+
+	blindingBytes, err := HexToBytes(blinding)
+	if err != nil {
+		return false, fmt.Errorf("invalid blinding: %w", err)
+	}
+
+	// Parse commitment point
+	cPubKey, err := secp256k1.ParsePubKey(commitmentBytes)
+	if err != nil {
+		return false, fmt.Errorf("invalid commitment point: %w", err)
+	}
+
+	// Recompute expected commitment
+	vScalar := new(secp256k1.ModNScalar)
+	vScalar.SetInt(uint32(value))
+
+	rScalar := new(secp256k1.ModNScalar)
+	rScalar.SetByteSlice(blindingBytes)
+
+	var expected secp256k1.JacobianPoint
+	if value == 0 {
+		secp256k1.ScalarMultNonConst(rScalar, generatorH, &expected)
+	} else {
+		var vG, rH secp256k1.JacobianPoint
+		secp256k1.ScalarBaseMultNonConst(vScalar, &vG)
+		secp256k1.ScalarMultNonConst(rScalar, generatorH, &rH)
+		secp256k1.AddNonConst(&vG, &rH, &expected)
+	}
+
+	expected.ToAffine()
+	expectedPubKey := secp256k1.NewPublicKey(&expected.X, &expected.Y)
+
+	return cPubKey.IsEqual(expectedPubKey), nil
+}
+
+// CommitZero creates a commitment to zero with a specific blinding factor.
+//
+// C = 0*G + r*H = r*H
+func CommitZero(blinding []byte) (HexString, HexString, error) {
+	return CommitWithBlinding(0, blinding)
+}
+
+// AddCommitments adds two commitments homomorphically.
+//
+// C1 + C2 = (v1*G + r1*H) + (v2*G + r2*H) = (v1+v2)*G + (r1+r2)*H
+func AddCommitments(c1, c2 HexString) (HexString, error) {
+	c1Bytes, err := HexToBytes(c1)
+	if err != nil {
+		return "", fmt.Errorf("invalid c1: %w", err)
+	}
+
+	c2Bytes, err := HexToBytes(c2)
+	if err != nil {
+		return "", fmt.Errorf("invalid c2: %w", err)
+	}
+
+	pubKey1, err := secp256k1.ParsePubKey(c1Bytes)
+	if err != nil {
+		return "", fmt.Errorf("invalid commitment c1: %w", err)
+	}
+
+	pubKey2, err := secp256k1.ParsePubKey(c2Bytes)
+	if err != nil {
+		return "", fmt.Errorf("invalid commitment c2: %w", err)
+	}
+
+	var point1, point2, sum secp256k1.JacobianPoint
+	pubKey1.AsJacobian(&point1)
+	pubKey2.AsJacobian(&point2)
+
+	secp256k1.AddNonConst(&point1, &point2, &sum)
+	sum.ToAffine()
+
+	resultPubKey := secp256k1.NewPublicKey(&sum.X, &sum.Y)
+	return BytesToHex(resultPubKey.SerializeCompressed()), nil
+}
+
+// SubtractCommitments subtracts two commitments homomorphically.
+//
+// C1 - C2 = (v1-v2)*G + (r1-r2)*H
+func SubtractCommitments(c1, c2 HexString) (HexString, error) {
+	c1Bytes, err := HexToBytes(c1)
+	if err != nil {
+		return "", fmt.Errorf("invalid c1: %w", err)
+	}
+
+	c2Bytes, err := HexToBytes(c2)
+	if err != nil {
+		return "", fmt.Errorf("invalid c2: %w", err)
+	}
+
+	pubKey1, err := secp256k1.ParsePubKey(c1Bytes)
+	if err != nil {
+		return "", fmt.Errorf("invalid commitment c1: %w", err)
+	}
+
+	pubKey2, err := secp256k1.ParsePubKey(c2Bytes)
+	if err != nil {
+		return "", fmt.Errorf("invalid commitment c2: %w", err)
+	}
+
+	var point1, point2, negPoint2, diff secp256k1.JacobianPoint
+	pubKey1.AsJacobian(&point1)
+	pubKey2.AsJacobian(&point2)
+
+	// Negate point2
+	negPoint2 = point2
+	negPoint2.Y.Negate(1)
+	negPoint2.Y.Normalize()
+
+	secp256k1.AddNonConst(&point1, &negPoint2, &diff)
+	diff.ToAffine()
+
+	resultPubKey := secp256k1.NewPublicKey(&diff.X, &diff.Y)
+	return BytesToHex(resultPubKey.SerializeCompressed()), nil
+}
+
+// AddBlindings adds blinding factors (for use with homomorphic addition).
+func AddBlindings(b1, b2 HexString) (HexString, error) {
+	b1Bytes, err := HexToBytes(b1)
+	if err != nil {
+		return "", fmt.Errorf("invalid b1: %w", err)
+	}
+
+	b2Bytes, err := HexToBytes(b2)
+	if err != nil {
+		return "", fmt.Errorf("invalid b2: %w", err)
+	}
+
+	s1 := new(secp256k1.ModNScalar)
+	s1.SetByteSlice(b1Bytes)
+
+	s2 := new(secp256k1.ModNScalar)
+	s2.SetByteSlice(b2Bytes)
+
+	sum := s1.Add(s2)
+	return BytesToHex(sum.Bytes()[:]), nil
+}
+
+// SubtractBlindings subtracts blinding factors (for use with homomorphic subtraction).
+func SubtractBlindings(b1, b2 HexString) (HexString, error) {
+	b1Bytes, err := HexToBytes(b1)
+	if err != nil {
+		return "", fmt.Errorf("invalid b1: %w", err)
+	}
+
+	b2Bytes, err := HexToBytes(b2)
+	if err != nil {
+		return "", fmt.Errorf("invalid b2: %w", err)
+	}
+
+	s1 := new(secp256k1.ModNScalar)
+	s1.SetByteSlice(b1Bytes)
+
+	s2 := new(secp256k1.ModNScalar)
+	s2.SetByteSlice(b2Bytes)
+
+	s2.Negate()
+	diff := s1.Add(s2)
+	return BytesToHex(diff.Bytes()[:]), nil
+}
+
+// GenerateBlinding generates a random blinding factor.
+func GenerateBlinding() (HexString, error) {
+	bytes := make([]byte, 32)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate blinding: %w", err)
+	}
+	return BytesToHex(bytes), nil
+}
+
+// GetGenerators returns the generators for ZK proof integration.
+func GetGenerators() Generators {
+	gPoint := secp256k1.Generator()
+	var gJac secp256k1.JacobianPoint
+	gPoint.AsJacobian(&gJac)
+
+	return Generators{
+		Gx: BytesToHex(gJac.X.Bytes()[:]),
+		Gy: BytesToHex(gJac.Y.Bytes()[:]),
+		Hx: BytesToHex(generatorH.X.Bytes()[:]),
+		Hy: BytesToHex(generatorH.Y.Bytes()[:]),
+	}
+}

--- a/sdks/go/sip/crypto.go
+++ b/sdks/go/sip/crypto.go
@@ -1,0 +1,56 @@
+package sip
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// HashSHA256 computes SHA-256 hash of data.
+//
+// Returns 32-byte hash as hex string with 0x prefix.
+func HashSHA256(data []byte) Hash {
+	hash := sha256.Sum256(data)
+	return "0x" + hex.EncodeToString(hash[:])
+}
+
+// GenerateRandomBytes generates cryptographically secure random bytes.
+//
+// Uses the platform's secure random source.
+func GenerateRandomBytes(length int) (HexString, error) {
+	bytes := make([]byte, length)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate random bytes: %w", err)
+	}
+	return "0x" + hex.EncodeToString(bytes), nil
+}
+
+// GenerateIntentID generates a unique intent identifier.
+//
+// Creates a cryptographically random intent ID with the `sip-` prefix.
+// IDs are globally unique with negligible collision probability (128-bit).
+func GenerateIntentID() (string, error) {
+	bytes := make([]byte, 16)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate intent ID: %w", err)
+	}
+	return "sip-" + hex.EncodeToString(bytes), nil
+}
+
+// HexToBytes converts hex string to bytes.
+//
+// Accepts hex string with or without 0x prefix.
+func HexToBytes(hexStr string) ([]byte, error) {
+	if len(hexStr) >= 2 && hexStr[:2] == "0x" {
+		hexStr = hexStr[2:]
+	}
+	return hex.DecodeString(hexStr)
+}
+
+// BytesToHex converts bytes to hex string with 0x prefix.
+func BytesToHex(data []byte) HexString {
+	return "0x" + hex.EncodeToString(data)
+}

--- a/sdks/go/sip/privacy.go
+++ b/sdks/go/sip/privacy.go
@@ -1,0 +1,129 @@
+package sip
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"time"
+
+	"golang.org/x/crypto/chacha20poly1305"
+)
+
+// GenerateViewingKey generates a new viewing key for selective disclosure.
+func GenerateViewingKey(label string) (*ViewingKey, error) {
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate viewing key: %w", err)
+	}
+
+	keyHash := sha256.Sum256(key)
+	createdAt := time.Now().UnixMilli()
+
+	return &ViewingKey{
+		Key:       BytesToHex(key),
+		KeyHash:   BytesToHex(keyHash[:]),
+		CreatedAt: createdAt,
+		Label:     label,
+	}, nil
+}
+
+// DeriveViewingKeyHash derives the hash of a viewing key.
+//
+// This hash is used for indexing and verification without
+// exposing the actual key.
+func DeriveViewingKeyHash(viewingKey HexString) (HexString, error) {
+	keyBytes, err := HexToBytes(viewingKey)
+	if err != nil {
+		return "", fmt.Errorf("invalid viewing key: %w", err)
+	}
+
+	hash := sha256.Sum256(keyBytes)
+	return BytesToHex(hash[:]), nil
+}
+
+// EncryptForViewingKey encrypts data for viewing key holders.
+//
+// Uses XChaCha20-Poly1305 for authenticated encryption.
+func EncryptForViewingKey(viewingKey HexString, plaintext []byte) (*EncryptedPayload, error) {
+	keyBytes, err := HexToBytes(viewingKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid viewing key: %w", err)
+	}
+
+	if len(keyBytes) != 32 {
+		return nil, errors.New("viewing key must be 32 bytes")
+	}
+
+	// Create XChaCha20-Poly1305 cipher
+	aead, err := chacha20poly1305.NewX(keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", err)
+	}
+
+	// Generate random nonce (24 bytes for XChaCha20)
+	nonce := make([]byte, chacha20poly1305.NonceSizeX)
+	_, err = rand.Read(nonce)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	// Encrypt
+	ciphertext := aead.Seal(nil, nonce, plaintext, nil)
+
+	return &EncryptedPayload{
+		Ciphertext: BytesToHex(ciphertext),
+		Nonce:      BytesToHex(nonce),
+	}, nil
+}
+
+// DecryptWithViewingKey decrypts data using a viewing key.
+func DecryptWithViewingKey(viewingKey HexString, payload *EncryptedPayload) ([]byte, error) {
+	keyBytes, err := HexToBytes(viewingKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid viewing key: %w", err)
+	}
+
+	nonceBytes, err := HexToBytes(payload.Nonce)
+	if err != nil {
+		return nil, fmt.Errorf("invalid nonce: %w", err)
+	}
+
+	ciphertextBytes, err := HexToBytes(payload.Ciphertext)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ciphertext: %w", err)
+	}
+
+	if len(keyBytes) != 32 {
+		return nil, errors.New("viewing key must be 32 bytes")
+	}
+
+	if len(nonceBytes) != chacha20poly1305.NonceSizeX {
+		return nil, errors.New("invalid nonce length")
+	}
+
+	// Create XChaCha20-Poly1305 cipher
+	aead, err := chacha20poly1305.NewX(keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", err)
+	}
+
+	// Decrypt
+	plaintext, err := aead.Open(nil, nonceBytes, ciphertextBytes, nil)
+	if err != nil {
+		return nil, fmt.Errorf("decryption failed: %w", err)
+	}
+
+	return plaintext, nil
+}
+
+// ShouldEncrypt determines if encryption should be used for a privacy level.
+func ShouldEncrypt(level PrivacyLevel) bool {
+	return level == PrivacyShielded || level == PrivacyCompliant
+}
+
+// ShouldIncludeViewingKey determines if viewing key should be included for a privacy level.
+func ShouldIncludeViewingKey(level PrivacyLevel) bool {
+	return level == PrivacyCompliant
+}

--- a/sdks/go/sip/sip_test.go
+++ b/sdks/go/sip/sip_test.go
@@ -1,0 +1,234 @@
+package sip
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCrypto(t *testing.T) {
+	t.Run("HashSHA256", func(t *testing.T) {
+		hash := HashSHA256([]byte("hello"))
+		if !strings.HasPrefix(hash, "0x") {
+			t.Error("Hash should start with 0x")
+		}
+		if len(hash) != 66 {
+			t.Errorf("Hash should be 66 chars, got %d", len(hash))
+		}
+	})
+
+	t.Run("GenerateRandomBytes", func(t *testing.T) {
+		r1, err := GenerateRandomBytes(32)
+		if err != nil {
+			t.Fatalf("Failed to generate random bytes: %v", err)
+		}
+
+		r2, _ := GenerateRandomBytes(32)
+		if r1 == r2 {
+			t.Error("Random bytes should be unique")
+		}
+	})
+
+	t.Run("GenerateIntentID", func(t *testing.T) {
+		id, err := GenerateIntentID()
+		if err != nil {
+			t.Fatalf("Failed to generate intent ID: %v", err)
+		}
+
+		if !strings.HasPrefix(id, "sip-") {
+			t.Error("Intent ID should start with sip-")
+		}
+		if len(id) != 36 {
+			t.Errorf("Intent ID should be 36 chars, got %d", len(id))
+		}
+	})
+}
+
+func TestCommitment(t *testing.T) {
+	t.Run("CommitAndVerify", func(t *testing.T) {
+		commitment, blinding, err := Commit(100)
+		if err != nil {
+			t.Fatalf("Failed to commit: %v", err)
+		}
+
+		if !strings.HasPrefix(commitment, "0x") {
+			t.Error("Commitment should start with 0x")
+		}
+
+		valid, err := VerifyOpening(commitment, 100, blinding)
+		if err != nil {
+			t.Fatalf("Failed to verify: %v", err)
+		}
+		if !valid {
+			t.Error("Commitment should verify for correct value")
+		}
+
+		invalid, _ := VerifyOpening(commitment, 101, blinding)
+		if invalid {
+			t.Error("Commitment should not verify for wrong value")
+		}
+	})
+
+	t.Run("HomomorphicAddition", func(t *testing.T) {
+		c1, b1, _ := Commit(100)
+		c2, b2, _ := Commit(50)
+
+		cSum, err := AddCommitments(c1, c2)
+		if err != nil {
+			t.Fatalf("Failed to add commitments: %v", err)
+		}
+
+		bSum, err := AddBlindings(b1, b2)
+		if err != nil {
+			t.Fatalf("Failed to add blindings: %v", err)
+		}
+
+		valid, _ := VerifyOpening(cSum, 150, bSum)
+		if !valid {
+			t.Error("Sum should verify to 150")
+		}
+	})
+}
+
+func TestStealth(t *testing.T) {
+	t.Run("GenerateMetaAddress", func(t *testing.T) {
+		meta, spendingPriv, viewingPriv, err := GenerateStealthMetaAddress("ethereum")
+		if err != nil {
+			t.Fatalf("Failed to generate meta address: %v", err)
+		}
+
+		if meta.Chain != "ethereum" {
+			t.Errorf("Chain should be ethereum, got %s", meta.Chain)
+		}
+		if !strings.HasPrefix(meta.SpendingKey, "0x") {
+			t.Error("Spending key should start with 0x")
+		}
+		if !strings.HasPrefix(spendingPriv, "0x") {
+			t.Error("Spending private key should start with 0x")
+		}
+		if !strings.HasPrefix(viewingPriv, "0x") {
+			t.Error("Viewing private key should start with 0x")
+		}
+	})
+
+	t.Run("GenerateAndCheckStealthAddress", func(t *testing.T) {
+		meta, spendingPriv, viewingPriv, _ := GenerateStealthMetaAddress("ethereum")
+		stealth, _, err := GenerateStealthAddress(meta)
+		if err != nil {
+			t.Fatalf("Failed to generate stealth address: %v", err)
+		}
+
+		if !strings.HasPrefix(stealth.Address, "0x") {
+			t.Error("Stealth address should start with 0x")
+		}
+
+		isMine, err := CheckStealthAddress(stealth, spendingPriv, viewingPriv)
+		if err != nil {
+			t.Fatalf("Failed to check stealth address: %v", err)
+		}
+		if !isMine {
+			t.Error("Should recognize own stealth address")
+		}
+	})
+
+	t.Run("DeriveStealthPrivateKey", func(t *testing.T) {
+		meta, spendingPriv, viewingPriv, _ := GenerateStealthMetaAddress("ethereum")
+		stealth, _, _ := GenerateStealthAddress(meta)
+
+		recovery, err := DeriveStealthPrivateKey(stealth, spendingPriv, viewingPriv)
+		if err != nil {
+			t.Fatalf("Failed to derive private key: %v", err)
+		}
+
+		if recovery.StealthAddress != stealth.Address {
+			t.Error("Stealth address mismatch")
+		}
+		if !strings.HasPrefix(recovery.PrivateKey, "0x") {
+			t.Error("Private key should start with 0x")
+		}
+	})
+
+	t.Run("EncodeDecodeMetaAddress", func(t *testing.T) {
+		meta, _, _, _ := GenerateStealthMetaAddress("ethereum")
+
+		encoded := EncodeStealthMetaAddress(meta)
+		if !strings.HasPrefix(encoded, "sip:ethereum:") {
+			t.Error("Encoded should start with sip:ethereum:")
+		}
+
+		decoded, err := DecodeStealthMetaAddress(encoded)
+		if err != nil {
+			t.Fatalf("Failed to decode: %v", err)
+		}
+
+		if decoded.Chain != meta.Chain {
+			t.Error("Chain mismatch")
+		}
+		if decoded.SpendingKey != meta.SpendingKey {
+			t.Error("Spending key mismatch")
+		}
+	})
+}
+
+func TestPrivacy(t *testing.T) {
+	t.Run("GenerateViewingKey", func(t *testing.T) {
+		vk, err := GenerateViewingKey("test-label")
+		if err != nil {
+			t.Fatalf("Failed to generate viewing key: %v", err)
+		}
+
+		if !strings.HasPrefix(vk.Key, "0x") {
+			t.Error("Key should start with 0x")
+		}
+		if vk.Label != "test-label" {
+			t.Error("Label mismatch")
+		}
+	})
+
+	t.Run("DeriveViewingKeyHash", func(t *testing.T) {
+		vk, _ := GenerateViewingKey("")
+		hash, err := DeriveViewingKeyHash(vk.Key)
+		if err != nil {
+			t.Fatalf("Failed to derive hash: %v", err)
+		}
+
+		if hash != vk.KeyHash {
+			t.Error("Hash should match")
+		}
+	})
+
+	t.Run("EncryptDecrypt", func(t *testing.T) {
+		vk, _ := GenerateViewingKey("")
+		plaintext := []byte("Hello, SIP Protocol!")
+
+		payload, err := EncryptForViewingKey(vk.Key, plaintext)
+		if err != nil {
+			t.Fatalf("Failed to encrypt: %v", err)
+		}
+
+		if !strings.HasPrefix(payload.Ciphertext, "0x") {
+			t.Error("Ciphertext should start with 0x")
+		}
+
+		decrypted, err := DecryptWithViewingKey(vk.Key, payload)
+		if err != nil {
+			t.Fatalf("Failed to decrypt: %v", err)
+		}
+
+		if !bytes.Equal(decrypted, plaintext) {
+			t.Error("Decrypted should match plaintext")
+		}
+	})
+}
+
+func TestPrivacyLevel(t *testing.T) {
+	if PrivacyTransparent != "transparent" {
+		t.Error("PrivacyTransparent should be 'transparent'")
+	}
+	if PrivacyShielded != "shielded" {
+		t.Error("PrivacyShielded should be 'shielded'")
+	}
+	if PrivacyCompliant != "compliant" {
+		t.Error("PrivacyCompliant should be 'compliant'")
+	}
+}

--- a/sdks/go/sip/stealth.go
+++ b/sdks/go/sip/stealth.go
@@ -1,0 +1,314 @@
+package sip
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"golang.org/x/crypto/sha3"
+)
+
+// GenerateStealthMetaAddress generates a new stealth meta-address keypair.
+//
+// Returns (meta_address, spending_private_key, viewing_private_key).
+func GenerateStealthMetaAddress(chain ChainID) (*StealthMetaAddress, HexString, HexString, error) {
+	// Generate random private keys
+	spendingPriv, err := secp256k1.GeneratePrivateKey()
+	if err != nil {
+		return nil, "", "", fmt.Errorf("failed to generate spending key: %w", err)
+	}
+
+	viewingPriv, err := secp256k1.GeneratePrivateKey()
+	if err != nil {
+		return nil, "", "", fmt.Errorf("failed to generate viewing key: %w", err)
+	}
+
+	// Derive public keys (compressed)
+	spendingPub := spendingPriv.PubKey().SerializeCompressed()
+	viewingPub := viewingPriv.PubKey().SerializeCompressed()
+
+	meta := &StealthMetaAddress{
+		SpendingKey: BytesToHex(spendingPub),
+		ViewingKey:  BytesToHex(viewingPub),
+		Chain:       chain,
+	}
+
+	return meta, BytesToHex(spendingPriv.Serialize()), BytesToHex(viewingPriv.Serialize()), nil
+}
+
+// GenerateStealthAddress generates a one-time stealth address for a recipient.
+//
+// Protocol:
+// 1. Sender generates ephemeral keypair (r, R = r*G)
+// 2. Compute shared secret: S = r * P_spend
+// 3. Compute stealth address: A = Q_view + hash(S)*G
+// 4. View tag = first byte of hash(S) for efficient scanning
+func GenerateStealthAddress(recipientMeta *StealthMetaAddress) (*StealthAddress, HexString, error) {
+	// Generate ephemeral keypair
+	ephemeralPriv, err := secp256k1.GeneratePrivateKey()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to generate ephemeral key: %w", err)
+	}
+	ephemeralPub := ephemeralPriv.PubKey()
+
+	// Parse recipient's keys
+	spendingKeyBytes, err := HexToBytes(recipientMeta.SpendingKey)
+	if err != nil {
+		return nil, "", fmt.Errorf("invalid spending key: %w", err)
+	}
+
+	viewingKeyBytes, err := HexToBytes(recipientMeta.ViewingKey)
+	if err != nil {
+		return nil, "", fmt.Errorf("invalid viewing key: %w", err)
+	}
+
+	spendingPub, err := secp256k1.ParsePubKey(spendingKeyBytes)
+	if err != nil {
+		return nil, "", fmt.Errorf("invalid spending public key: %w", err)
+	}
+
+	viewingPub, err := secp256k1.ParsePubKey(viewingKeyBytes)
+	if err != nil {
+		return nil, "", fmt.Errorf("invalid viewing public key: %w", err)
+	}
+
+	// Compute shared secret: S = r * P_spend
+	var spendingJac, sharedSecretJac secp256k1.JacobianPoint
+	spendingPub.AsJacobian(&spendingJac)
+	secp256k1.ScalarMultNonConst(&ephemeralPriv.Key, &spendingJac, &sharedSecretJac)
+	sharedSecretJac.ToAffine()
+	sharedSecretPub := secp256k1.NewPublicKey(&sharedSecretJac.X, &sharedSecretJac.Y)
+	sharedSecretBytes := sharedSecretPub.SerializeCompressed()
+
+	// Hash the shared secret
+	sharedSecretHash := sha256.Sum256(sharedSecretBytes)
+
+	// Compute stealth address: A = Q_view + hash(S)*G
+	hashScalar := new(secp256k1.ModNScalar)
+	hashScalar.SetByteSlice(sharedSecretHash[:])
+
+	var hashTimesG secp256k1.JacobianPoint
+	secp256k1.ScalarBaseMultNonConst(hashScalar, &hashTimesG)
+
+	var viewingJac, stealthJac secp256k1.JacobianPoint
+	viewingPub.AsJacobian(&viewingJac)
+	secp256k1.AddNonConst(&viewingJac, &hashTimesG, &stealthJac)
+	stealthJac.ToAffine()
+
+	stealthPub := secp256k1.NewPublicKey(&stealthJac.X, &stealthJac.Y)
+	stealthAddressBytes := stealthPub.SerializeCompressed()
+
+	// View tag (first byte of hash for efficient scanning)
+	viewTag := sharedSecretHash[0]
+
+	stealth := &StealthAddress{
+		Address:            BytesToHex(stealthAddressBytes),
+		EphemeralPublicKey: BytesToHex(ephemeralPub.SerializeCompressed()),
+		ViewTag:            viewTag,
+	}
+
+	return stealth, BytesToHex(sharedSecretHash[:]), nil
+}
+
+// DeriveStealthPrivateKey derives the private key for a stealth address.
+//
+// Protocol:
+// 1. Compute shared secret: S = p_spend * R_ephemeral
+// 2. Derive stealth private key: q_view + hash(S) mod n
+func DeriveStealthPrivateKey(stealth *StealthAddress, spendingPrivKey, viewingPrivKey HexString) (*StealthAddressRecovery, error) {
+	spendingPrivBytes, err := HexToBytes(spendingPrivKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid spending private key: %w", err)
+	}
+
+	viewingPrivBytes, err := HexToBytes(viewingPrivKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid viewing private key: %w", err)
+	}
+
+	ephemeralPubBytes, err := HexToBytes(stealth.EphemeralPublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ephemeral public key: %w", err)
+	}
+
+	spendingPriv := secp256k1.PrivKeyFromBytes(spendingPrivBytes)
+	ephemeralPub, err := secp256k1.ParsePubKey(ephemeralPubBytes)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ephemeral key: %w", err)
+	}
+
+	// Compute shared secret: S = p_spend * R_ephemeral
+	var ephemeralJac, sharedSecretJac secp256k1.JacobianPoint
+	ephemeralPub.AsJacobian(&ephemeralJac)
+	secp256k1.ScalarMultNonConst(&spendingPriv.Key, &ephemeralJac, &sharedSecretJac)
+	sharedSecretJac.ToAffine()
+	sharedSecretPub := secp256k1.NewPublicKey(&sharedSecretJac.X, &sharedSecretJac.Y)
+	sharedSecretBytes := sharedSecretPub.SerializeCompressed()
+
+	// Hash the shared secret
+	sharedSecretHash := sha256.Sum256(sharedSecretBytes)
+
+	// Derive stealth private key: q_view + hash(S) mod n
+	viewingScalar := new(secp256k1.ModNScalar)
+	viewingScalar.SetByteSlice(viewingPrivBytes)
+
+	hashScalar := new(secp256k1.ModNScalar)
+	hashScalar.SetByteSlice(sharedSecretHash[:])
+
+	stealthScalar := viewingScalar.Add(hashScalar)
+
+	return &StealthAddressRecovery{
+		StealthAddress:     stealth.Address,
+		EphemeralPublicKey: stealth.EphemeralPublicKey,
+		PrivateKey:         BytesToHex(stealthScalar.Bytes()[:]),
+	}, nil
+}
+
+// CheckStealthAddress checks if a stealth address belongs to this recipient.
+//
+// Uses view tag for efficient filtering, then does full verification.
+func CheckStealthAddress(stealth *StealthAddress, spendingPrivKey, viewingPrivKey HexString) (bool, error) {
+	spendingPrivBytes, err := HexToBytes(spendingPrivKey)
+	if err != nil {
+		return false, fmt.Errorf("invalid spending private key: %w", err)
+	}
+
+	viewingPrivBytes, err := HexToBytes(viewingPrivKey)
+	if err != nil {
+		return false, fmt.Errorf("invalid viewing private key: %w", err)
+	}
+
+	ephemeralPubBytes, err := HexToBytes(stealth.EphemeralPublicKey)
+	if err != nil {
+		return false, fmt.Errorf("invalid ephemeral public key: %w", err)
+	}
+
+	providedAddressBytes, err := HexToBytes(stealth.Address)
+	if err != nil {
+		return false, fmt.Errorf("invalid stealth address: %w", err)
+	}
+
+	spendingPriv := secp256k1.PrivKeyFromBytes(spendingPrivBytes)
+	ephemeralPub, err := secp256k1.ParsePubKey(ephemeralPubBytes)
+	if err != nil {
+		return false, fmt.Errorf("invalid ephemeral key: %w", err)
+	}
+
+	// Compute shared secret
+	var ephemeralJac, sharedSecretJac secp256k1.JacobianPoint
+	ephemeralPub.AsJacobian(&ephemeralJac)
+	secp256k1.ScalarMultNonConst(&spendingPriv.Key, &ephemeralJac, &sharedSecretJac)
+	sharedSecretJac.ToAffine()
+	sharedSecretPub := secp256k1.NewPublicKey(&sharedSecretJac.X, &sharedSecretJac.Y)
+	sharedSecretBytes := sharedSecretPub.SerializeCompressed()
+
+	// Hash the shared secret
+	sharedSecretHash := sha256.Sum256(sharedSecretBytes)
+
+	// Quick view tag check
+	if sharedSecretHash[0] != stealth.ViewTag {
+		return false, nil
+	}
+
+	// Full verification: derive expected stealth address
+	viewingScalar := new(secp256k1.ModNScalar)
+	viewingScalar.SetByteSlice(viewingPrivBytes)
+
+	hashScalar := new(secp256k1.ModNScalar)
+	hashScalar.SetByteSlice(sharedSecretHash[:])
+
+	stealthScalar := viewingScalar.Add(hashScalar)
+
+	// Compute expected public key
+	var expectedJac secp256k1.JacobianPoint
+	secp256k1.ScalarBaseMultNonConst(stealthScalar, &expectedJac)
+	expectedJac.ToAffine()
+	expectedPub := secp256k1.NewPublicKey(&expectedJac.X, &expectedJac.Y)
+	expectedBytes := expectedPub.SerializeCompressed()
+
+	// Compare
+	providedPub, err := secp256k1.ParsePubKey(providedAddressBytes)
+	if err != nil {
+		return false, nil
+	}
+
+	return expectedPub.IsEqual(providedPub), nil
+}
+
+// PublicKeyToEthAddress converts a secp256k1 public key to an Ethereum address.
+//
+// Algorithm (EIP-55):
+// 1. Decompress the public key to uncompressed form (65 bytes)
+// 2. Remove the 0x04 prefix (take last 64 bytes)
+// 3. keccak256 hash of the 64 bytes
+// 4. Take the last 20 bytes as the address
+// 5. Apply EIP-55 checksum
+func PublicKeyToEthAddress(publicKey HexString) (HexString, error) {
+	keyBytes, err := HexToBytes(publicKey)
+	if err != nil {
+		return "", fmt.Errorf("invalid public key: %w", err)
+	}
+
+	pubKey, err := secp256k1.ParsePubKey(keyBytes)
+	if err != nil {
+		return "", fmt.Errorf("invalid public key: %w", err)
+	}
+
+	// Get uncompressed public key (65 bytes starting with 0x04)
+	uncompressed := pubKey.SerializeUncompressed()
+
+	// Remove 0x04 prefix and keccak256 hash
+	pubKeyWithoutPrefix := uncompressed[1:]
+	hasher := sha3.NewLegacyKeccak256()
+	hasher.Write(pubKeyWithoutPrefix)
+	hash := hasher.Sum(nil)
+
+	// Take last 20 bytes
+	addressBytes := hash[12:]
+	addressHex := fmt.Sprintf("%x", addressBytes)
+
+	// Apply EIP-55 checksum
+	checksumHasher := sha3.NewLegacyKeccak256()
+	checksumHasher.Write([]byte(addressHex))
+	checksumHash := checksumHasher.Sum(nil)
+
+	var checksummed strings.Builder
+	for i, c := range addressHex {
+		if c >= '0' && c <= '9' {
+			checksummed.WriteByte(byte(c))
+		} else {
+			nibble := (checksumHash[i/2] >> (4 * (1 - uint(i%2)))) & 0x0f
+			if nibble >= 8 {
+				checksummed.WriteByte(byte(c - 32)) // Uppercase
+			} else {
+				checksummed.WriteByte(byte(c))
+			}
+		}
+	}
+
+	return "0x" + checksummed.String(), nil
+}
+
+// EncodeStealthMetaAddress encodes a stealth meta-address to SIP format.
+//
+// Format: sip:<chain>:<spending_key>:<viewing_key>
+func EncodeStealthMetaAddress(meta *StealthMetaAddress) string {
+	return fmt.Sprintf("sip:%s:%s:%s", meta.Chain, meta.SpendingKey, meta.ViewingKey)
+}
+
+// DecodeStealthMetaAddress decodes a SIP-encoded stealth meta-address.
+func DecodeStealthMetaAddress(encoded string) (*StealthMetaAddress, error) {
+	parts := strings.Split(encoded, ":")
+	if len(parts) != 4 || parts[0] != "sip" {
+		return nil, errors.New("invalid stealth meta-address format")
+	}
+
+	return &StealthMetaAddress{
+		Chain:       parts[1],
+		SpendingKey: parts[2],
+		ViewingKey:  parts[3],
+	}, nil
+}

--- a/sdks/go/sip/types.go
+++ b/sdks/go/sip/types.go
@@ -1,0 +1,99 @@
+// Package sip provides the SIP Protocol SDK for Go.
+//
+// The privacy standard for Web3. Stealth addresses, Pedersen commitments,
+// and viewing keys for compliant privacy.
+package sip
+
+// HexString is a hex string with 0x prefix (e.g., "0x1234abcd")
+type HexString = string
+
+// ChainID is a chain identifier (e.g., "ethereum", "solana", "near")
+type ChainID = string
+
+// Hash is a 32-byte hash as hex string with 0x prefix
+type Hash = string
+
+// StealthMetaAddress contains public keys for generating one-time addresses.
+type StealthMetaAddress struct {
+	// SpendingKey is a compressed secp256k1 public key (33 bytes, 0x02/0x03 prefix)
+	SpendingKey HexString `json:"spending_key"`
+	// ViewingKey is a compressed secp256k1 public key (33 bytes, 0x02/0x03 prefix)
+	ViewingKey HexString `json:"viewing_key"`
+	// Chain is the blockchain this address is for
+	Chain ChainID `json:"chain"`
+	// Label is an optional human-readable label
+	Label string `json:"label,omitempty"`
+}
+
+// StealthAddress is a one-time stealth address derived from a meta-address.
+type StealthAddress struct {
+	// Address is the stealth address (compressed public key)
+	Address HexString `json:"address"`
+	// EphemeralPublicKey is the sender's ephemeral public key
+	EphemeralPublicKey HexString `json:"ephemeral_public_key"`
+	// ViewTag is the first byte of shared secret hash for efficient scanning
+	ViewTag uint8 `json:"view_tag"`
+}
+
+// StealthAddressRecovery contains recovery data for spending from a stealth address.
+type StealthAddressRecovery struct {
+	// StealthAddress is the stealth address being recovered
+	StealthAddress HexString `json:"stealth_address"`
+	// EphemeralPublicKey is the ephemeral key used to generate the address
+	EphemeralPublicKey HexString `json:"ephemeral_public_key"`
+	// PrivateKey is the derived private key for spending
+	PrivateKey HexString `json:"private_key"`
+}
+
+// PedersenCommitment is a Pedersen commitment with its blinding factor.
+//
+// C = v*G + r*H where:
+//   - v = value (hidden)
+//   - r = blinding factor (random)
+//   - G, H = independent generators
+type PedersenCommitment struct {
+	// Commitment is the commitment point (compressed, 33 bytes)
+	Commitment HexString `json:"commitment"`
+	// Blinding is the blinding factor (32 bytes, secret)
+	Blinding HexString `json:"blinding"`
+}
+
+// ViewingKey is a viewing key for selective disclosure.
+type ViewingKey struct {
+	// Key is the viewing key (32 bytes)
+	Key HexString `json:"key"`
+	// KeyHash is the SHA-256 hash of the key for indexing
+	KeyHash HexString `json:"key_hash"`
+	// CreatedAt is the Unix timestamp of key creation (milliseconds)
+	CreatedAt int64 `json:"created_at"`
+	// Label is an optional human-readable label
+	Label string `json:"label,omitempty"`
+}
+
+// PrivacyLevel represents privacy levels for SIP transactions.
+type PrivacyLevel string
+
+const (
+	// PrivacyTransparent - No privacy, all data public
+	PrivacyTransparent PrivacyLevel = "transparent"
+	// PrivacyShielded - Full privacy, sender/amount/recipient hidden
+	PrivacyShielded PrivacyLevel = "shielded"
+	// PrivacyCompliant - Privacy with viewing key for auditors
+	PrivacyCompliant PrivacyLevel = "compliant"
+)
+
+// EncryptedPayload contains encrypted data with nonce for decryption.
+type EncryptedPayload struct {
+	// Ciphertext is the encrypted data (hex)
+	Ciphertext HexString `json:"ciphertext"`
+	// Nonce is the nonce/IV used for encryption (hex)
+	Nonce HexString `json:"nonce"`
+}
+
+// Generators contains the G and H points for ZK proof integration.
+type Generators struct {
+	Gx HexString `json:"gx"`
+	Gy HexString `json:"gy"`
+	Hx HexString `json:"hx"`
+	Hy HexString `json:"hy"`
+}

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,0 +1,179 @@
+# SIP Protocol Python SDK
+
+The privacy standard for Web3. Stealth addresses, Pedersen commitments, and viewing keys for compliant privacy.
+
+## Installation
+
+```bash
+pip install sip-protocol
+```
+
+## Quick Start
+
+```python
+from sip_protocol import (
+    generate_stealth_meta_address,
+    generate_stealth_address,
+    derive_stealth_private_key,
+    commit,
+    verify_opening,
+    generate_viewing_key,
+    encrypt_for_viewing_key,
+    decrypt_with_viewing_key,
+    PrivacyLevel,
+)
+
+# Generate stealth address keypair
+meta, spending_priv, viewing_priv = generate_stealth_meta_address("ethereum")
+print(f"Spending key: {meta.spending_key}")
+print(f"Viewing key: {meta.viewing_key}")
+
+# Generate one-time stealth address for payment
+stealth, shared_secret = generate_stealth_address(meta)
+print(f"Stealth address: {stealth.address}")
+
+# Recipient derives private key to spend
+recovery = derive_stealth_private_key(stealth, spending_priv, viewing_priv)
+print(f"Derived private key: {recovery.private_key}")
+```
+
+## Features
+
+### Stealth Addresses (EIP-5564)
+
+Generate unlinkable one-time addresses for private payments:
+
+```python
+from sip_protocol import (
+    generate_stealth_meta_address,
+    generate_stealth_address,
+    check_stealth_address,
+    public_key_to_eth_address,
+)
+
+# Recipient publishes their meta-address
+meta, spending_priv, viewing_priv = generate_stealth_meta_address("ethereum")
+
+# Sender generates one-time stealth address
+stealth, _ = generate_stealth_address(meta)
+
+# Convert to Ethereum address
+eth_address = public_key_to_eth_address(stealth.address)
+print(f"Send ETH to: {eth_address}")
+
+# Recipient scans for their payments
+is_mine = check_stealth_address(stealth, spending_priv, viewing_priv)
+```
+
+### Pedersen Commitments
+
+Hide amounts with homomorphic commitments:
+
+```python
+from sip_protocol import (
+    commit,
+    verify_opening,
+    add_commitments,
+    add_blindings,
+)
+
+# Create commitment to 100 tokens
+c1, b1 = commit(100)
+
+# Create commitment to 50 tokens
+c2, b2 = commit(50)
+
+# Add commitments homomorphically
+c_sum = add_commitments(c1, c2)
+b_sum = add_blindings(b1, b2)
+
+# Verify the sum
+assert verify_opening(c_sum, 150, b_sum)
+```
+
+### Viewing Keys
+
+Selective disclosure for compliance:
+
+```python
+from sip_protocol import (
+    generate_viewing_key,
+    encrypt_for_viewing_key,
+    decrypt_with_viewing_key,
+)
+
+# Generate viewing key for auditor
+vk = generate_viewing_key("tax-audit-2024")
+
+# Encrypt transaction details
+payload = encrypt_for_viewing_key(vk.key, b"Transaction: 100 USDC to 0x...")
+
+# Auditor decrypts with viewing key
+plaintext = decrypt_with_viewing_key(vk.key, payload)
+```
+
+## Privacy Levels
+
+```python
+from sip_protocol import PrivacyLevel
+
+# TRANSPARENT - No privacy, all data public
+# SHIELDED - Full privacy, sender/amount/recipient hidden
+# COMPLIANT - Privacy with viewing key for auditors
+```
+
+## API Reference
+
+### Stealth Addresses
+
+- `generate_stealth_meta_address(chain, label?)` - Generate keypair
+- `generate_stealth_address(meta_address)` - Generate one-time address
+- `derive_stealth_private_key(stealth, spending_priv, viewing_priv)` - Recover private key
+- `check_stealth_address(stealth, spending_priv, viewing_priv)` - Check ownership
+- `public_key_to_eth_address(public_key)` - Convert to ETH address
+- `encode_stealth_meta_address(meta)` - Encode to SIP format
+- `decode_stealth_meta_address(encoded)` - Decode from SIP format
+
+### Pedersen Commitments
+
+- `commit(value, blinding?)` - Create commitment
+- `verify_opening(commitment, value, blinding)` - Verify commitment
+- `add_commitments(c1, c2)` - Homomorphic addition
+- `subtract_commitments(c1, c2)` - Homomorphic subtraction
+- `add_blindings(b1, b2)` - Add blinding factors
+- `subtract_blindings(b1, b2)` - Subtract blinding factors
+- `generate_blinding()` - Generate random blinding
+
+### Viewing Keys
+
+- `generate_viewing_key(label?)` - Generate viewing key
+- `derive_viewing_key_hash(viewing_key)` - Get key hash
+- `encrypt_for_viewing_key(viewing_key, plaintext)` - Encrypt data
+- `decrypt_with_viewing_key(viewing_key, payload)` - Decrypt data
+
+## Development
+
+```bash
+# Install dev dependencies
+pip install -e ".[dev]"
+
+# Run tests
+pytest
+
+# Type check
+mypy sip_protocol
+
+# Lint
+ruff check sip_protocol
+```
+
+## License
+
+MIT License - see [LICENSE](../../LICENSE) for details.
+
+## Links
+
+- [Website](https://sip-protocol.org)
+- [Documentation](https://docs.sip-protocol.org)
+- [GitHub](https://github.com/sip-protocol/sip-protocol)
+- [TypeScript SDK](https://www.npmjs.com/package/@sip-protocol/sdk)

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,0 +1,73 @@
+[project]
+name = "sip-protocol"
+version = "0.1.0"
+description = "SIP Protocol SDK - Privacy standard for Web3"
+readme = "README.md"
+license = { text = "MIT" }
+authors = [
+    { name = "SIP Protocol", email = "rector@rectorspace.com" }
+]
+requires-python = ">=3.9"
+keywords = ["privacy", "web3", "blockchain", "stealth-addresses", "pedersen-commitments"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Security :: Cryptography",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+dependencies = [
+    "py_ecc>=7.0.0",
+    "pycryptodome>=3.19.0",
+    "coincurve>=19.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4.0",
+    "pytest-cov>=4.1.0",
+    "mypy>=1.7.0",
+    "ruff>=0.1.6",
+]
+
+[project.urls]
+Homepage = "https://sip-protocol.org"
+Documentation = "https://docs.sip-protocol.org"
+Repository = "https://github.com/sip-protocol/sip-protocol"
+Issues = "https://github.com/sip-protocol/sip-protocol/issues"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/sip_protocol",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["sip_protocol"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "N", "UP", "B"]
+ignore = ["E501"]
+
+[tool.mypy]
+python_version = "3.9"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v --cov=sip_protocol --cov-report=term-missing"

--- a/sdks/python/sip_protocol/__init__.py
+++ b/sdks/python/sip_protocol/__init__.py
@@ -1,0 +1,102 @@
+"""
+SIP Protocol SDK for Python
+
+The privacy standard for Web3. Stealth addresses, Pedersen commitments,
+and viewing keys for compliant privacy.
+
+Example:
+    >>> from sip_protocol import generate_stealth_meta_address, commit
+    >>>
+    >>> # Generate stealth address keypair
+    >>> meta, spending_priv, viewing_priv = generate_stealth_meta_address("ethereum")
+    >>>
+    >>> # Create a Pedersen commitment
+    >>> commitment, blinding = commit(1000)
+"""
+
+__version__ = "0.1.0"
+
+from .crypto import (
+    hash_sha256,
+    generate_random_bytes,
+    generate_intent_id,
+)
+
+from .commitment import (
+    commit,
+    verify_opening,
+    commit_zero,
+    add_commitments,
+    subtract_commitments,
+    add_blindings,
+    subtract_blindings,
+    generate_blinding,
+    get_generators,
+)
+
+from .stealth import (
+    generate_stealth_meta_address,
+    generate_stealth_address,
+    derive_stealth_private_key,
+    check_stealth_address,
+    public_key_to_eth_address,
+    encode_stealth_meta_address,
+    decode_stealth_meta_address,
+)
+
+from .privacy import (
+    generate_viewing_key,
+    derive_viewing_key_hash,
+    encrypt_for_viewing_key,
+    decrypt_with_viewing_key,
+    PrivacyLevel,
+)
+
+from .types import (
+    HexString,
+    StealthMetaAddress,
+    StealthAddress,
+    StealthAddressRecovery,
+    PedersenCommitment,
+    ViewingKey,
+)
+
+__all__ = [
+    # Version
+    "__version__",
+    # Crypto
+    "hash_sha256",
+    "generate_random_bytes",
+    "generate_intent_id",
+    # Commitment
+    "commit",
+    "verify_opening",
+    "commit_zero",
+    "add_commitments",
+    "subtract_commitments",
+    "add_blindings",
+    "subtract_blindings",
+    "generate_blinding",
+    "get_generators",
+    # Stealth
+    "generate_stealth_meta_address",
+    "generate_stealth_address",
+    "derive_stealth_private_key",
+    "check_stealth_address",
+    "public_key_to_eth_address",
+    "encode_stealth_meta_address",
+    "decode_stealth_meta_address",
+    # Privacy
+    "generate_viewing_key",
+    "derive_viewing_key_hash",
+    "encrypt_for_viewing_key",
+    "decrypt_with_viewing_key",
+    "PrivacyLevel",
+    # Types
+    "HexString",
+    "StealthMetaAddress",
+    "StealthAddress",
+    "StealthAddressRecovery",
+    "PedersenCommitment",
+    "ViewingKey",
+]

--- a/sdks/python/sip_protocol/commitment.py
+++ b/sdks/python/sip_protocol/commitment.py
@@ -1,0 +1,305 @@
+"""
+Pedersen Commitment Implementation for SIP Protocol.
+
+Cryptographically secure Pedersen commitments on secp256k1.
+
+Security Properties:
+- Hiding (Computational): Cannot determine value from commitment
+- Binding (Computational): Cannot open commitment to different value
+- Homomorphic: C(v1) + C(v2) = C(v1 + v2) when blindings sum
+
+Generator H Construction:
+H is constructed using "nothing-up-my-sleeve" (NUMS) method to ensure
+nobody knows the discrete log of H w.r.t. G.
+"""
+
+import hashlib
+import secrets
+from typing import Tuple, Dict
+
+from coincurve import PublicKey, PrivateKey
+from coincurve._libsecp256k1 import ffi, lib
+
+from .types import HexString, PedersenCommitment
+from .crypto import hex_to_bytes, bytes_to_hex
+
+
+# Domain separation tag for H generation
+H_DOMAIN = "SIP-PEDERSEN-GENERATOR-H-v1"
+
+# secp256k1 curve order
+CURVE_ORDER = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+
+
+def _generate_h() -> bytes:
+    """
+    Generate the independent generator H using NUMS method.
+
+    Uses try-and-increment approach:
+    1. Hash the domain separator to get a candidate x-coordinate
+    2. Try to lift x to a curve point
+    3. If it fails, increment counter and retry
+    """
+    for counter in range(256):
+        # Create candidate x-coordinate
+        input_data = f"{H_DOMAIN}:{counter}".encode("utf-8")
+        hash_bytes = hashlib.sha256(input_data).digest()
+
+        try:
+            # Try to create a point from this x-coordinate (with even y)
+            # The '02' prefix indicates compressed point with even y
+            point_bytes = bytes([0x02]) + hash_bytes
+
+            # Validate this is a valid curve point
+            PublicKey(point_bytes)
+
+            # Check it's not the identity or base point
+            # (coincurve doesn't easily expose G, but this hash won't collide)
+            return point_bytes
+        except Exception:
+            # Not a valid point, try next counter
+            continue
+
+    raise RuntimeError("Failed to generate H point - this should never happen")
+
+
+# The independent generator H (NUMS point)
+_H_BYTES = _generate_h()
+
+
+def _point_multiply(scalar: int, point_bytes: bytes) -> bytes:
+    """Multiply a point by a scalar."""
+    # Use coincurve for point operations
+    point = PublicKey(point_bytes)
+    result = point.multiply(scalar.to_bytes(32, "big"))
+    return result.format(compressed=True)
+
+
+def _point_add(point1_bytes: bytes, point2_bytes: bytes) -> bytes:
+    """Add two curve points."""
+    point1 = PublicKey(point1_bytes)
+    result = point1.combine([PublicKey(point2_bytes)])
+    return result.format(compressed=True)
+
+
+def _get_generator_g() -> bytes:
+    """Get the base generator G."""
+    # G is the public key for private key = 1
+    priv = PrivateKey(b"\x00" * 31 + b"\x01")
+    return priv.public_key.format(compressed=True)
+
+
+_G_BYTES = _get_generator_g()
+
+
+def commit(value: int, blinding: bytes = None) -> Tuple[HexString, HexString]:
+    """
+    Create a Pedersen commitment to a value.
+
+    C = v*G + r*H
+
+    Where:
+    - v = value (the amount being committed)
+    - r = blinding factor (random, keeps value hidden)
+    - G = base generator
+    - H = independent generator (NUMS)
+
+    Args:
+        value: The value to commit to (must be < curve order)
+        blinding: Optional blinding factor (random 32 bytes if not provided)
+
+    Returns:
+        Tuple of (commitment, blinding) as hex strings
+
+    Example:
+        >>> commitment, blinding = commit(100)
+        >>> verify_opening(commitment, 100, blinding)
+        True
+    """
+    if value < 0:
+        raise ValueError("Value must be non-negative")
+    if value >= CURVE_ORDER:
+        raise ValueError("Value must be less than curve order")
+
+    # Generate or use provided blinding factor
+    if blinding is None:
+        blinding = secrets.token_bytes(32)
+    elif len(blinding) != 32:
+        raise ValueError("Blinding must be 32 bytes")
+
+    # Ensure blinding is in valid range (mod n)
+    r_scalar = int.from_bytes(blinding, "big") % CURVE_ORDER
+    if r_scalar == 0:
+        raise RuntimeError("CRITICAL: Zero blinding scalar - investigate RNG")
+
+    # C = v*G + r*H
+    if value == 0:
+        # Only blinding contributes: C = r*H
+        c_bytes = _point_multiply(r_scalar, _H_BYTES)
+    else:
+        # Normal case: C = v*G + r*H
+        v_g = _point_multiply(value, _G_BYTES)
+        r_h = _point_multiply(r_scalar, _H_BYTES)
+        c_bytes = _point_add(v_g, r_h)
+
+    return (bytes_to_hex(c_bytes), bytes_to_hex(blinding))
+
+
+def verify_opening(commitment: HexString, value: int, blinding: HexString) -> bool:
+    """
+    Verify that a commitment opens to a specific value.
+
+    Recomputes C' = v*G + r*H and checks if C' == C
+
+    Args:
+        commitment: The commitment point to verify
+        value: The claimed value
+        blinding: The blinding factor used
+
+    Returns:
+        True if the commitment opens correctly
+    """
+    try:
+        # Parse the commitment point
+        c_bytes = hex_to_bytes(commitment)
+
+        # Recompute expected commitment
+        blinding_bytes = hex_to_bytes(blinding)
+        r_scalar = int.from_bytes(blinding_bytes, "big") % CURVE_ORDER
+
+        if value == 0:
+            expected = _point_multiply(r_scalar, _H_BYTES)
+        else:
+            v_g = _point_multiply(value, _G_BYTES)
+            r_h = _point_multiply(r_scalar, _H_BYTES)
+            expected = _point_add(v_g, r_h)
+
+        return c_bytes == expected
+    except Exception:
+        return False
+
+
+def commit_zero(blinding: bytes) -> Tuple[HexString, HexString]:
+    """
+    Create a commitment to zero with a specific blinding factor.
+
+    C = 0*G + r*H = r*H
+
+    Useful for creating balance proofs.
+
+    Args:
+        blinding: The blinding factor
+
+    Returns:
+        Tuple of (commitment, blinding)
+    """
+    return commit(0, blinding)
+
+
+def add_commitments(c1: HexString, c2: HexString) -> HexString:
+    """
+    Add two commitments homomorphically.
+
+    C1 + C2 = (v1*G + r1*H) + (v2*G + r2*H) = (v1+v2)*G + (r1+r2)*H
+
+    Note: The blinding factors also add. If you need to verify the sum,
+    you must also sum the blinding factors.
+
+    Args:
+        c1: First commitment point
+        c2: Second commitment point
+
+    Returns:
+        Sum of commitments
+    """
+    c1_bytes = hex_to_bytes(c1)
+    c2_bytes = hex_to_bytes(c2)
+    result = _point_add(c1_bytes, c2_bytes)
+    return bytes_to_hex(result)
+
+
+def subtract_commitments(c1: HexString, c2: HexString) -> HexString:
+    """
+    Subtract two commitments homomorphically.
+
+    C1 - C2 = (v1-v2)*G + (r1-r2)*H
+
+    Args:
+        c1: First commitment point
+        c2: Second commitment point (to subtract)
+
+    Returns:
+        Difference of commitments
+    """
+    c1_bytes = hex_to_bytes(c1)
+    c2_bytes = hex_to_bytes(c2)
+
+    # Negate c2 by negating the y-coordinate (flip parity byte)
+    c2_negated = bytes([0x03 if c2_bytes[0] == 0x02 else 0x02]) + c2_bytes[1:]
+
+    result = _point_add(c1_bytes, c2_negated)
+    return bytes_to_hex(result)
+
+
+def add_blindings(b1: HexString, b2: HexString) -> HexString:
+    """
+    Add blinding factors (for use with homomorphic addition).
+
+    Args:
+        b1: First blinding factor
+        b2: Second blinding factor
+
+    Returns:
+        Sum of blindings (mod curve order)
+    """
+    r1 = int.from_bytes(hex_to_bytes(b1), "big")
+    r2 = int.from_bytes(hex_to_bytes(b2), "big")
+    result = (r1 + r2) % CURVE_ORDER
+    return bytes_to_hex(result.to_bytes(32, "big"))
+
+
+def subtract_blindings(b1: HexString, b2: HexString) -> HexString:
+    """
+    Subtract blinding factors (for use with homomorphic subtraction).
+
+    Args:
+        b1: First blinding factor
+        b2: Second blinding factor (to subtract)
+
+    Returns:
+        Difference of blindings (mod curve order)
+    """
+    r1 = int.from_bytes(hex_to_bytes(b1), "big")
+    r2 = int.from_bytes(hex_to_bytes(b2), "big")
+    result = (r1 - r2 + CURVE_ORDER) % CURVE_ORDER
+    return bytes_to_hex(result.to_bytes(32, "big"))
+
+
+def generate_blinding() -> HexString:
+    """Generate a random blinding factor."""
+    return bytes_to_hex(secrets.token_bytes(32))
+
+
+def get_generators() -> Dict[str, Dict[str, HexString]]:
+    """
+    Get the generators for ZK proof integration.
+
+    Returns the G and H points for use in ZK circuits.
+    """
+    g_point = PublicKey(_G_BYTES)
+    h_point = PublicKey(_H_BYTES)
+
+    # Get uncompressed format to extract x, y coordinates
+    g_uncompressed = g_point.format(compressed=False)
+    h_uncompressed = h_point.format(compressed=False)
+
+    return {
+        "G": {
+            "x": bytes_to_hex(g_uncompressed[1:33]),
+            "y": bytes_to_hex(g_uncompressed[33:]),
+        },
+        "H": {
+            "x": bytes_to_hex(h_uncompressed[1:33]),
+            "y": bytes_to_hex(h_uncompressed[33:]),
+        },
+    }

--- a/sdks/python/sip_protocol/crypto.py
+++ b/sdks/python/sip_protocol/crypto.py
@@ -1,0 +1,100 @@
+"""
+Cryptographic utilities for SIP Protocol.
+
+Provides low-level cryptographic primitives including:
+- Hash functions (SHA-256)
+- Random number generation
+- Intent ID generation
+"""
+
+import hashlib
+import secrets
+from typing import Union
+
+from .types import HexString, Hash
+
+
+def hash_sha256(data: Union[str, bytes]) -> Hash:
+    """
+    Compute SHA-256 hash of data.
+
+    Args:
+        data: Input data as UTF-8 string or raw bytes
+
+    Returns:
+        32-byte hash as hex string with 0x prefix
+
+    Example:
+        >>> hash_sha256("Hello, SIP Protocol!")
+        '0xabc123...'
+    """
+    if isinstance(data, str):
+        data = data.encode("utf-8")
+    digest = hashlib.sha256(data).hexdigest()
+    return Hash(f"0x{digest}")
+
+
+def generate_random_bytes(length: int) -> HexString:
+    """
+    Generate cryptographically secure random bytes.
+
+    Uses the platform's secure random source.
+
+    Args:
+        length: Number of random bytes to generate
+
+    Returns:
+        Random bytes as hex string with 0x prefix
+
+    Example:
+        >>> generate_random_bytes(32)  # 32-byte private key
+        '0xabc123...def'
+    """
+    random_bytes = secrets.token_bytes(length)
+    return HexString(f"0x{random_bytes.hex()}")
+
+
+def generate_intent_id() -> str:
+    """
+    Generate a unique intent identifier.
+
+    Creates a cryptographically random intent ID with the `sip-` prefix.
+    IDs are globally unique with negligible collision probability (128-bit).
+
+    Returns:
+        Intent ID string in format: `sip-<32 hex chars>`
+
+    Example:
+        >>> generate_intent_id()
+        'sip-a1b2c3d4e5f67890a1b2c3d4e5f67890'
+    """
+    random_bytes = secrets.token_bytes(16)
+    return f"sip-{random_bytes.hex()}"
+
+
+def hex_to_bytes(hex_str: str) -> bytes:
+    """
+    Convert hex string to bytes.
+
+    Args:
+        hex_str: Hex string with or without 0x prefix
+
+    Returns:
+        Raw bytes
+    """
+    if hex_str.startswith("0x"):
+        hex_str = hex_str[2:]
+    return bytes.fromhex(hex_str)
+
+
+def bytes_to_hex(data: bytes) -> HexString:
+    """
+    Convert bytes to hex string with 0x prefix.
+
+    Args:
+        data: Raw bytes
+
+    Returns:
+        Hex string with 0x prefix
+    """
+    return HexString(f"0x{data.hex()}")

--- a/sdks/python/sip_protocol/privacy.py
+++ b/sdks/python/sip_protocol/privacy.py
@@ -1,0 +1,183 @@
+"""
+Privacy and Viewing Key Implementation for SIP Protocol.
+
+Provides:
+- Viewing key generation and derivation
+- XChaCha20-Poly1305 encryption/decryption
+- Selective disclosure for compliance
+"""
+
+import hashlib
+import secrets
+import time
+from typing import Optional
+
+from Crypto.Cipher import ChaCha20_Poly1305
+
+from .types import HexString, ViewingKey, EncryptedPayload, PrivacyLevel
+from .crypto import hex_to_bytes, bytes_to_hex
+
+
+def generate_viewing_key(label: Optional[str] = None) -> ViewingKey:
+    """
+    Generate a new viewing key for selective disclosure.
+
+    Args:
+        label: Optional human-readable label
+
+    Returns:
+        ViewingKey object with key and hash
+
+    Example:
+        >>> vk = generate_viewing_key("audit-2024")
+        >>> print(vk.key_hash)
+        '0xabc123...'
+    """
+    key = secrets.token_bytes(32)
+    key_hash = hashlib.sha256(key).digest()
+    created_at = int(time.time() * 1000)
+
+    return ViewingKey(
+        key=bytes_to_hex(key),
+        key_hash=bytes_to_hex(key_hash),
+        created_at=created_at,
+        label=label,
+    )
+
+
+def derive_viewing_key_hash(viewing_key: HexString) -> HexString:
+    """
+    Derive the hash of a viewing key.
+
+    This hash is used for indexing and verification without
+    exposing the actual key.
+
+    Args:
+        viewing_key: The viewing key (32 bytes)
+
+    Returns:
+        SHA-256 hash of the viewing key
+
+    Example:
+        >>> key_hash = derive_viewing_key_hash(vk.key)
+    """
+    key_bytes = hex_to_bytes(viewing_key)
+    hash_bytes = hashlib.sha256(key_bytes).digest()
+    return bytes_to_hex(hash_bytes)
+
+
+def encrypt_for_viewing_key(
+    viewing_key: HexString, plaintext: bytes
+) -> EncryptedPayload:
+    """
+    Encrypt data for viewing key holders.
+
+    Uses XChaCha20-Poly1305 for authenticated encryption.
+
+    Args:
+        viewing_key: The viewing key (32 bytes)
+        plaintext: Data to encrypt
+
+    Returns:
+        EncryptedPayload with ciphertext and nonce
+
+    Example:
+        >>> payload = encrypt_for_viewing_key(vk.key, b"secret data")
+    """
+    key_bytes = hex_to_bytes(viewing_key)
+
+    # XChaCha20-Poly1305 requires 24-byte nonce
+    nonce = secrets.token_bytes(24)
+
+    cipher = ChaCha20_Poly1305.new(key=key_bytes, nonce=nonce)
+    ciphertext, tag = cipher.encrypt_and_digest(plaintext)
+
+    # Append tag to ciphertext for authenticated decryption
+    ciphertext_with_tag = ciphertext + tag
+
+    return EncryptedPayload(
+        ciphertext=bytes_to_hex(ciphertext_with_tag),
+        nonce=bytes_to_hex(nonce),
+    )
+
+
+def decrypt_with_viewing_key(
+    viewing_key: HexString, payload: EncryptedPayload
+) -> bytes:
+    """
+    Decrypt data using a viewing key.
+
+    Args:
+        viewing_key: The viewing key (32 bytes)
+        payload: The encrypted payload (ciphertext + nonce)
+
+    Returns:
+        Decrypted plaintext
+
+    Raises:
+        ValueError: If decryption fails (wrong key or corrupted data)
+
+    Example:
+        >>> plaintext = decrypt_with_viewing_key(vk.key, payload)
+    """
+    key_bytes = hex_to_bytes(viewing_key)
+    nonce_bytes = hex_to_bytes(payload.nonce)
+    ciphertext_with_tag = hex_to_bytes(payload.ciphertext)
+
+    # Split ciphertext and tag (tag is last 16 bytes)
+    ciphertext = ciphertext_with_tag[:-16]
+    tag = ciphertext_with_tag[-16:]
+
+    cipher = ChaCha20_Poly1305.new(key=key_bytes, nonce=nonce_bytes)
+
+    try:
+        plaintext = cipher.decrypt_and_verify(ciphertext, tag)
+        return plaintext
+    except ValueError as e:
+        raise ValueError(f"Decryption failed: {e}")
+
+
+def validate_privacy_level(level: str) -> PrivacyLevel:
+    """
+    Validate and convert a string to PrivacyLevel enum.
+
+    Args:
+        level: String representation of privacy level
+
+    Returns:
+        PrivacyLevel enum value
+
+    Raises:
+        ValueError: If level is not valid
+    """
+    try:
+        return PrivacyLevel(level.lower())
+    except ValueError:
+        valid = [e.value for e in PrivacyLevel]
+        raise ValueError(f"Invalid privacy level: {level}. Valid options: {valid}")
+
+
+def should_encrypt(level: PrivacyLevel) -> bool:
+    """
+    Determine if encryption should be used for a privacy level.
+
+    Args:
+        level: The privacy level
+
+    Returns:
+        True if data should be encrypted
+    """
+    return level in (PrivacyLevel.SHIELDED, PrivacyLevel.COMPLIANT)
+
+
+def should_include_viewing_key(level: PrivacyLevel) -> bool:
+    """
+    Determine if viewing key should be included for a privacy level.
+
+    Args:
+        level: The privacy level
+
+    Returns:
+        True if viewing key should be included
+    """
+    return level == PrivacyLevel.COMPLIANT

--- a/sdks/python/sip_protocol/stealth.py
+++ b/sdks/python/sip_protocol/stealth.py
@@ -1,0 +1,336 @@
+"""
+Stealth Address Implementation for SIP Protocol.
+
+Implements EIP-5564 style stealth addresses using secp256k1.
+Used for Ethereum, Polygon, Arbitrum, Optimism, Base, Bitcoin, Zcash.
+
+Stealth addresses provide unlinkable payments:
+1. Sender generates one-time address from recipient's public meta-address
+2. Recipient scans blockchain using view tag for efficient filtering
+3. Only recipient can derive the private key to spend
+"""
+
+import hashlib
+import secrets
+from typing import Tuple, Optional
+
+from coincurve import PublicKey, PrivateKey
+from Crypto.Hash import keccak
+
+from .types import (
+    HexString,
+    ChainId,
+    StealthMetaAddress,
+    StealthAddress,
+    StealthAddressRecovery,
+)
+from .crypto import hex_to_bytes, bytes_to_hex
+
+
+# secp256k1 curve order
+CURVE_ORDER = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+
+
+def generate_stealth_meta_address(
+    chain: ChainId, label: Optional[str] = None
+) -> Tuple[StealthMetaAddress, HexString, HexString]:
+    """
+    Generate a new stealth meta-address keypair.
+
+    Args:
+        chain: The blockchain this address is for
+        label: Optional human-readable label
+
+    Returns:
+        Tuple of (meta_address, spending_private_key, viewing_private_key)
+
+    Example:
+        >>> meta, spending_priv, viewing_priv = generate_stealth_meta_address("ethereum")
+        >>> print(meta.spending_key)
+        '0x02abc...'
+    """
+    # Generate random private keys
+    spending_private = secrets.token_bytes(32)
+    viewing_private = secrets.token_bytes(32)
+
+    # Derive public keys
+    spending_pub = PrivateKey(spending_private).public_key.format(compressed=True)
+    viewing_pub = PrivateKey(viewing_private).public_key.format(compressed=True)
+
+    meta_address = StealthMetaAddress(
+        spending_key=bytes_to_hex(spending_pub),
+        viewing_key=bytes_to_hex(viewing_pub),
+        chain=chain,
+        label=label,
+    )
+
+    return (
+        meta_address,
+        bytes_to_hex(spending_private),
+        bytes_to_hex(viewing_private),
+    )
+
+
+def generate_stealth_address(
+    recipient_meta_address: StealthMetaAddress,
+) -> Tuple[StealthAddress, HexString]:
+    """
+    Generate a one-time stealth address for a recipient.
+
+    Protocol:
+    1. Sender generates ephemeral keypair (r, R = r*G)
+    2. Compute shared secret: S = r * P_spend
+    3. Compute stealth address: A = Q_view + hash(S)*G
+    4. View tag = first byte of hash(S) for efficient scanning
+
+    Args:
+        recipient_meta_address: The recipient's stealth meta-address
+
+    Returns:
+        Tuple of (stealth_address, shared_secret)
+
+    Example:
+        >>> stealth, secret = generate_stealth_address(recipient_meta)
+        >>> print(stealth.address)
+        '0x02def...'
+    """
+    # Generate ephemeral keypair
+    ephemeral_private = secrets.token_bytes(32)
+    ephemeral_pub = PrivateKey(ephemeral_private).public_key.format(compressed=True)
+
+    # Parse recipient's keys
+    spending_key_bytes = hex_to_bytes(recipient_meta_address.spending_key)
+    viewing_key_bytes = hex_to_bytes(recipient_meta_address.viewing_key)
+
+    # Compute shared secret: S = r * P_spend
+    spending_point = PublicKey(spending_key_bytes)
+    shared_secret_point = spending_point.multiply(ephemeral_private)
+    shared_secret_bytes = shared_secret_point.format(compressed=True)
+
+    # Hash the shared secret for use as a scalar
+    shared_secret_hash = hashlib.sha256(shared_secret_bytes).digest()
+
+    # Compute stealth address: A = Q_view + hash(S)*G
+    # hash(S)*G
+    hash_scalar = int.from_bytes(shared_secret_hash, "big") % CURVE_ORDER
+    hash_times_g = PrivateKey(hash_scalar.to_bytes(32, "big")).public_key
+
+    # Q_view + hash(S)*G
+    viewing_point = PublicKey(viewing_key_bytes)
+    stealth_point = viewing_point.combine([hash_times_g])
+    stealth_address_bytes = stealth_point.format(compressed=True)
+
+    # View tag (first byte of hash for efficient scanning)
+    view_tag = shared_secret_hash[0]
+
+    stealth_address = StealthAddress(
+        address=bytes_to_hex(stealth_address_bytes),
+        ephemeral_public_key=bytes_to_hex(ephemeral_pub),
+        view_tag=view_tag,
+    )
+
+    return (stealth_address, bytes_to_hex(shared_secret_hash))
+
+
+def derive_stealth_private_key(
+    stealth_address: StealthAddress,
+    spending_private_key: HexString,
+    viewing_private_key: HexString,
+) -> StealthAddressRecovery:
+    """
+    Derive the private key for a stealth address.
+
+    Protocol:
+    1. Compute shared secret: S = p_spend * R_ephemeral
+    2. Derive stealth private key: q_view + hash(S) mod n
+
+    Args:
+        stealth_address: The stealth address to recover
+        spending_private_key: Recipient's spending private key
+        viewing_private_key: Recipient's viewing private key
+
+    Returns:
+        StealthAddressRecovery with the derived private key
+
+    Example:
+        >>> recovery = derive_stealth_private_key(stealth, spending_priv, viewing_priv)
+        >>> # Use recovery.private_key to sign transactions
+    """
+    spending_priv_bytes = hex_to_bytes(spending_private_key)
+    viewing_priv_bytes = hex_to_bytes(viewing_private_key)
+    ephemeral_pub_bytes = hex_to_bytes(stealth_address.ephemeral_public_key)
+
+    # Compute shared secret: S = p_spend * R_ephemeral
+    ephemeral_point = PublicKey(ephemeral_pub_bytes)
+    shared_secret_point = ephemeral_point.multiply(spending_priv_bytes)
+    shared_secret_bytes = shared_secret_point.format(compressed=True)
+
+    # Hash the shared secret
+    shared_secret_hash = hashlib.sha256(shared_secret_bytes).digest()
+
+    # Derive stealth private key: q_view + hash(S) mod n
+    viewing_scalar = int.from_bytes(viewing_priv_bytes, "big")
+    hash_scalar = int.from_bytes(shared_secret_hash, "big")
+    stealth_private_scalar = (viewing_scalar + hash_scalar) % CURVE_ORDER
+
+    stealth_private_key = stealth_private_scalar.to_bytes(32, "big")
+
+    return StealthAddressRecovery(
+        stealth_address=stealth_address.address,
+        ephemeral_public_key=stealth_address.ephemeral_public_key,
+        private_key=bytes_to_hex(stealth_private_key),
+    )
+
+
+def check_stealth_address(
+    stealth_address: StealthAddress,
+    spending_private_key: HexString,
+    viewing_private_key: HexString,
+) -> bool:
+    """
+    Check if a stealth address belongs to this recipient.
+
+    Uses view tag for efficient filtering, then does full verification.
+
+    Args:
+        stealth_address: The stealth address to check
+        spending_private_key: Recipient's spending private key
+        viewing_private_key: Recipient's viewing private key
+
+    Returns:
+        True if the stealth address belongs to this recipient
+
+    Example:
+        >>> is_mine = check_stealth_address(stealth, spending_priv, viewing_priv)
+    """
+    spending_priv_bytes = hex_to_bytes(spending_private_key)
+    viewing_priv_bytes = hex_to_bytes(viewing_private_key)
+    ephemeral_pub_bytes = hex_to_bytes(stealth_address.ephemeral_public_key)
+
+    try:
+        # Compute shared secret
+        ephemeral_point = PublicKey(ephemeral_pub_bytes)
+        shared_secret_point = ephemeral_point.multiply(spending_priv_bytes)
+        shared_secret_bytes = shared_secret_point.format(compressed=True)
+        shared_secret_hash = hashlib.sha256(shared_secret_bytes).digest()
+
+        # Quick view tag check
+        if shared_secret_hash[0] != stealth_address.view_tag:
+            return False
+
+        # Full verification: derive expected stealth address
+        viewing_scalar = int.from_bytes(viewing_priv_bytes, "big")
+        hash_scalar = int.from_bytes(shared_secret_hash, "big")
+        stealth_private_scalar = (viewing_scalar + hash_scalar) % CURVE_ORDER
+
+        # Compute expected public key
+        expected_pub = PrivateKey(
+            stealth_private_scalar.to_bytes(32, "big")
+        ).public_key.format(compressed=True)
+
+        # Compare with provided stealth address
+        provided_address = hex_to_bytes(stealth_address.address)
+        return expected_pub == provided_address
+
+    except Exception:
+        return False
+
+
+def public_key_to_eth_address(public_key: HexString) -> HexString:
+    """
+    Convert a secp256k1 public key to an Ethereum address.
+
+    Algorithm (EIP-55):
+    1. Decompress the public key to uncompressed form (65 bytes)
+    2. Remove the 0x04 prefix (take last 64 bytes)
+    3. keccak256 hash of the 64 bytes
+    4. Take the last 20 bytes as the address
+    5. Apply EIP-55 checksum
+
+    Args:
+        public_key: Compressed or uncompressed secp256k1 public key
+
+    Returns:
+        Checksummed Ethereum address
+
+    Example:
+        >>> eth_addr = public_key_to_eth_address(stealth.address)
+        >>> print(eth_addr)
+        '0x1234...abcd'
+    """
+    key_bytes = hex_to_bytes(public_key)
+
+    # Decompress if needed
+    if len(key_bytes) == 33:
+        point = PublicKey(key_bytes)
+        key_bytes = point.format(compressed=False)
+    elif len(key_bytes) != 65:
+        raise ValueError(f"Invalid public key length: {len(key_bytes)}")
+
+    # Remove 0x04 prefix and keccak256 hash
+    pub_key_without_prefix = key_bytes[1:]
+    h = keccak.new(digest_bits=256)
+    h.update(pub_key_without_prefix)
+    address_hash = h.digest()
+
+    # Take last 20 bytes
+    address_bytes = address_hash[-20:]
+    address_hex = address_bytes.hex()
+
+    # Apply EIP-55 checksum
+    h = keccak.new(digest_bits=256)
+    h.update(address_hex.encode("ascii"))
+    checksum_hash = h.hexdigest()
+
+    checksummed = ""
+    for i, char in enumerate(address_hex):
+        if char in "0123456789":
+            checksummed += char
+        else:
+            checksummed += char.upper() if int(checksum_hash[i], 16) >= 8 else char.lower()
+
+    return HexString(f"0x{checksummed}")
+
+
+def encode_stealth_meta_address(meta_address: StealthMetaAddress) -> str:
+    """
+    Encode a stealth meta-address to SIP format.
+
+    Format: sip:<chain>:<spending_key>:<viewing_key>
+
+    Args:
+        meta_address: The meta-address to encode
+
+    Returns:
+        Encoded string
+
+    Example:
+        >>> encoded = encode_stealth_meta_address(meta)
+        >>> print(encoded)
+        'sip:ethereum:0x02abc...:0x03def...'
+    """
+    return f"sip:{meta_address.chain}:{meta_address.spending_key}:{meta_address.viewing_key}"
+
+
+def decode_stealth_meta_address(encoded: str) -> StealthMetaAddress:
+    """
+    Decode a SIP-encoded stealth meta-address.
+
+    Args:
+        encoded: The encoded string (sip:<chain>:<spending>:<viewing>)
+
+    Returns:
+        StealthMetaAddress object
+
+    Raises:
+        ValueError: If the format is invalid
+    """
+    parts = encoded.split(":")
+    if len(parts) != 4 or parts[0] != "sip":
+        raise ValueError(f"Invalid stealth meta-address format: {encoded}")
+
+    return StealthMetaAddress(
+        chain=ChainId(parts[1]),
+        spending_key=HexString(parts[2]),
+        viewing_key=HexString(parts[3]),
+    )

--- a/sdks/python/sip_protocol/types.py
+++ b/sdks/python/sip_protocol/types.py
@@ -1,0 +1,135 @@
+"""
+Type definitions for SIP Protocol Python SDK.
+
+These types mirror the TypeScript definitions in @sip-protocol/types.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import NewType, Optional
+
+# Type aliases
+HexString = NewType("HexString", str)
+"""A hex string with 0x prefix (e.g., '0x1234abcd')"""
+
+ChainId = NewType("ChainId", str)
+"""Chain identifier (e.g., 'ethereum', 'solana', 'near')"""
+
+Hash = NewType("Hash", str)
+"""A 32-byte hash as hex string with 0x prefix"""
+
+
+@dataclass(frozen=True)
+class StealthMetaAddress:
+    """
+    A stealth meta-address containing public keys for generating one-time addresses.
+
+    Attributes:
+        spending_key: Compressed secp256k1 public key (33 bytes, 0x02/0x03 prefix)
+        viewing_key: Compressed secp256k1 public key (33 bytes, 0x02/0x03 prefix)
+        chain: The blockchain this address is for
+        label: Optional human-readable label
+    """
+
+    spending_key: HexString
+    viewing_key: HexString
+    chain: ChainId
+    label: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class StealthAddress:
+    """
+    A one-time stealth address derived from a meta-address.
+
+    Attributes:
+        address: The stealth address (compressed public key)
+        ephemeral_public_key: The sender's ephemeral public key
+        view_tag: First byte of shared secret hash for efficient scanning
+    """
+
+    address: HexString
+    ephemeral_public_key: HexString
+    view_tag: int
+
+
+@dataclass(frozen=True)
+class StealthAddressRecovery:
+    """
+    Recovery data for spending from a stealth address.
+
+    Attributes:
+        stealth_address: The stealth address being recovered
+        ephemeral_public_key: The ephemeral key used to generate the address
+        private_key: The derived private key for spending
+    """
+
+    stealth_address: HexString
+    ephemeral_public_key: HexString
+    private_key: HexString
+
+
+@dataclass(frozen=True)
+class PedersenCommitment:
+    """
+    A Pedersen commitment with its blinding factor.
+
+    C = v*G + r*H where:
+    - v = value (hidden)
+    - r = blinding factor (random)
+    - G, H = independent generators
+
+    Attributes:
+        commitment: The commitment point (compressed, 33 bytes)
+        blinding: The blinding factor (32 bytes, secret)
+    """
+
+    commitment: HexString
+    blinding: HexString
+
+
+@dataclass(frozen=True)
+class ViewingKey:
+    """
+    A viewing key for selective disclosure.
+
+    Attributes:
+        key: The viewing key (32 bytes)
+        key_hash: SHA-256 hash of the key for indexing
+        created_at: Unix timestamp of key creation
+        label: Optional human-readable label
+    """
+
+    key: HexString
+    key_hash: HexString
+    created_at: int
+    label: Optional[str] = None
+
+
+class PrivacyLevel(str, Enum):
+    """
+    Privacy levels for SIP transactions.
+
+    Attributes:
+        TRANSPARENT: No privacy, all data public
+        SHIELDED: Full privacy, sender/amount/recipient hidden
+        COMPLIANT: Privacy with viewing key for auditors
+    """
+
+    TRANSPARENT = "transparent"
+    SHIELDED = "shielded"
+    COMPLIANT = "compliant"
+
+
+@dataclass(frozen=True)
+class EncryptedPayload:
+    """
+    Encrypted data with nonce for decryption.
+
+    Attributes:
+        ciphertext: The encrypted data (hex)
+        nonce: The nonce/IV used for encryption (hex)
+    """
+
+    ciphertext: HexString
+    nonce: HexString

--- a/sdks/python/tests/__init__.py
+++ b/sdks/python/tests/__init__.py
@@ -1,0 +1,1 @@
+# SIP Protocol Python SDK Tests

--- a/sdks/python/tests/test_sip_protocol.py
+++ b/sdks/python/tests/test_sip_protocol.py
@@ -1,0 +1,185 @@
+"""
+SIP Protocol Python SDK Tests
+
+Tests for stealth addresses, Pedersen commitments, and viewing keys.
+"""
+
+import pytest
+
+
+class TestCrypto:
+    """Tests for crypto utilities."""
+
+    def test_hash_sha256(self):
+        from sip_protocol import hash_sha256
+
+        result = hash_sha256("hello")
+        assert result.startswith("0x")
+        assert len(result) == 66  # 0x + 64 hex chars
+
+    def test_generate_random_bytes(self):
+        from sip_protocol import generate_random_bytes
+
+        result = generate_random_bytes(32)
+        assert result.startswith("0x")
+        assert len(result) == 66  # 0x + 64 hex chars
+
+        # Should be unique
+        result2 = generate_random_bytes(32)
+        assert result != result2
+
+    def test_generate_intent_id(self):
+        from sip_protocol import generate_intent_id
+
+        result = generate_intent_id()
+        assert result.startswith("sip-")
+        assert len(result) == 36  # sip- + 32 hex chars
+
+
+class TestCommitment:
+    """Tests for Pedersen commitments."""
+
+    def test_commit_and_verify(self):
+        from sip_protocol import commit, verify_opening
+
+        commitment, blinding = commit(100)
+        assert commitment.startswith("0x")
+        assert blinding.startswith("0x")
+
+        # Should verify correctly
+        assert verify_opening(commitment, 100, blinding)
+
+        # Should fail with wrong value
+        assert not verify_opening(commitment, 101, blinding)
+
+    def test_homomorphic_addition(self):
+        from sip_protocol import commit, add_commitments, add_blindings, verify_opening
+
+        c1, b1 = commit(100)
+        c2, b2 = commit(50)
+
+        c_sum = add_commitments(c1, c2)
+        b_sum = add_blindings(b1, b2)
+
+        # Sum should verify to 150
+        assert verify_opening(c_sum, 150, b_sum)
+
+
+class TestStealth:
+    """Tests for stealth addresses."""
+
+    def test_generate_meta_address(self):
+        from sip_protocol import generate_stealth_meta_address
+
+        meta, spending_priv, viewing_priv = generate_stealth_meta_address("ethereum")
+
+        assert meta.chain == "ethereum"
+        assert meta.spending_key.startswith("0x")
+        assert meta.viewing_key.startswith("0x")
+        assert spending_priv.startswith("0x")
+        assert viewing_priv.startswith("0x")
+
+    def test_generate_stealth_address(self):
+        from sip_protocol import generate_stealth_meta_address, generate_stealth_address
+
+        meta, _, _ = generate_stealth_meta_address("ethereum")
+        stealth, shared_secret = generate_stealth_address(meta)
+
+        assert stealth.address.startswith("0x")
+        assert stealth.ephemeral_public_key.startswith("0x")
+        assert 0 <= stealth.view_tag <= 255
+
+    def test_check_stealth_address(self):
+        from sip_protocol import (
+            generate_stealth_meta_address,
+            generate_stealth_address,
+            check_stealth_address,
+        )
+
+        meta, spending_priv, viewing_priv = generate_stealth_meta_address("ethereum")
+        stealth, _ = generate_stealth_address(meta)
+
+        # Should recognize own address
+        assert check_stealth_address(stealth, spending_priv, viewing_priv)
+
+    def test_derive_stealth_private_key(self):
+        from sip_protocol import (
+            generate_stealth_meta_address,
+            generate_stealth_address,
+            derive_stealth_private_key,
+        )
+
+        meta, spending_priv, viewing_priv = generate_stealth_meta_address("ethereum")
+        stealth, _ = generate_stealth_address(meta)
+
+        recovery = derive_stealth_private_key(stealth, spending_priv, viewing_priv)
+
+        assert recovery.stealth_address == stealth.address
+        assert recovery.private_key.startswith("0x")
+
+    def test_encode_decode_meta_address(self):
+        from sip_protocol import (
+            generate_stealth_meta_address,
+            encode_stealth_meta_address,
+            decode_stealth_meta_address,
+        )
+
+        meta, _, _ = generate_stealth_meta_address("ethereum")
+
+        encoded = encode_stealth_meta_address(meta)
+        assert encoded.startswith("sip:ethereum:")
+
+        decoded = decode_stealth_meta_address(encoded)
+        assert decoded.chain == meta.chain
+        assert decoded.spending_key == meta.spending_key
+        assert decoded.viewing_key == meta.viewing_key
+
+
+class TestPrivacy:
+    """Tests for viewing keys and encryption."""
+
+    def test_generate_viewing_key(self):
+        from sip_protocol import generate_viewing_key
+
+        vk = generate_viewing_key("test-label")
+
+        assert vk.key.startswith("0x")
+        assert vk.key_hash.startswith("0x")
+        assert vk.label == "test-label"
+        assert vk.created_at > 0
+
+    def test_derive_viewing_key_hash(self):
+        from sip_protocol import generate_viewing_key, derive_viewing_key_hash
+
+        vk = generate_viewing_key()
+        hash = derive_viewing_key_hash(vk.key)
+
+        assert hash == vk.key_hash
+
+    def test_encrypt_decrypt(self):
+        from sip_protocol import (
+            generate_viewing_key,
+            encrypt_for_viewing_key,
+            decrypt_with_viewing_key,
+        )
+
+        vk = generate_viewing_key()
+        plaintext = b"Hello, SIP Protocol!"
+
+        payload = encrypt_for_viewing_key(vk.key, plaintext)
+        assert payload.ciphertext.startswith("0x")
+        assert payload.nonce.startswith("0x")
+
+        decrypted = decrypt_with_viewing_key(vk.key, payload)
+        assert decrypted == plaintext
+
+
+class TestPrivacyLevel:
+    """Tests for privacy levels."""
+
+    def test_privacy_levels(self):
+        from sip_protocol import PrivacyLevel
+
+        assert PrivacyLevel.TRANSPARENT.value == "transparent"
+        assert PrivacyLevel.SHIELDED.value == "shielded"
+        assert PrivacyLevel.COMPLIANT.value == "compliant"

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,0 +1,54 @@
+[package]
+name = "sip-protocol"
+version = "0.1.0"
+edition = "2021"
+authors = ["SIP Protocol <rector@rectorspace.com>"]
+description = "SIP Protocol SDK - Privacy standard for Web3"
+license = "MIT"
+repository = "https://github.com/sip-protocol/sip-protocol"
+homepage = "https://sip-protocol.org"
+documentation = "https://docs.sip-protocol.org"
+readme = "README.md"
+keywords = ["privacy", "web3", "blockchain", "stealth-addresses", "pedersen"]
+categories = ["cryptography", "web-programming"]
+
+[lib]
+name = "sip_protocol"
+path = "src/lib.rs"
+
+[features]
+default = ["std"]
+std = []
+wasm = ["wasm-bindgen", "getrandom/js"]
+
+[dependencies]
+# Elliptic curves (noble-curves compatible)
+k256 = { version = "0.13", features = ["arithmetic", "ecdh"] }
+sha2 = "0.10"
+sha3 = "0.10"
+hmac = "0.12"
+rand = "0.8"
+hex = "0.4"
+thiserror = "2"
+lazy_static = "1.5"
+
+# Encryption
+chacha20poly1305 = "0.10"
+
+# WASM support (optional)
+wasm-bindgen = { version = "0.2", optional = true }
+getrandom = { version = "0.2", optional = true }
+
+# Serialization
+serde = { version = "1", features = ["derive"], optional = true }
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "commitment"
+harness = false
+
+[profile.release]
+opt-level = 3
+lto = true

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -1,0 +1,194 @@
+# SIP Protocol Rust SDK
+
+The privacy standard for Web3. Stealth addresses, Pedersen commitments, and viewing keys for compliant privacy.
+
+## Installation
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+sip-protocol = "0.1"
+```
+
+## Quick Start
+
+```rust
+use sip_protocol::{
+    generate_stealth_meta_address,
+    generate_stealth_address,
+    derive_stealth_private_key,
+    commit,
+    verify_opening,
+    generate_viewing_key,
+    encrypt_for_viewing_key,
+    decrypt_with_viewing_key,
+    PrivacyLevel,
+};
+
+fn main() {
+    // Generate stealth address keypair
+    let (meta, spending_priv, viewing_priv) = generate_stealth_meta_address("ethereum");
+    println!("Spending key: {}", meta.spending_key);
+    println!("Viewing key: {}", meta.viewing_key);
+
+    // Generate one-time stealth address for payment
+    let (stealth, shared_secret) = generate_stealth_address(&meta).unwrap();
+    println!("Stealth address: {}", stealth.address);
+
+    // Recipient derives private key to spend
+    let recovery = derive_stealth_private_key(&stealth, &spending_priv, &viewing_priv).unwrap();
+    println!("Derived private key: {}", recovery.private_key);
+}
+```
+
+## Features
+
+### Stealth Addresses (EIP-5564)
+
+Generate unlinkable one-time addresses for private payments:
+
+```rust
+use sip_protocol::{
+    generate_stealth_meta_address,
+    generate_stealth_address,
+    check_stealth_address,
+    public_key_to_eth_address,
+};
+
+// Recipient publishes their meta-address
+let (meta, spending_priv, viewing_priv) = generate_stealth_meta_address("ethereum");
+
+// Sender generates one-time stealth address
+let (stealth, _) = generate_stealth_address(&meta).unwrap();
+
+// Convert to Ethereum address
+let eth_address = public_key_to_eth_address(&stealth.address).unwrap();
+println!("Send ETH to: {}", eth_address);
+
+// Recipient scans for their payments
+let is_mine = check_stealth_address(&stealth, &spending_priv, &viewing_priv).unwrap();
+```
+
+### Pedersen Commitments
+
+Hide amounts with homomorphic commitments:
+
+```rust
+use sip_protocol::{
+    commit,
+    verify_opening,
+    add_commitments,
+    add_blindings,
+};
+
+// Create commitment to 100 tokens
+let (c1, b1) = commit(100).unwrap();
+
+// Create commitment to 50 tokens
+let (c2, b2) = commit(50).unwrap();
+
+// Add commitments homomorphically
+let c_sum = add_commitments(&c1, &c2).unwrap();
+let b_sum = add_blindings(&b1, &b2).unwrap();
+
+// Verify the sum
+assert!(verify_opening(&c_sum, 150, &b_sum).unwrap());
+```
+
+### Viewing Keys
+
+Selective disclosure for compliance:
+
+```rust
+use sip_protocol::{
+    generate_viewing_key,
+    encrypt_for_viewing_key,
+    decrypt_with_viewing_key,
+};
+
+// Generate viewing key for auditor
+let vk = generate_viewing_key(Some("tax-audit-2024"));
+
+// Encrypt transaction details
+let payload = encrypt_for_viewing_key(&vk.key, b"Transaction: 100 USDC to 0x...").unwrap();
+
+// Auditor decrypts with viewing key
+let plaintext = decrypt_with_viewing_key(&vk.key, &payload).unwrap();
+```
+
+## Privacy Levels
+
+```rust
+use sip_protocol::PrivacyLevel;
+
+// Transparent - No privacy, all data public
+// Shielded - Full privacy, sender/amount/recipient hidden
+// Compliant - Privacy with viewing key for auditors
+```
+
+## WASM Support
+
+Enable WASM compilation with the `wasm` feature:
+
+```toml
+[dependencies]
+sip-protocol = { version = "0.1", features = ["wasm"] }
+```
+
+## API Reference
+
+### Stealth Addresses
+
+- `generate_stealth_meta_address(chain)` - Generate keypair
+- `generate_stealth_address(meta_address)` - Generate one-time address
+- `derive_stealth_private_key(stealth, spending_priv, viewing_priv)` - Recover private key
+- `check_stealth_address(stealth, spending_priv, viewing_priv)` - Check ownership
+- `public_key_to_eth_address(public_key)` - Convert to ETH address
+- `encode_stealth_meta_address(meta)` - Encode to SIP format
+- `decode_stealth_meta_address(encoded)` - Decode from SIP format
+
+### Pedersen Commitments
+
+- `commit(value)` - Create commitment
+- `verify_opening(commitment, value, blinding)` - Verify commitment
+- `add_commitments(c1, c2)` - Homomorphic addition
+- `subtract_commitments(c1, c2)` - Homomorphic subtraction
+- `add_blindings(b1, b2)` - Add blinding factors
+- `subtract_blindings(b1, b2)` - Subtract blinding factors
+- `generate_blinding()` - Generate random blinding
+
+### Viewing Keys
+
+- `generate_viewing_key(label)` - Generate viewing key
+- `derive_viewing_key_hash(viewing_key)` - Get key hash
+- `encrypt_for_viewing_key(viewing_key, plaintext)` - Encrypt data
+- `decrypt_with_viewing_key(viewing_key, payload)` - Decrypt data
+
+## Development
+
+```bash
+# Build
+cargo build
+
+# Run tests
+cargo test
+
+# Build for release
+cargo build --release
+
+# Build for WASM
+cargo build --target wasm32-unknown-unknown --features wasm
+```
+
+## License
+
+MIT License - see [LICENSE](../../LICENSE) for details.
+
+## Links
+
+- [Website](https://sip-protocol.org)
+- [Documentation](https://docs.sip-protocol.org)
+- [GitHub](https://github.com/sip-protocol/sip-protocol)
+- [TypeScript SDK](https://www.npmjs.com/package/@sip-protocol/sdk)
+- [Python SDK](https://pypi.org/project/sip-protocol/)

--- a/sdks/rust/src/commitment.rs
+++ b/sdks/rust/src/commitment.rs
@@ -1,0 +1,292 @@
+//! Pedersen Commitment Implementation for SIP Protocol.
+//!
+//! Cryptographically secure Pedersen commitments on secp256k1.
+//!
+//! # Security Properties
+//!
+//! - **Hiding (Computational)**: Cannot determine value from commitment
+//! - **Binding (Computational)**: Cannot open commitment to different value
+//! - **Homomorphic**: C(v1) + C(v2) = C(v1 + v2) when blindings sum
+//!
+//! # Generator H Construction
+//!
+//! H is constructed using "nothing-up-my-sleeve" (NUMS) method to ensure
+//! nobody knows the discrete log of H w.r.t. G.
+
+use k256::{
+    elliptic_curve::{
+        group::GroupEncoding,
+        sec1::{FromEncodedPoint, ToEncodedPoint},
+        Field, PrimeField,
+    },
+    AffinePoint, ProjectivePoint, Scalar,
+};
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+
+use crate::crypto::{bytes_to_hex, hex_to_bytes};
+use crate::error::{Error, Result};
+use crate::types::HexString;
+
+/// Domain separation tag for H generation
+const H_DOMAIN: &str = "SIP-PEDERSEN-GENERATOR-H-v1";
+
+/// The base generator G (secp256k1)
+fn get_generator_g() -> ProjectivePoint {
+    ProjectivePoint::GENERATOR
+}
+
+/// Generate the independent generator H using NUMS method.
+fn generate_h() -> ProjectivePoint {
+    for counter in 0..256 {
+        // Create candidate x-coordinate
+        let input = format!("{}:{}", H_DOMAIN, counter);
+        let mut hasher = Sha256::new();
+        hasher.update(input.as_bytes());
+        let hash = hasher.finalize();
+
+        // Try to create a point from this x-coordinate (with even y)
+        let mut point_bytes = [0u8; 33];
+        point_bytes[0] = 0x02; // Compressed, even y
+        point_bytes[1..].copy_from_slice(&hash);
+
+        if let Ok(point) = AffinePoint::from_bytes(&point_bytes.into()) {
+            let proj = ProjectivePoint::from(point);
+            if !proj.is_identity().into() && proj != ProjectivePoint::GENERATOR {
+                return proj;
+            }
+        }
+    }
+
+    panic!("Failed to generate H point - this should never happen");
+}
+
+lazy_static::lazy_static! {
+    static ref H: ProjectivePoint = generate_h();
+}
+
+/// Create a Pedersen commitment to a value.
+///
+/// C = v*G + r*H
+///
+/// Where:
+/// - v = value (the amount being committed)
+/// - r = blinding factor (random, keeps value hidden)
+/// - G = base generator
+/// - H = independent generator (NUMS)
+///
+/// # Arguments
+///
+/// * `value` - The value to commit to
+///
+/// # Returns
+///
+/// Tuple of (commitment, blinding) as hex strings
+///
+/// # Example
+///
+/// ```rust
+/// use sip_protocol::commit;
+///
+/// let (commitment, blinding) = commit(100).unwrap();
+/// ```
+pub fn commit(value: u64) -> Result<(HexString, HexString)> {
+    // Generate random blinding factor
+    let mut blinding_bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut blinding_bytes);
+
+    commit_with_blinding(value, &blinding_bytes)
+}
+
+/// Create a Pedersen commitment with a specific blinding factor.
+pub fn commit_with_blinding(value: u64, blinding: &[u8]) -> Result<(HexString, HexString)> {
+    if blinding.len() != 32 {
+        return Err(Error::CryptoError("Blinding must be 32 bytes".to_string()));
+    }
+
+    let g = get_generator_g();
+
+    // Convert value and blinding to scalars
+    let v_scalar = Scalar::from(value);
+    let r_scalar = Scalar::from_repr_vartime((*blinding).into())
+        .ok_or_else(|| Error::CryptoError("Invalid blinding scalar".to_string()))?;
+
+    if r_scalar.is_zero().into() {
+        return Err(Error::CryptoError(
+            "Zero blinding scalar - investigate RNG".to_string(),
+        ));
+    }
+
+    // C = v*G + r*H
+    let commitment = if value == 0 {
+        // Only blinding contributes: C = r*H
+        *H * r_scalar
+    } else {
+        // Normal case: C = v*G + r*H
+        g * v_scalar + *H * r_scalar
+    };
+
+    let commitment_bytes = commitment.to_affine().to_bytes();
+
+    Ok((
+        bytes_to_hex(&commitment_bytes),
+        bytes_to_hex(blinding),
+    ))
+}
+
+/// Verify that a commitment opens to a specific value.
+///
+/// Recomputes C' = v*G + r*H and checks if C' == C
+///
+/// # Arguments
+///
+/// * `commitment` - The commitment point to verify
+/// * `value` - The claimed value
+/// * `blinding` - The blinding factor used
+///
+/// # Returns
+///
+/// true if the commitment opens correctly
+pub fn verify_opening(commitment: &str, value: u64, blinding: &str) -> Result<bool> {
+    let commitment_bytes = hex_to_bytes(commitment)?;
+    let blinding_bytes = hex_to_bytes(blinding)?;
+
+    let g = get_generator_g();
+
+    // Parse commitment point
+    let c_point = AffinePoint::from_bytes(commitment_bytes.as_slice().into())
+        .map(ProjectivePoint::from)
+        .map_err(|_| Error::InvalidPublicKey("Invalid commitment point".to_string()))?;
+
+    // Recompute expected commitment
+    let v_scalar = Scalar::from(value);
+    let r_scalar = Scalar::from_repr_vartime(blinding_bytes.as_slice().try_into().unwrap())
+        .ok_or_else(|| Error::CryptoError("Invalid blinding scalar".to_string()))?;
+
+    let expected = if value == 0 {
+        *H * r_scalar
+    } else {
+        g * v_scalar + *H * r_scalar
+    };
+
+    Ok(c_point == expected)
+}
+
+/// Create a commitment to zero with a specific blinding factor.
+///
+/// C = 0*G + r*H = r*H
+pub fn commit_zero(blinding: &[u8]) -> Result<(HexString, HexString)> {
+    commit_with_blinding(0, blinding)
+}
+
+/// Add two commitments homomorphically.
+///
+/// C1 + C2 = (v1*G + r1*H) + (v2*G + r2*H) = (v1+v2)*G + (r1+r2)*H
+pub fn add_commitments(c1: &str, c2: &str) -> Result<HexString> {
+    let c1_bytes = hex_to_bytes(c1)?;
+    let c2_bytes = hex_to_bytes(c2)?;
+
+    let point1 = AffinePoint::from_bytes(c1_bytes.as_slice().into())
+        .map(ProjectivePoint::from)
+        .map_err(|_| Error::InvalidPublicKey("Invalid commitment c1".to_string()))?;
+
+    let point2 = AffinePoint::from_bytes(c2_bytes.as_slice().into())
+        .map(ProjectivePoint::from)
+        .map_err(|_| Error::InvalidPublicKey("Invalid commitment c2".to_string()))?;
+
+    let sum = point1 + point2;
+    Ok(bytes_to_hex(&sum.to_affine().to_bytes()))
+}
+
+/// Subtract two commitments homomorphically.
+///
+/// C1 - C2 = (v1-v2)*G + (r1-r2)*H
+pub fn subtract_commitments(c1: &str, c2: &str) -> Result<HexString> {
+    let c1_bytes = hex_to_bytes(c1)?;
+    let c2_bytes = hex_to_bytes(c2)?;
+
+    let point1 = AffinePoint::from_bytes(c1_bytes.as_slice().into())
+        .map(ProjectivePoint::from)
+        .map_err(|_| Error::InvalidPublicKey("Invalid commitment c1".to_string()))?;
+
+    let point2 = AffinePoint::from_bytes(c2_bytes.as_slice().into())
+        .map(ProjectivePoint::from)
+        .map_err(|_| Error::InvalidPublicKey("Invalid commitment c2".to_string()))?;
+
+    let diff = point1 - point2;
+    Ok(bytes_to_hex(&diff.to_affine().to_bytes()))
+}
+
+/// Add blinding factors (for use with homomorphic addition).
+pub fn add_blindings(b1: &str, b2: &str) -> Result<HexString> {
+    let b1_bytes = hex_to_bytes(b1)?;
+    let b2_bytes = hex_to_bytes(b2)?;
+
+    let s1 = Scalar::from_repr_vartime(b1_bytes.as_slice().try_into().unwrap())
+        .ok_or_else(|| Error::CryptoError("Invalid blinding b1".to_string()))?;
+    let s2 = Scalar::from_repr_vartime(b2_bytes.as_slice().try_into().unwrap())
+        .ok_or_else(|| Error::CryptoError("Invalid blinding b2".to_string()))?;
+
+    let sum = s1 + s2;
+    Ok(bytes_to_hex(&sum.to_bytes()))
+}
+
+/// Subtract blinding factors (for use with homomorphic subtraction).
+pub fn subtract_blindings(b1: &str, b2: &str) -> Result<HexString> {
+    let b1_bytes = hex_to_bytes(b1)?;
+    let b2_bytes = hex_to_bytes(b2)?;
+
+    let s1 = Scalar::from_repr_vartime(b1_bytes.as_slice().try_into().unwrap())
+        .ok_or_else(|| Error::CryptoError("Invalid blinding b1".to_string()))?;
+    let s2 = Scalar::from_repr_vartime(b2_bytes.as_slice().try_into().unwrap())
+        .ok_or_else(|| Error::CryptoError("Invalid blinding b2".to_string()))?;
+
+    let diff = s1 - s2;
+    Ok(bytes_to_hex(&diff.to_bytes()))
+}
+
+/// Generate a random blinding factor.
+pub fn generate_blinding() -> HexString {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    bytes_to_hex(&bytes)
+}
+
+/// Get the generators for ZK proof integration.
+pub fn get_generators() -> (HexString, HexString, HexString, HexString) {
+    let g = get_generator_g().to_affine();
+    let h = H.to_affine();
+
+    let g_encoded = g.to_encoded_point(false);
+    let h_encoded = h.to_encoded_point(false);
+
+    (
+        bytes_to_hex(g_encoded.x().unwrap()),
+        bytes_to_hex(g_encoded.y().unwrap()),
+        bytes_to_hex(h_encoded.x().unwrap()),
+        bytes_to_hex(h_encoded.y().unwrap()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_commit_and_verify() {
+        let (commitment, blinding) = commit(100).unwrap();
+        assert!(verify_opening(&commitment, 100, &blinding).unwrap());
+        assert!(!verify_opening(&commitment, 101, &blinding).unwrap());
+    }
+
+    #[test]
+    fn test_homomorphic_addition() {
+        let (c1, b1) = commit(100).unwrap();
+        let (c2, b2) = commit(50).unwrap();
+
+        let c_sum = add_commitments(&c1, &c2).unwrap();
+        let b_sum = add_blindings(&b1, &b2).unwrap();
+
+        assert!(verify_opening(&c_sum, 150, &b_sum).unwrap());
+    }
+}

--- a/sdks/rust/src/crypto.rs
+++ b/sdks/rust/src/crypto.rs
@@ -1,0 +1,146 @@
+//! Cryptographic utilities for SIP Protocol.
+//!
+//! Provides low-level cryptographic primitives including:
+//! - Hash functions (SHA-256)
+//! - Random number generation
+//! - Intent ID generation
+
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+
+use crate::error::{Error, Result};
+use crate::types::{Hash, HexString};
+
+/// Compute SHA-256 hash of data.
+///
+/// # Arguments
+///
+/// * `data` - Input data as bytes
+///
+/// # Returns
+///
+/// 32-byte hash as hex string with 0x prefix
+///
+/// # Example
+///
+/// ```rust
+/// use sip_protocol::hash_sha256;
+///
+/// let hash = hash_sha256(b"Hello, SIP Protocol!");
+/// println!("{}", hash);
+/// ```
+pub fn hash_sha256(data: &[u8]) -> Hash {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    let result = hasher.finalize();
+    format!("0x{}", hex::encode(result))
+}
+
+/// Generate cryptographically secure random bytes.
+///
+/// Uses the platform's secure random source.
+///
+/// # Arguments
+///
+/// * `length` - Number of random bytes to generate
+///
+/// # Returns
+///
+/// Random bytes as hex string with 0x prefix
+///
+/// # Example
+///
+/// ```rust
+/// use sip_protocol::generate_random_bytes;
+///
+/// let random = generate_random_bytes(32); // 32-byte private key
+/// ```
+pub fn generate_random_bytes(length: usize) -> HexString {
+    let mut bytes = vec![0u8; length];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    format!("0x{}", hex::encode(bytes))
+}
+
+/// Generate a unique intent identifier.
+///
+/// Creates a cryptographically random intent ID with the `sip-` prefix.
+/// IDs are globally unique with negligible collision probability (128-bit).
+///
+/// # Returns
+///
+/// Intent ID string in format: `sip-<32 hex chars>`
+///
+/// # Example
+///
+/// ```rust
+/// use sip_protocol::generate_intent_id;
+///
+/// let id = generate_intent_id();
+/// println!("{}", id); // sip-a1b2c3d4e5f67890a1b2c3d4e5f67890
+/// ```
+pub fn generate_intent_id() -> String {
+    let mut bytes = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    format!("sip-{}", hex::encode(bytes))
+}
+
+/// Convert hex string to bytes.
+///
+/// # Arguments
+///
+/// * `hex_str` - Hex string with or without 0x prefix
+///
+/// # Returns
+///
+/// Raw bytes
+pub fn hex_to_bytes(hex_str: &str) -> Result<Vec<u8>> {
+    let hex_str = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+    hex::decode(hex_str).map_err(|e| Error::InvalidHex(e.to_string()))
+}
+
+/// Convert bytes to hex string with 0x prefix.
+///
+/// # Arguments
+///
+/// * `data` - Raw bytes
+///
+/// # Returns
+///
+/// Hex string with 0x prefix
+pub fn bytes_to_hex(data: &[u8]) -> HexString {
+    format!("0x{}", hex::encode(data))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_sha256() {
+        let hash = hash_sha256(b"hello");
+        assert!(hash.starts_with("0x"));
+        assert_eq!(hash.len(), 66); // 0x + 64 hex chars
+    }
+
+    #[test]
+    fn test_generate_random_bytes() {
+        let random = generate_random_bytes(32);
+        assert!(random.starts_with("0x"));
+        assert_eq!(random.len(), 66); // 0x + 64 hex chars
+    }
+
+    #[test]
+    fn test_generate_intent_id() {
+        let id = generate_intent_id();
+        assert!(id.starts_with("sip-"));
+        assert_eq!(id.len(), 36); // sip- + 32 hex chars
+    }
+
+    #[test]
+    fn test_hex_conversion() {
+        let original = vec![1, 2, 3, 4];
+        let hex = bytes_to_hex(&original);
+        let bytes = hex_to_bytes(&hex).unwrap();
+        assert_eq!(original, bytes);
+    }
+}

--- a/sdks/rust/src/error.rs
+++ b/sdks/rust/src/error.rs
@@ -1,0 +1,50 @@
+//! Error types for SIP Protocol SDK.
+
+use thiserror::Error;
+
+/// Result type for SIP Protocol operations
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Error types for SIP Protocol SDK
+#[derive(Error, Debug)]
+pub enum Error {
+    /// Invalid hex string format
+    #[error("Invalid hex string: {0}")]
+    InvalidHex(String),
+
+    /// Invalid public key
+    #[error("Invalid public key: {0}")]
+    InvalidPublicKey(String),
+
+    /// Invalid private key
+    #[error("Invalid private key: {0}")]
+    InvalidPrivateKey(String),
+
+    /// Invalid stealth meta-address format
+    #[error("Invalid stealth meta-address: {0}")]
+    InvalidStealthMetaAddress(String),
+
+    /// Value out of range
+    #[error("Value out of range: {0}")]
+    ValueOutOfRange(String),
+
+    /// Cryptographic operation failed
+    #[error("Crypto error: {0}")]
+    CryptoError(String),
+
+    /// Encryption failed
+    #[error("Encryption error: {0}")]
+    EncryptionError(String),
+
+    /// Decryption failed
+    #[error("Decryption error: {0}")]
+    DecryptionError(String),
+
+    /// Invalid chain ID
+    #[error("Invalid chain ID: {0}")]
+    InvalidChainId(String),
+
+    /// Verification failed
+    #[error("Verification failed: {0}")]
+    VerificationFailed(String),
+}

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -1,0 +1,53 @@
+//! # SIP Protocol Rust SDK
+//!
+//! The privacy standard for Web3. Stealth addresses, Pedersen commitments,
+//! and viewing keys for compliant privacy.
+//!
+//! ## Quick Start
+//!
+//! ```rust
+//! use sip_protocol::{
+//!     stealth::{generate_stealth_meta_address, generate_stealth_address},
+//!     commitment::commit,
+//!     privacy::generate_viewing_key,
+//! };
+//!
+//! // Generate stealth address keypair
+//! let (meta, spending_priv, viewing_priv) = generate_stealth_meta_address("ethereum");
+//!
+//! // Generate one-time stealth address
+//! let (stealth, shared_secret) = generate_stealth_address(&meta).unwrap();
+//!
+//! // Create Pedersen commitment
+//! let (commitment, blinding) = commit(100).unwrap();
+//! ```
+
+pub mod commitment;
+pub mod crypto;
+pub mod error;
+pub mod privacy;
+pub mod stealth;
+pub mod types;
+
+pub use commitment::{
+    add_blindings, add_commitments, commit, commit_zero, generate_blinding, get_generators,
+    subtract_blindings, subtract_commitments, verify_opening,
+};
+pub use crypto::{generate_intent_id, generate_random_bytes, hash_sha256};
+pub use error::{Error, Result};
+pub use privacy::{
+    decrypt_with_viewing_key, derive_viewing_key_hash, encrypt_for_viewing_key,
+    generate_viewing_key, PrivacyLevel,
+};
+pub use stealth::{
+    check_stealth_address, decode_stealth_meta_address, derive_stealth_private_key,
+    encode_stealth_meta_address, generate_stealth_address, generate_stealth_meta_address,
+    public_key_to_eth_address,
+};
+pub use types::{
+    ChainId, EncryptedPayload, HexString, PedersenCommitment, StealthAddress,
+    StealthAddressRecovery, StealthMetaAddress, ViewingKey,
+};
+
+/// SDK version
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/sdks/rust/src/privacy.rs
+++ b/sdks/rust/src/privacy.rs
@@ -1,0 +1,184 @@
+//! Privacy and Viewing Key Implementation for SIP Protocol.
+//!
+//! Provides:
+//! - Viewing key generation and derivation
+//! - XChaCha20-Poly1305 encryption/decryption
+//! - Selective disclosure for compliance
+
+use chacha20poly1305::{
+    aead::{Aead, KeyInit},
+    XChaCha20Poly1305, XNonce,
+};
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::crypto::{bytes_to_hex, hex_to_bytes};
+use crate::error::{Error, Result};
+use crate::types::{EncryptedPayload, HexString, ViewingKey};
+
+pub use crate::types::PrivacyLevel;
+
+/// Generate a new viewing key for selective disclosure.
+///
+/// # Arguments
+///
+/// * `label` - Optional human-readable label
+///
+/// # Returns
+///
+/// ViewingKey object with key and hash
+///
+/// # Example
+///
+/// ```rust
+/// use sip_protocol::generate_viewing_key;
+///
+/// let vk = generate_viewing_key(Some("audit-2024"));
+/// ```
+pub fn generate_viewing_key(label: Option<&str>) -> ViewingKey {
+    let mut key = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut key);
+
+    let mut hasher = Sha256::new();
+    hasher.update(&key);
+    let key_hash = hasher.finalize();
+
+    let created_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+
+    ViewingKey {
+        key: bytes_to_hex(&key),
+        key_hash: bytes_to_hex(&key_hash),
+        created_at,
+        label: label.map(String::from),
+    }
+}
+
+/// Derive the hash of a viewing key.
+///
+/// This hash is used for indexing and verification without
+/// exposing the actual key.
+pub fn derive_viewing_key_hash(viewing_key: &str) -> Result<HexString> {
+    let key_bytes = hex_to_bytes(viewing_key)?;
+
+    let mut hasher = Sha256::new();
+    hasher.update(&key_bytes);
+    let hash = hasher.finalize();
+
+    Ok(bytes_to_hex(&hash))
+}
+
+/// Encrypt data for viewing key holders.
+///
+/// Uses XChaCha20-Poly1305 for authenticated encryption.
+///
+/// # Arguments
+///
+/// * `viewing_key` - The viewing key (32 bytes)
+/// * `plaintext` - Data to encrypt
+///
+/// # Returns
+///
+/// EncryptedPayload with ciphertext and nonce
+pub fn encrypt_for_viewing_key(viewing_key: &str, plaintext: &[u8]) -> Result<EncryptedPayload> {
+    let key_bytes = hex_to_bytes(viewing_key)?;
+
+    if key_bytes.len() != 32 {
+        return Err(Error::CryptoError("Viewing key must be 32 bytes".to_string()));
+    }
+
+    // Generate random nonce (24 bytes for XChaCha20)
+    let mut nonce_bytes = [0u8; 24];
+    rand::thread_rng().fill_bytes(&mut nonce_bytes);
+    let nonce = XNonce::from_slice(&nonce_bytes);
+
+    // Create cipher and encrypt
+    let cipher = XChaCha20Poly1305::new_from_slice(&key_bytes)
+        .map_err(|e| Error::EncryptionError(e.to_string()))?;
+
+    let ciphertext = cipher
+        .encrypt(nonce, plaintext)
+        .map_err(|e| Error::EncryptionError(e.to_string()))?;
+
+    Ok(EncryptedPayload {
+        ciphertext: bytes_to_hex(&ciphertext),
+        nonce: bytes_to_hex(&nonce_bytes),
+    })
+}
+
+/// Decrypt data using a viewing key.
+///
+/// # Arguments
+///
+/// * `viewing_key` - The viewing key (32 bytes)
+/// * `payload` - The encrypted payload (ciphertext + nonce)
+///
+/// # Returns
+///
+/// Decrypted plaintext
+pub fn decrypt_with_viewing_key(viewing_key: &str, payload: &EncryptedPayload) -> Result<Vec<u8>> {
+    let key_bytes = hex_to_bytes(viewing_key)?;
+    let nonce_bytes = hex_to_bytes(&payload.nonce)?;
+    let ciphertext = hex_to_bytes(&payload.ciphertext)?;
+
+    if key_bytes.len() != 32 {
+        return Err(Error::CryptoError("Viewing key must be 32 bytes".to_string()));
+    }
+
+    if nonce_bytes.len() != 24 {
+        return Err(Error::DecryptionError("Invalid nonce length".to_string()));
+    }
+
+    let nonce = XNonce::from_slice(&nonce_bytes);
+
+    let cipher = XChaCha20Poly1305::new_from_slice(&key_bytes)
+        .map_err(|e| Error::DecryptionError(e.to_string()))?;
+
+    cipher
+        .decrypt(nonce, ciphertext.as_slice())
+        .map_err(|e| Error::DecryptionError(e.to_string()))
+}
+
+/// Determine if encryption should be used for a privacy level.
+pub fn should_encrypt(level: PrivacyLevel) -> bool {
+    matches!(level, PrivacyLevel::Shielded | PrivacyLevel::Compliant)
+}
+
+/// Determine if viewing key should be included for a privacy level.
+pub fn should_include_viewing_key(level: PrivacyLevel) -> bool {
+    matches!(level, PrivacyLevel::Compliant)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_viewing_key() {
+        let vk = generate_viewing_key(Some("test"));
+        assert!(vk.key.starts_with("0x"));
+        assert!(vk.key_hash.starts_with("0x"));
+        assert_eq!(vk.label, Some("test".to_string()));
+    }
+
+    #[test]
+    fn test_encrypt_decrypt() {
+        let vk = generate_viewing_key(None);
+        let plaintext = b"Hello, SIP Protocol!";
+
+        let payload = encrypt_for_viewing_key(&vk.key, plaintext).unwrap();
+        let decrypted = decrypt_with_viewing_key(&vk.key, &payload).unwrap();
+
+        assert_eq!(plaintext.as_slice(), decrypted.as_slice());
+    }
+
+    #[test]
+    fn test_derive_viewing_key_hash() {
+        let vk = generate_viewing_key(None);
+        let hash = derive_viewing_key_hash(&vk.key).unwrap();
+        assert_eq!(hash, vk.key_hash);
+    }
+}

--- a/sdks/rust/src/stealth.rs
+++ b/sdks/rust/src/stealth.rs
@@ -1,0 +1,330 @@
+//! Stealth Address Implementation for SIP Protocol.
+//!
+//! Implements EIP-5564 style stealth addresses using secp256k1.
+//! Used for Ethereum, Polygon, Arbitrum, Optimism, Base, Bitcoin, Zcash.
+//!
+//! # Protocol
+//!
+//! Stealth addresses provide unlinkable payments:
+//! 1. Sender generates one-time address from recipient's public meta-address
+//! 2. Recipient scans blockchain using view tag for efficient filtering
+//! 3. Only recipient can derive the private key to spend
+
+use k256::{
+    ecdh::EphemeralSecret,
+    elliptic_curve::{group::GroupEncoding, sec1::FromEncodedPoint, PrimeField},
+    AffinePoint, ProjectivePoint, PublicKey, Scalar, SecretKey,
+};
+use rand::rngs::OsRng;
+use sha2::{Digest, Sha256};
+use sha3::Keccak256;
+
+use crate::crypto::{bytes_to_hex, hex_to_bytes};
+use crate::error::{Error, Result};
+use crate::types::{ChainId, HexString, StealthAddress, StealthAddressRecovery, StealthMetaAddress};
+
+/// Generate a new stealth meta-address keypair.
+///
+/// # Arguments
+///
+/// * `chain` - The blockchain this address is for
+///
+/// # Returns
+///
+/// Tuple of (meta_address, spending_private_key, viewing_private_key)
+///
+/// # Example
+///
+/// ```rust
+/// use sip_protocol::generate_stealth_meta_address;
+///
+/// let (meta, spending_priv, viewing_priv) = generate_stealth_meta_address("ethereum");
+/// ```
+pub fn generate_stealth_meta_address(chain: &str) -> (StealthMetaAddress, HexString, HexString) {
+    // Generate random private keys
+    let spending_secret = SecretKey::random(&mut OsRng);
+    let viewing_secret = SecretKey::random(&mut OsRng);
+
+    // Derive public keys (compressed)
+    let spending_pub = spending_secret.public_key();
+    let viewing_pub = viewing_secret.public_key();
+
+    let meta_address = StealthMetaAddress::new(
+        bytes_to_hex(&spending_pub.to_sec1_bytes()),
+        bytes_to_hex(&viewing_pub.to_sec1_bytes()),
+        chain.to_string(),
+    );
+
+    (
+        meta_address,
+        bytes_to_hex(&spending_secret.to_bytes()),
+        bytes_to_hex(&viewing_secret.to_bytes()),
+    )
+}
+
+/// Generate a one-time stealth address for a recipient.
+///
+/// # Protocol
+///
+/// 1. Sender generates ephemeral keypair (r, R = r*G)
+/// 2. Compute shared secret: S = r * P_spend
+/// 3. Compute stealth address: A = Q_view + hash(S)*G
+/// 4. View tag = first byte of hash(S) for efficient scanning
+///
+/// # Arguments
+///
+/// * `recipient_meta_address` - The recipient's stealth meta-address
+///
+/// # Returns
+///
+/// Tuple of (stealth_address, shared_secret)
+pub fn generate_stealth_address(
+    recipient_meta_address: &StealthMetaAddress,
+) -> Result<(StealthAddress, HexString)> {
+    // Generate ephemeral keypair
+    let ephemeral_secret = SecretKey::random(&mut OsRng);
+    let ephemeral_pub = ephemeral_secret.public_key();
+
+    // Parse recipient's keys
+    let spending_key_bytes = hex_to_bytes(&recipient_meta_address.spending_key)?;
+    let viewing_key_bytes = hex_to_bytes(&recipient_meta_address.viewing_key)?;
+
+    let spending_pub = PublicKey::from_sec1_bytes(&spending_key_bytes)
+        .map_err(|_| Error::InvalidPublicKey("Invalid spending key".to_string()))?;
+    let viewing_pub = PublicKey::from_sec1_bytes(&viewing_key_bytes)
+        .map_err(|_| Error::InvalidPublicKey("Invalid viewing key".to_string()))?;
+
+    // Compute shared secret: S = r * P_spend
+    let shared_secret_point = k256::ecdh::diffie_hellman(
+        ephemeral_secret.to_nonzero_scalar(),
+        spending_pub.as_affine(),
+    );
+
+    // Hash the shared secret for use as a scalar
+    let mut hasher = Sha256::new();
+    hasher.update(shared_secret_point.raw_secret_bytes());
+    let shared_secret_hash: [u8; 32] = hasher.finalize().into();
+
+    // Compute stealth address: A = Q_view + hash(S)*G
+    let hash_scalar = Scalar::from_repr_vartime(shared_secret_hash.into())
+        .ok_or_else(|| Error::CryptoError("Invalid hash scalar".to_string()))?;
+
+    let hash_times_g = ProjectivePoint::GENERATOR * hash_scalar;
+    let viewing_point = ProjectivePoint::from(*viewing_pub.as_affine());
+    let stealth_point = viewing_point + hash_times_g;
+    let stealth_address_bytes = stealth_point.to_affine().to_bytes();
+
+    // View tag (first byte of hash for efficient scanning)
+    let view_tag = shared_secret_hash[0];
+
+    let stealth_address = StealthAddress {
+        address: bytes_to_hex(&stealth_address_bytes),
+        ephemeral_public_key: bytes_to_hex(&ephemeral_pub.to_sec1_bytes()),
+        view_tag,
+    };
+
+    Ok((stealth_address, bytes_to_hex(&shared_secret_hash)))
+}
+
+/// Derive the private key for a stealth address.
+///
+/// # Protocol
+///
+/// 1. Compute shared secret: S = p_spend * R_ephemeral
+/// 2. Derive stealth private key: q_view + hash(S) mod n
+pub fn derive_stealth_private_key(
+    stealth_address: &StealthAddress,
+    spending_private_key: &str,
+    viewing_private_key: &str,
+) -> Result<StealthAddressRecovery> {
+    let spending_priv_bytes = hex_to_bytes(spending_private_key)?;
+    let viewing_priv_bytes = hex_to_bytes(viewing_private_key)?;
+    let ephemeral_pub_bytes = hex_to_bytes(&stealth_address.ephemeral_public_key)?;
+
+    let spending_secret = SecretKey::from_slice(&spending_priv_bytes)
+        .map_err(|_| Error::InvalidPrivateKey("Invalid spending key".to_string()))?;
+    let ephemeral_pub = PublicKey::from_sec1_bytes(&ephemeral_pub_bytes)
+        .map_err(|_| Error::InvalidPublicKey("Invalid ephemeral key".to_string()))?;
+
+    // Compute shared secret: S = p_spend * R_ephemeral
+    let shared_secret_point = k256::ecdh::diffie_hellman(
+        spending_secret.to_nonzero_scalar(),
+        ephemeral_pub.as_affine(),
+    );
+
+    // Hash the shared secret
+    let mut hasher = Sha256::new();
+    hasher.update(shared_secret_point.raw_secret_bytes());
+    let shared_secret_hash: [u8; 32] = hasher.finalize().into();
+
+    // Derive stealth private key: q_view + hash(S) mod n
+    let viewing_scalar = Scalar::from_repr_vartime(viewing_priv_bytes.as_slice().try_into().unwrap())
+        .ok_or_else(|| Error::InvalidPrivateKey("Invalid viewing scalar".to_string()))?;
+    let hash_scalar = Scalar::from_repr_vartime(shared_secret_hash.into())
+        .ok_or_else(|| Error::CryptoError("Invalid hash scalar".to_string()))?;
+
+    let stealth_private_scalar = viewing_scalar + hash_scalar;
+
+    Ok(StealthAddressRecovery {
+        stealth_address: stealth_address.address.clone(),
+        ephemeral_public_key: stealth_address.ephemeral_public_key.clone(),
+        private_key: bytes_to_hex(&stealth_private_scalar.to_bytes()),
+    })
+}
+
+/// Check if a stealth address belongs to this recipient.
+///
+/// Uses view tag for efficient filtering, then does full verification.
+pub fn check_stealth_address(
+    stealth_address: &StealthAddress,
+    spending_private_key: &str,
+    viewing_private_key: &str,
+) -> Result<bool> {
+    let spending_priv_bytes = hex_to_bytes(spending_private_key)?;
+    let viewing_priv_bytes = hex_to_bytes(viewing_private_key)?;
+    let ephemeral_pub_bytes = hex_to_bytes(&stealth_address.ephemeral_public_key)?;
+
+    let spending_secret = SecretKey::from_slice(&spending_priv_bytes)
+        .map_err(|_| Error::InvalidPrivateKey("Invalid spending key".to_string()))?;
+    let ephemeral_pub = PublicKey::from_sec1_bytes(&ephemeral_pub_bytes)
+        .map_err(|_| Error::InvalidPublicKey("Invalid ephemeral key".to_string()))?;
+
+    // Compute shared secret
+    let shared_secret_point = k256::ecdh::diffie_hellman(
+        spending_secret.to_nonzero_scalar(),
+        ephemeral_pub.as_affine(),
+    );
+
+    let mut hasher = Sha256::new();
+    hasher.update(shared_secret_point.raw_secret_bytes());
+    let shared_secret_hash: [u8; 32] = hasher.finalize().into();
+
+    // Quick view tag check
+    if shared_secret_hash[0] != stealth_address.view_tag {
+        return Ok(false);
+    }
+
+    // Full verification: derive expected stealth address
+    let viewing_scalar = Scalar::from_repr_vartime(viewing_priv_bytes.as_slice().try_into().unwrap())
+        .ok_or_else(|| Error::InvalidPrivateKey("Invalid viewing scalar".to_string()))?;
+    let hash_scalar = Scalar::from_repr_vartime(shared_secret_hash.into())
+        .ok_or_else(|| Error::CryptoError("Invalid hash scalar".to_string()))?;
+
+    let stealth_private_scalar = viewing_scalar + hash_scalar;
+
+    // Compute expected public key
+    let expected_point = ProjectivePoint::GENERATOR * stealth_private_scalar;
+    let expected_bytes = expected_point.to_affine().to_bytes();
+
+    // Compare with provided stealth address
+    let provided_bytes = hex_to_bytes(&stealth_address.address)?;
+
+    Ok(expected_bytes.as_slice() == provided_bytes.as_slice())
+}
+
+/// Convert a secp256k1 public key to an Ethereum address.
+///
+/// Algorithm (EIP-55):
+/// 1. Decompress the public key to uncompressed form (65 bytes)
+/// 2. Remove the 0x04 prefix (take last 64 bytes)
+/// 3. keccak256 hash of the 64 bytes
+/// 4. Take the last 20 bytes as the address
+/// 5. Apply EIP-55 checksum
+pub fn public_key_to_eth_address(public_key: &str) -> Result<HexString> {
+    let key_bytes = hex_to_bytes(public_key)?;
+
+    let pub_key = PublicKey::from_sec1_bytes(&key_bytes)
+        .map_err(|_| Error::InvalidPublicKey("Invalid public key".to_string()))?;
+
+    // Get uncompressed public key (65 bytes starting with 0x04)
+    let uncompressed = pub_key.to_encoded_point(false);
+    let pub_key_bytes = uncompressed.as_bytes();
+
+    // Remove 0x04 prefix and keccak256 hash
+    let pub_key_without_prefix = &pub_key_bytes[1..];
+    let mut hasher = Keccak256::new();
+    hasher.update(pub_key_without_prefix);
+    let hash = hasher.finalize();
+
+    // Take last 20 bytes
+    let address_bytes = &hash[12..];
+    let address_hex = hex::encode(address_bytes);
+
+    // Apply EIP-55 checksum
+    let mut checksum_hasher = Keccak256::new();
+    checksum_hasher.update(address_hex.as_bytes());
+    let checksum_hash = checksum_hasher.finalize();
+
+    let mut checksummed = String::with_capacity(40);
+    for (i, c) in address_hex.chars().enumerate() {
+        if c.is_ascii_digit() {
+            checksummed.push(c);
+        } else {
+            let nibble = (checksum_hash[i / 2] >> (4 * (1 - (i % 2)))) & 0x0f;
+            if nibble >= 8 {
+                checksummed.push(c.to_ascii_uppercase());
+            } else {
+                checksummed.push(c.to_ascii_lowercase());
+            }
+        }
+    }
+
+    Ok(format!("0x{}", checksummed))
+}
+
+/// Encode a stealth meta-address to SIP format.
+///
+/// Format: sip:<chain>:<spending_key>:<viewing_key>
+pub fn encode_stealth_meta_address(meta_address: &StealthMetaAddress) -> String {
+    format!(
+        "sip:{}:{}:{}",
+        meta_address.chain, meta_address.spending_key, meta_address.viewing_key
+    )
+}
+
+/// Decode a SIP-encoded stealth meta-address.
+pub fn decode_stealth_meta_address(encoded: &str) -> Result<StealthMetaAddress> {
+    let parts: Vec<&str> = encoded.split(':').collect();
+    if parts.len() != 4 || parts[0] != "sip" {
+        return Err(Error::InvalidStealthMetaAddress(format!(
+            "Invalid format: {}",
+            encoded
+        )));
+    }
+
+    Ok(StealthMetaAddress::new(
+        parts[2].to_string(),
+        parts[3].to_string(),
+        parts[1].to_string(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_and_recover() {
+        let (meta, spending_priv, viewing_priv) = generate_stealth_meta_address("ethereum");
+
+        let (stealth, _) = generate_stealth_address(&meta).unwrap();
+
+        assert!(check_stealth_address(&stealth, &spending_priv, &viewing_priv).unwrap());
+
+        let recovery =
+            derive_stealth_private_key(&stealth, &spending_priv, &viewing_priv).unwrap();
+        assert!(!recovery.private_key.is_empty());
+    }
+
+    #[test]
+    fn test_encode_decode_meta_address() {
+        let (meta, _, _) = generate_stealth_meta_address("ethereum");
+
+        let encoded = encode_stealth_meta_address(&meta);
+        let decoded = decode_stealth_meta_address(&encoded).unwrap();
+
+        assert_eq!(meta.chain, decoded.chain);
+        assert_eq!(meta.spending_key, decoded.spending_key);
+        assert_eq!(meta.viewing_key, decoded.viewing_key);
+    }
+}

--- a/sdks/rust/src/types.rs
+++ b/sdks/rust/src/types.rs
@@ -1,0 +1,146 @@
+//! Type definitions for SIP Protocol Rust SDK.
+//!
+//! These types mirror the TypeScript definitions in @sip-protocol/types.
+
+use std::fmt;
+
+/// A hex string with 0x prefix (e.g., "0x1234abcd")
+pub type HexString = String;
+
+/// Chain identifier (e.g., "ethereum", "solana", "near")
+pub type ChainId = String;
+
+/// A 32-byte hash as hex string with 0x prefix
+pub type Hash = String;
+
+/// A stealth meta-address containing public keys for generating one-time addresses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StealthMetaAddress {
+    /// Compressed secp256k1 public key (33 bytes, 0x02/0x03 prefix)
+    pub spending_key: HexString,
+    /// Compressed secp256k1 public key (33 bytes, 0x02/0x03 prefix)
+    pub viewing_key: HexString,
+    /// The blockchain this address is for
+    pub chain: ChainId,
+    /// Optional human-readable label
+    pub label: Option<String>,
+}
+
+impl StealthMetaAddress {
+    /// Create a new stealth meta-address
+    pub fn new(spending_key: HexString, viewing_key: HexString, chain: ChainId) -> Self {
+        Self {
+            spending_key,
+            viewing_key,
+            chain,
+            label: None,
+        }
+    }
+
+    /// Create with a label
+    pub fn with_label(
+        spending_key: HexString,
+        viewing_key: HexString,
+        chain: ChainId,
+        label: String,
+    ) -> Self {
+        Self {
+            spending_key,
+            viewing_key,
+            chain,
+            label: Some(label),
+        }
+    }
+}
+
+/// A one-time stealth address derived from a meta-address.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StealthAddress {
+    /// The stealth address (compressed public key)
+    pub address: HexString,
+    /// The sender's ephemeral public key
+    pub ephemeral_public_key: HexString,
+    /// First byte of shared secret hash for efficient scanning
+    pub view_tag: u8,
+}
+
+/// Recovery data for spending from a stealth address.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StealthAddressRecovery {
+    /// The stealth address being recovered
+    pub stealth_address: HexString,
+    /// The ephemeral key used to generate the address
+    pub ephemeral_public_key: HexString,
+    /// The derived private key for spending
+    pub private_key: HexString,
+}
+
+/// A Pedersen commitment with its blinding factor.
+///
+/// C = v*G + r*H where:
+/// - v = value (hidden)
+/// - r = blinding factor (random)
+/// - G, H = independent generators
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PedersenCommitment {
+    /// The commitment point (compressed, 33 bytes)
+    pub commitment: HexString,
+    /// The blinding factor (32 bytes, secret)
+    pub blinding: HexString,
+}
+
+/// A viewing key for selective disclosure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ViewingKey {
+    /// The viewing key (32 bytes)
+    pub key: HexString,
+    /// SHA-256 hash of the key for indexing
+    pub key_hash: HexString,
+    /// Unix timestamp of key creation (milliseconds)
+    pub created_at: u64,
+    /// Optional human-readable label
+    pub label: Option<String>,
+}
+
+/// Privacy levels for SIP transactions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PrivacyLevel {
+    /// No privacy, all data public
+    Transparent,
+    /// Full privacy, sender/amount/recipient hidden
+    Shielded,
+    /// Privacy with viewing key for auditors
+    Compliant,
+}
+
+impl fmt::Display for PrivacyLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PrivacyLevel::Transparent => write!(f, "transparent"),
+            PrivacyLevel::Shielded => write!(f, "shielded"),
+            PrivacyLevel::Compliant => write!(f, "compliant"),
+        }
+    }
+}
+
+impl std::str::FromStr for PrivacyLevel {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "transparent" => Ok(PrivacyLevel::Transparent),
+            "shielded" => Ok(PrivacyLevel::Shielded),
+            "compliant" => Ok(PrivacyLevel::Compliant),
+            _ => Err(format!("Invalid privacy level: {}", s)),
+        }
+    }
+}
+
+/// Encrypted data with nonce for decryption.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncryptedPayload {
+    /// The encrypted data (hex)
+    pub ciphertext: HexString,
+    /// The nonce/IV used for encryption (hex)
+    pub nonce: HexString,
+}


### PR DESCRIPTION
## Summary
- Adds Python SDK (`sdks/python/`) with PyPI-ready `pyproject.toml`
- Adds Rust SDK (`sdks/rust/`) with crates.io-ready `Cargo.toml` and WASM support
- Adds Go SDK (`sdks/go/`) with pkg.go.dev-ready `go.mod`
- All SDKs implement consistent API for stealth addresses, Pedersen commitments, and viewing keys

## Test plan
- [ ] Python: `cd sdks/python && pip install -e ".[dev]" && pytest`
- [ ] Rust: `cd sdks/rust && cargo test`
- [ ] Go: `cd sdks/go && go test ./...`

Closes #460