### PR TITLE
feat(specs): add Privacy Coalition Strategy (M21-09)

### DIFF
--- a/docs/specs/PRIVACY-COALITION-STRATEGY.md
+++ b/docs/specs/PRIVACY-COALITION-STRATEGY.md
@@ -1,0 +1,668 @@
+# SIP Privacy Coalition Strategy
+
+**Status:** Draft
+**Version:** 1.0.0
+**Last Updated:** 2026-01-20
+**Related:** [Working Group Charter](./WORKING-GROUP-CHARTER.md), [EIP Engagement Strategy](./EIP-ENGAGEMENT-STRATEGY.md)
+
+---
+
+## Executive Summary
+
+This document outlines the strategy for building a coalition of privacy-focused projects to support the SIP standard. A unified voice from the privacy community strengthens the proposal, accelerates adoption, and demonstrates industry-wide commitment to privacy standards.
+
+**Goal:** Unite the privacy community behind a common standard while respecting each project's unique value proposition.
+
+**Core Principle:** Collaboration, not competition. SIP complements existing solutions.
+
+---
+
+## 1. Target Privacy Projects
+
+### 1.1 Priority Matrix
+
+| Project | Focus | Chain | Priority | Synergy |
+|---------|-------|-------|----------|---------|
+| **Zcash Foundation** | Shielded transactions | Zcash | Critical | Privacy expertise, academic credibility |
+| **Aztec Protocol** | Private DeFi | Ethereum L2 | Critical | ZK expertise, EVM privacy |
+| **Railgun** | DeFi privacy | Multi-EVM | High | Existing user base, infrastructure |
+| **Secret Network** | Private smart contracts | Cosmos | High | Cross-chain privacy, TEE approach |
+| **Penumbra** | Shielded DEX | Cosmos | High | Intent-based design, DEX privacy |
+| **Tornado Cash (community)** | Mixing pools | EVM | Medium | Lessons learned, regulatory context |
+| **Nocturne** | Private accounts | Ethereum | Medium | Account abstraction privacy |
+| **Namada** | Multi-asset shielded | Cosmos | Medium | Asset-agnostic privacy |
+| **Manta Network** | Privacy L1/L2 | Polkadot/EVM | Medium | ZK ecosystem, modular privacy |
+| **Oasis Network** | Confidential compute | Oasis | Lower | TEE approach (different model) |
+
+### 1.2 Project Profiles
+
+#### Zcash Foundation
+
+```
+Focus: Pioneering shielded transaction technology
+Technology: zk-SNARKs, Sapling protocol, Orchard
+Key People: Josh Swihart (CEO), Jack Gavigan (ED)
+Relevance: Academic credibility, privacy research leadership
+Website: https://zfnd.org
+```
+
+**Why Partner:**
+- Gold standard for privacy research
+- Academic and regulatory credibility
+- Halo2 proof system (potential SIP integration)
+
+**Value to Zcash:**
+- Broader ecosystem adoption of privacy primitives
+- Cross-chain privacy extends Zcash influence
+- Standards alignment benefits Zcash ecosystem
+
+#### Aztec Protocol
+
+```
+Focus: Private DeFi on Ethereum
+Technology: PLONK, Noir language, zkRollup
+Key People: Zac Williamson (CEO), Joe Andrews (CTO)
+Relevance: ZK expertise, Noir circuit language
+Website: https://aztec.network
+```
+
+**Why Partner:**
+- Noir circuit language (SIP already uses Noir)
+- Deep ZK cryptography expertise
+- EVM-focused privacy solutions
+
+**Value to Aztec:**
+- SIP brings privacy to more applications
+- Noir adoption increases (SIP uses Noir)
+- Complementary rather than competitive
+
+#### Railgun
+
+```
+Focus: Privacy system for DeFi
+Technology: zk-SNARKs, shielded balances
+Key People: Community-governed (DAO)
+Relevance: Production DeFi privacy, multi-chain
+Website: https://railgun.org
+```
+
+**Why Partner:**
+- Live production system with real users
+- Multi-chain deployment experience
+- DeFi integration patterns
+
+**Value to Railgun:**
+- Standard interfaces simplify integrations
+- Interoperability with SIP-compatible apps
+- Unified privacy narrative
+
+#### Secret Network
+
+```
+Focus: Privacy-preserving smart contracts
+Technology: Trusted Execution Environments (TEE)
+Key People: Guy Zyskind (co-founder), Tor Bair
+Relevance: Cross-chain privacy, different privacy model
+Website: https://scrt.network
+```
+
+**Why Partner:**
+- Cross-chain privacy experience
+- Different technical approach (TEE vs ZK)
+- Cosmos ecosystem connections
+
+**Value to Secret:**
+- Cryptographic privacy complements TEE approach
+- Cross-chain standards benefit Secret bridges
+- Broader privacy coalition strengthens advocacy
+
+#### Penumbra
+
+```
+Focus: Shielded DEX and staking
+Technology: Groth16, shielded pools, intents
+Key People: Henry de Valence (founder)
+Relevance: Intent-based architecture (like SIP)
+Website: https://penumbra.zone
+```
+
+**Why Partner:**
+- Intent-based design alignment with SIP
+- Shielded DEX expertise
+- Cosmos IBC privacy
+
+**Value to Penumbra:**
+- Intent standardization across ecosystems
+- Privacy standard increases legitimacy
+- Cross-chain intents interoperability
+
+---
+
+## 2. Partnership Strategy
+
+### 2.1 Engagement Tiers
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    PARTNERSHIP TIERS                             │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  TIER 1: STRATEGIC PARTNERS                                      │
+│  ├── Joint research initiatives                                  │
+│  ├── Co-authored standards proposals                             │
+│  ├── Technical integration planning                              │
+│  └── Shared advocacy and messaging                               │
+│                                                                  │
+│  TIER 2: TECHNICAL COLLABORATORS                                 │
+│  ├── Technical feedback on specifications                        │
+│  ├── Interoperability testing                                    │
+│  ├── Shared best practices                                       │
+│  └── Working group participation                                 │
+│                                                                  │
+│  TIER 3: COALITION SUPPORTERS                                    │
+│  ├── Public endorsement of privacy standards                     │
+│  ├── Joint statements and advocacy                               │
+│  ├── Conference co-presentations                                 │
+│  └── Social media amplification                                  │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 Value Proposition Framework
+
+| Partner Type | SIP Offers | SIP Gains |
+|--------------|------------|-----------|
+| **ZK Protocols** | Broader adoption of ZK privacy | Technical expertise, credibility |
+| **Privacy Chains** | Cross-chain standard | Ecosystem connections, use cases |
+| **DeFi Privacy** | User-facing standard | Integration patterns, real-world feedback |
+| **Research Orgs** | Implementation platform | Academic validation, research |
+
+### 2.3 Non-Competition Positioning
+
+**Key Message:** SIP is infrastructure, not a competing product.
+
+```
+"SIP is the HTTP of privacy - a protocol layer that enables privacy
+across all applications, regardless of the underlying chain or privacy
+technology. We complement specialized solutions like Zcash, Aztec, and
+Railgun by providing a unified interface for privacy-preserving intents."
+```
+
+**Differentiation Table:**
+
+| Aspect | SIP | Other Privacy Projects |
+|--------|-----|------------------------|
+| **Focus** | Privacy standard/interface | Privacy implementation |
+| **Chain** | Multi-chain middleware | Usually single-chain |
+| **Users** | Developers/integrators | End users |
+| **Competition** | None (infra layer) | Each other |
+
+---
+
+## 3. Coalition Structure
+
+### 3.1 Governance Model
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│               PRIVACY STANDARDS COALITION                        │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  STEERING COMMITTEE                                              │
+│  ├── 1 representative per Strategic Partner                      │
+│  ├── Quarterly strategy meetings                                 │
+│  └── Consensus-based decision making                             │
+│                                                                  │
+│  TECHNICAL WORKING GROUP                                         │
+│  ├── Open to all Technical Collaborators                         │
+│  ├── Bi-weekly technical calls                                   │
+│  └── Specification review and feedback                           │
+│                                                                  │
+│  ADVOCACY COMMITTEE                                              │
+│  ├── Open to all Coalition Supporters                            │
+│  ├── Coordinates public messaging                                │
+│  └── Manages joint statements and events                         │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 3.2 Membership Benefits
+
+| Tier | Benefits |
+|------|----------|
+| **Strategic Partner** | Steering committee seat, co-authorship, joint funding opportunities |
+| **Technical Collaborator** | Early spec access, integration support, working group participation |
+| **Coalition Supporter** | Logo on coalition page, joint statement inclusion, event invitations |
+
+### 3.3 Membership Requirements
+
+| Tier | Requirements |
+|------|--------------|
+| **Strategic Partner** | Active contribution to specifications, dedicated liaison |
+| **Technical Collaborator** | Technical feedback participation, working group attendance |
+| **Coalition Supporter** | Public endorsement of privacy standards, code of conduct agreement |
+
+---
+
+## 4. Outreach Templates
+
+### 4.1 Initial Contact - Privacy Projects
+
+**Subject:** Privacy Standards Coalition - Invitation to [Project Name]
+
+```
+Hi [Name],
+
+I'm [Your Name] from the SIP Protocol team. We're forming a coalition
+of privacy-focused projects to establish common standards for privacy
+in Web3.
+
+Why we're reaching out to [Project]:
+- Your pioneering work on [specific technology/contribution]
+- [Project]'s credibility in the privacy community
+- Alignment between our technical approaches
+
+What we're proposing:
+The "Privacy Standards Coalition" - a collaborative group to:
+1. Establish interoperable privacy standards
+2. Present a unified voice on privacy regulation
+3. Share technical best practices
+4. Advocate for privacy as a fundamental right
+
+SIP's role:
+We're building privacy middleware - a standard interface layer that
+complements specialized solutions like [Project]. We're not competing;
+we're creating infrastructure that makes all privacy solutions more
+accessible.
+
+What we're asking:
+- 30-minute intro call to discuss alignment
+- Technical feedback on our specifications
+- Potential participation in the coalition
+
+Resources:
+- SIP Specification: [link]
+- Coalition Charter (draft): [link]
+- Working Group: [link]
+
+We believe privacy is stronger together. Would you be open to a
+conversation?
+
+Best,
+[Your Name]
+SIP Protocol Team
+```
+
+### 4.2 Zcash Foundation Specific
+
+**Subject:** SIP Protocol - Privacy Standards Partnership with Zcash Foundation
+
+```
+Dear Josh / Zcash Foundation team,
+
+I'm [Your Name] from SIP Protocol. We're building privacy middleware
+for Web3 and deeply admire Zcash's pioneering work in shielded
+transactions.
+
+Why Zcash matters to SIP:
+- Zcash set the gold standard for cryptographic privacy
+- Your academic rigor elevates the entire space
+- Halo2/Orchard represent the frontier of ZK privacy
+
+How SIP complements Zcash:
+SIP brings Zcash-style privacy primitives (stealth addresses, Pedersen
+commitments) to multi-chain applications. We're not building another
+privacy coin - we're building the interface layer that makes privacy
+accessible everywhere.
+
+Partnership opportunities:
+1. Technical review of SIP's cryptographic approach
+2. Potential Halo2 integration for proof composition
+3. Joint advocacy for privacy standards
+4. Co-authorship on privacy EIPs/standards
+
+We'd be honored to have Zcash Foundation's involvement in the Privacy
+Standards Coalition we're forming. Your expertise and credibility
+would be invaluable.
+
+Would you be open to a technical discussion?
+
+Best regards,
+[Your Name]
+SIP Protocol
+```
+
+### 4.3 Aztec Protocol Specific
+
+**Subject:** SIP + Aztec - Noir Circuits and Privacy Standards
+
+```
+Hi Zac / Aztec team,
+
+I'm [Your Name] from SIP Protocol. We're big fans of Aztec's work -
+in fact, SIP uses Noir for our ZK circuits.
+
+The Noir connection:
+SIP's validity and funding proofs are written in Noir. Your tooling
+has been essential to our development. We'd love to collaborate more
+formally.
+
+Synergy opportunities:
+1. SIP increases Noir adoption across ecosystems
+2. Joint work on privacy circuit standards
+3. Shared learnings on EVM privacy challenges
+4. Coalition advocacy for privacy in Ethereum
+
+What we're building:
+SIP is privacy middleware - stealth addresses, Pedersen commitments,
+viewing keys - as a standard interface. We complement Aztec's privacy
+L2 by bringing these primitives to applications everywhere.
+
+We're forming a Privacy Standards Coalition and would love Aztec's
+participation. Your ZK expertise and Noir ecosystem are natural fits.
+
+Call to discuss?
+
+Best,
+[Your Name]
+```
+
+### 4.4 Follow-Up Template
+
+**Subject:** Re: Privacy Standards Coalition - Next Steps
+
+```
+Hi [Name],
+
+Following up on my previous message about the Privacy Standards
+Coalition.
+
+Quick context:
+- SIP is forming a coalition of privacy projects
+- Goal: unified standards and advocacy for privacy in Web3
+- Current members: [list if any]
+
+Why [Project] specifically:
+[One specific reason relevant to this project]
+
+Low-commitment first step:
+- 20-minute intro call
+- Or async review of our coalition charter: [link]
+
+We're flexible on engagement level. Even informal feedback helps.
+
+Best,
+[Your Name]
+```
+
+---
+
+## 5. Joint Statement Template
+
+### 5.1 Coalition Founding Statement
+
+```markdown
+# Privacy Standards Coalition - Founding Statement
+
+**For Immediate Release**
+[Date]
+
+## United for Privacy: Leading Projects Form Standards Coalition
+
+Today, [list of founding members] announce the formation of the
+Privacy Standards Coalition, a collaborative initiative to establish
+common standards for privacy in Web3.
+
+### Our Commitment
+
+We believe privacy is a fundamental right, not a feature. The
+Privacy Standards Coalition commits to:
+
+1. **Interoperability**: Developing standards that allow privacy
+   solutions to work together across chains and protocols.
+
+2. **Accessibility**: Making privacy available to all users, not
+   just those with technical expertise.
+
+3. **Compliance**: Creating privacy solutions that can coexist
+   with legitimate regulatory requirements through selective
+   disclosure mechanisms.
+
+4. **Collaboration**: Sharing research, best practices, and
+   resources to advance the state of privacy technology.
+
+### Founding Members
+
+[For each member:]
+- **[Project Name]**: "[One-sentence quote from project lead]"
+
+### Our First Initiative
+
+The Coalition's first initiative is supporting the SIP-EIP
+(Shielded Intents Protocol), a proposed Ethereum standard for
+privacy-preserving intents. This standard provides:
+
+- Stealth addresses for unlinkable receiving
+- Pedersen commitments for hidden amounts
+- Viewing keys for selective disclosure
+
+### Join Us
+
+Privacy projects interested in joining the Coalition can apply at:
+[link]
+
+### Media Contact
+
+[Contact information]
+
+---
+
+*The Privacy Standards Coalition is an independent, community-governed
+initiative. Member participation does not imply endorsement of specific
+implementations.*
+```
+
+### 5.2 Advocacy Joint Statement Template
+
+```markdown
+# Joint Statement on [Topic]
+
+**[Date]**
+
+The undersigned members of the Privacy Standards Coalition issue
+the following statement regarding [topic]:
+
+[2-3 paragraph statement]
+
+**Signatories:**
+
+- [Project 1], represented by [Name], [Title]
+- [Project 2], represented by [Name], [Title]
+- [Project 3], represented by [Name], [Title]
+- ...
+
+---
+
+*This statement represents the views of the signing organizations
+and does not necessarily reflect the position of all Coalition
+members.*
+```
+
+---
+
+## 6. Advocacy Calendar
+
+### 6.1 Key Events 2026
+
+| Date | Event | Location | Opportunity |
+|------|-------|----------|-------------|
+| Feb 2026 | ETHDenver | Denver, CO | Coalition launch event |
+| Mar 2026 | Zcash conference | TBD | Privacy community outreach |
+| Apr 2026 | ETH Seoul | Seoul | Asia privacy advocacy |
+| May 2026 | Consensus | Austin, TX | Industry-wide visibility |
+| Jul 2026 | EthCC | Brussels | European privacy focus |
+| Sep 2026 | Solana Breakpoint | TBD | Solana privacy advocacy |
+| Nov 2026 | Devconnect | TBD | Technical deep-dives |
+
+### 6.2 Coordinated Messaging
+
+| Month | Theme | Activities |
+|-------|-------|------------|
+| **Q1** | Coalition Formation | Launch announcement, founding statement |
+| **Q2** | Technical Standards | EIP submission, specification reviews |
+| **Q3** | Developer Adoption | Hackathons, integration bounties |
+| **Q4** | Ecosystem Growth | Wallet integrations, protocol adoptions |
+
+### 6.3 Communication Channels
+
+| Channel | Purpose | Frequency |
+|---------|---------|-----------|
+| **Twitter/X** | Public announcements | As needed |
+| **Discord** | Coalition coordination | Daily |
+| **Newsletter** | Progress updates | Monthly |
+| **Blog** | Deep-dive content | Bi-weekly |
+
+---
+
+## 7. Success Metrics
+
+### 7.1 Coalition Growth
+
+| Metric | Q1 Target | Q2 Target | Q4 Target |
+|--------|-----------|-----------|-----------|
+| Strategic Partners | 2 | 4 | 6 |
+| Technical Collaborators | 5 | 10 | 20 |
+| Coalition Supporters | 10 | 25 | 50 |
+
+### 7.2 Engagement Metrics
+
+| Metric | Target |
+|--------|--------|
+| Joint statements issued | 4/year |
+| Co-presented events | 6/year |
+| Technical collaborations | 3 active |
+| Standard co-authorships | 2 |
+
+### 7.3 Impact Metrics
+
+| Metric | Target |
+|--------|--------|
+| Projects adopting SIP standard | 10 by Q4 |
+| Regulatory mentions | Cited in 2+ policy discussions |
+| Academic citations | 5+ papers |
+| Developer awareness | 10K+ unique visitors to docs |
+
+---
+
+## 8. Tracking Dashboard
+
+### 8.1 Outreach Status
+
+| Project | Status | Contact | Last Update | Next Action |
+|---------|--------|---------|-------------|-------------|
+| Zcash Foundation | 🔲 Not Started | TBD | - | Initial outreach |
+| Aztec Protocol | 🔲 Not Started | TBD | - | Initial outreach |
+| Railgun | 🔲 Not Started | TBD | - | Initial outreach |
+| Secret Network | 🔲 Not Started | TBD | - | Initial outreach |
+| Penumbra | 🔲 Not Started | TBD | - | Initial outreach |
+| Nocturne | 🔲 Not Started | TBD | - | Initial outreach |
+| Namada | 🔲 Not Started | TBD | - | Initial outreach |
+| Manta Network | 🔲 Not Started | TBD | - | Initial outreach |
+
+### 8.2 Partnership Progress
+
+```
+Zcash Foundation:
+├── 🔲 Initial Contact
+├── 🔲 Intro Call
+├── 🔲 Technical Discussion
+├── 🔲 Partnership Agreement
+└── 🔲 Public Announcement
+
+Aztec Protocol:
+├── 🔲 Initial Contact
+├── 🔲 Intro Call
+├── 🔲 Technical Discussion
+├── 🔲 Partnership Agreement
+└── 🔲 Public Announcement
+
+[Repeat for each project]
+```
+
+### 8.3 Coalition Milestones
+
+| Milestone | Target Date | Status |
+|-----------|-------------|--------|
+| First Strategic Partner | Q1 2026 | 🔲 |
+| Coalition Founding Statement | Q1 2026 | 🔲 |
+| 5 Technical Collaborators | Q2 2026 | 🔲 |
+| First Joint Event | Q2 2026 | 🔲 |
+| 10 Coalition Supporters | Q3 2026 | 🔲 |
+| First Standard Co-Authorship | Q3 2026 | 🔲 |
+
+---
+
+## 9. Risk Mitigation
+
+### 9.1 Potential Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Projects view SIP as competitor | High | Medium | Clear positioning as infrastructure |
+| Regulatory concerns deter partners | High | Medium | Compliance-focused messaging |
+| Slow partnership progress | Medium | Medium | Multiple outreach channels |
+| Coalition governance disputes | Medium | Low | Clear governance framework |
+| One partner dominates narrative | Medium | Low | Equal voice principles |
+
+### 9.2 Mitigation Strategies
+
+**Competition Concerns:**
+- Lead with "infrastructure, not product" messaging
+- Highlight how SIP increases adoption of partner technologies
+- Offer co-authorship and shared credit
+
+**Regulatory Concerns:**
+- Emphasize viewing keys and compliance features
+- Position coalition as responsible privacy advocates
+- Engage with regulatory discussions proactively
+
+**Slow Progress:**
+- Set realistic timelines
+- Multiple simultaneous outreach tracks
+- Celebrate small wins publicly
+
+---
+
+## 10. Resources
+
+### 10.1 Coalition Assets
+
+| Asset | Purpose | Status |
+|-------|---------|--------|
+| Logo | Visual identity | 🔲 To create |
+| Website | Coalition home | 🔲 To create |
+| Charter | Governance doc | ✅ Draft complete |
+| Slide deck | Presentations | 🔲 To create |
+
+### 10.2 Contact Database
+
+| Project | Primary Contact | Email | Twitter |
+|---------|-----------------|-------|---------|
+| Zcash Foundation | Josh Swihart | TBD | @jswihart |
+| Aztec | Zac Williamson | TBD | @aztaborina |
+| Railgun | DAO | TBD | @railaborina_project |
+| Secret | Guy Zyskind | TBD | @gaborina |
+| Penumbra | Henry de Valence | TBD | @hdevalence |
+
+### 10.3 Reference Materials
+
+| Document | Link |
+|----------|------|
+| SIP Specification | [./SIP-EIP.md](./SIP-EIP.md) |
+| Working Group Charter | [./WORKING-GROUP-CHARTER.md](./WORKING-GROUP-CHARTER.md) |
+| Wallet Integration Guide | [./WALLET-INTEGRATION-GUIDE.md](./WALLET-INTEGRATION-GUIDE.md) |
+| EIP Engagement Strategy | [./EIP-ENGAGEMENT-STRATEGY.md](./EIP-ENGAGEMENT-STRATEGY.md) |
+
+---
+
+*This strategy document is a living document and will be updated as coalition-building progresses.*


### PR DESCRIPTION
## Summary

Adds comprehensive strategy for building a coalition of privacy-focused projects to support the SIP standard. A unified privacy community strengthens the proposal and accelerates adoption.

### Strategy Contents

**Target Privacy Projects:**
- **Tier 1 (Critical):** Zcash Foundation, Aztec Protocol
- **Tier 2 (High):** Railgun, Secret Network, Penumbra
- **Tier 3 (Medium):** Nocturne, Namada, Manta Network, Oasis

**Partnership Structure:**
- Strategic Partners: Joint research, co-authorship, steering committee
- Technical Collaborators: Spec feedback, working group participation
- Coalition Supporters: Public endorsement, joint advocacy

**Key Positioning:**
- SIP as infrastructure, not competitor
- "Privacy is stronger together" messaging
- Complementary to existing solutions (not replacement)

**Outreach Materials:**
- Project-specific templates (Zcash, Aztec, general)
- Joint statement templates (founding, advocacy)
- Follow-up templates

**Advocacy Planning:**
- 2026 event calendar (ETHDenver, Zcash conf, EthCC, etc.)
- Coordinated messaging themes by quarter
- Communication channel strategy

**Success Metrics:**
- Partnership growth targets (2→4→6 strategic partners)
- Joint activities (4 statements, 6 events/year)
- Impact metrics (10 adopters, policy citations)

### Files Changed

- `docs/specs/PRIVACY-COALITION-STRATEGY.md` (+668 lines)

### Testing

Documentation only - no code changes.

Closes #281