### PR TITLE
docs(governance): add industry working group formation materials (M21-24)

### DIFF
--- a/docs/governance/FIRST-MEETING-AGENDA.md
+++ b/docs/governance/FIRST-MEETING-AGENDA.md
@@ -1,0 +1,274 @@
+# Privacy Standards Working Group - Founding Meeting Agenda
+
+**Date:** [TBD - Q2 2026]
+**Time:** 10:00 AM PT / 1:00 PM ET / 6:00 PM UTC
+**Duration:** 90 minutes
+**Format:** Virtual (Zoom/Google Meet)
+
+---
+
+## Pre-Meeting Preparation
+
+### Required Reading (All Attendees)
+- [ ] Working Group Charter (final version)
+- [ ] SIP-001: Core Protocol Specification
+- [ ] SIP-002: Stealth Address Format
+- [ ] SIP-003: Viewing Key Standard
+
+### Optional Background
+- Compliance Whitepaper
+- Cross-Chain Privacy Standard Proposal
+
+---
+
+## Agenda
+
+### 1. Welcome & Introductions (15 minutes)
+**10:00 - 10:15 PT**
+
+**Facilitator:** [SIP Protocol Representative]
+
+| Item | Time | Description |
+|------|------|-------------|
+| Welcome | 2 min | Thank founding members, state mission |
+| Roll Call | 3 min | Confirm attendance, quorum |
+| Introductions | 10 min | Each member: org, representative, interest area |
+
+**Attendee Introduction Format:**
+> "[Organization] - [Name], [Title]. We're interested in [specific area] and bring [expertise/perspective]."
+
+---
+
+### 2. Charter Ratification (10 minutes)
+**10:15 - 10:25 PT**
+
+**Facilitator:** [SIP Protocol Representative]
+
+| Item | Time | Description |
+|------|------|-------------|
+| Charter Review | 3 min | Highlight key sections |
+| Q&A | 5 min | Address final questions |
+| Ratification Vote | 2 min | Formal adoption |
+
+**Motion:**
+> "I move to ratify the Privacy Standards Working Group Charter version 1.0.0 as presented."
+
+**Vote:** Simple majority of founding members required.
+
+---
+
+### 3. Steering Committee Election (20 minutes)
+**10:25 - 10:45 PT**
+
+**Facilitator:** [Neutral Party / SIP Representative]
+
+#### 3.1 Nomination Process (5 min)
+
+Each founding member may nominate one candidate (including self-nomination).
+
+**Nomination Format:**
+> "I nominate [Name] from [Organization] for the Steering Committee."
+
+#### 3.2 Candidate Statements (10 min)
+
+Each nominee: 1-minute statement on qualifications and vision.
+
+#### 3.3 Election (5 min)
+
+- Each member votes for up to 7 candidates
+- Top 7 vote-getters elected
+- Tie-breaker: alphabetical by organization
+
+**Proposed Initial Officers:**
+- Chair: Elected by Steering Committee post-meeting
+- Vice-Chair: Elected by Steering Committee post-meeting
+- Secretary: Elected by Steering Committee post-meeting
+
+---
+
+### 4. Subgroup Formation (15 minutes)
+**10:45 - 11:00 PT**
+
+**Facilitator:** [Steering Committee Chair-Elect]
+
+#### 4.1 Subgroup Overview (3 min)
+
+| Subgroup | Focus | Meeting Cadence |
+|----------|-------|-----------------|
+| Technical | Specifications, implementations | Bi-weekly |
+| Compliance | Regulatory, audit standards | Monthly |
+| Ecosystem | Adoption, education | Monthly |
+
+#### 4.2 Subgroup Sign-Up (7 min)
+
+Members indicate interest in subgroup participation.
+
+**Sign-Up Format:**
+> "[Organization] will participate in [Subgroup 1] and [Subgroup 2]."
+
+#### 4.3 Subgroup Chair Selection (5 min)
+
+- Technical Subgroup Chair: [Nomination/Election]
+- Compliance Subgroup Chair: [Nomination/Election]
+- Ecosystem Subgroup Chair: [Nomination/Election]
+
+---
+
+### 5. Initial Work Plan Discussion (20 minutes)
+**11:00 - 11:20 PT**
+
+**Facilitator:** [Technical Subgroup Chair-Elect]
+
+#### 5.1 Proposed Q2 2026 Priorities (10 min)
+
+**Technical Subgroup:**
+| Priority | Description | Target |
+|----------|-------------|--------|
+| P1 | Finalize SIP-001/002/003 | End of Q2 |
+| P2 | EIP-5564 compatibility testing | Mid Q2 |
+| P3 | Reference implementation review | Ongoing |
+| P4 | Test vector development | End of Q2 |
+
+**Compliance Subgroup:**
+| Priority | Description | Target |
+|----------|-------------|--------|
+| P1 | Regulatory landscape document | Mid Q2 |
+| P2 | Viewing key disclosure standard | End of Q2 |
+| P3 | Travel Rule integration spec | End of Q2 |
+
+**Ecosystem Subgroup:**
+| Priority | Description | Target |
+|----------|-------------|--------|
+| P1 | Member onboarding program | Immediate |
+| P2 | Public website launch | Mid Q2 |
+| P3 | Developer documentation | End of Q2 |
+| P4 | ETH Denver/conference presence | As scheduled |
+
+#### 5.2 Member Input (10 min)
+
+Open floor for member priorities and concerns.
+
+**Discussion Questions:**
+- What's missing from this work plan?
+- What should be higher/lower priority?
+- What resources can your organization contribute?
+
+---
+
+### 6. Logistics & Next Steps (10 minutes)
+**11:20 - 11:30 PT**
+
+**Facilitator:** [Secretary-Elect]
+
+#### 6.1 Communication Channels (3 min)
+
+| Channel | Purpose | Access |
+|---------|---------|--------|
+| Mailing List | Official announcements | All members |
+| Discord/Slack | Day-to-day discussion | All members |
+| GitHub Org | Specification repos | All members |
+| Private Folder | Confidential docs | Members only |
+
+#### 6.2 Meeting Schedule (3 min)
+
+| Meeting | Frequency | Day/Time |
+|---------|-----------|----------|
+| Full Assembly | Quarterly | [TBD] |
+| Steering Committee | Monthly | [TBD] |
+| Technical Subgroup | Bi-weekly | [TBD] |
+| Compliance Subgroup | Monthly | [TBD] |
+| Ecosystem Subgroup | Monthly | [TBD] |
+
+#### 6.3 Immediate Action Items (4 min)
+
+| Action | Owner | Due |
+|--------|-------|-----|
+| Distribute meeting recording | Secretary | +1 day |
+| Publish meeting minutes | Secretary | +7 days |
+| Setup GitHub organization | Technical Chair | +7 days |
+| Create communication channels | Ecosystem Chair | +3 days |
+| Schedule subgroup kickoffs | Subgroup Chairs | +14 days |
+| Prepare public announcement | Ecosystem Subgroup | +14 days |
+
+---
+
+### 7. Public Announcement Discussion (Optional, if time)
+**If time permits**
+
+- Review draft announcement
+- Coordinate member social posts
+- Set embargo/launch date
+
+---
+
+## Post-Meeting Deliverables
+
+### Within 24 Hours
+- [ ] Meeting recording distributed to attendees
+- [ ] Action item list sent to owners
+
+### Within 7 Days
+- [ ] Official meeting minutes published
+- [ ] Charter with signatures formalized
+- [ ] Communication channels operational
+- [ ] GitHub organization created
+
+### Within 14 Days
+- [ ] Subgroup kickoff meetings held
+- [ ] Public announcement released
+- [ ] Press outreach completed
+- [ ] Member coordinated social posts
+
+---
+
+## Appendix: Voting Procedures
+
+### Charter Ratification
+- **Method:** Roll call vote
+- **Threshold:** Simple majority (>50%)
+- **Quorum:** All founding members
+
+### Steering Committee Election
+- **Method:** Ranked choice or plurality
+- **Threshold:** Top 7 candidates
+- **Quorum:** Majority of founding members
+
+### Work Plan Adoption
+- **Method:** Consensus or voice vote
+- **Threshold:** No objections (consensus)
+- **Quorum:** Majority of founding members
+
+---
+
+## Meeting Roles
+
+| Role | Responsibility | Assigned To |
+|------|----------------|-------------|
+| Facilitator | Guide discussion, keep time | [TBD] |
+| Note Taker | Capture minutes, action items | [TBD] |
+| Tech Support | Manage Zoom, recording | [TBD] |
+| Timekeeper | Signal time warnings | [TBD] |
+
+---
+
+## Attendee List
+
+### Confirmed Founding Members
+
+| Organization | Representative | Email | Subgroup Interest |
+|--------------|----------------|-------|-------------------|
+| [Org 1] | [Name] | [email] | [Technical/Compliance/Ecosystem] |
+| [Org 2] | [Name] | [email] | [Technical/Compliance/Ecosystem] |
+| ... | ... | ... | ... |
+
+### Observers (Non-Voting)
+
+| Organization | Representative | Email |
+|--------------|----------------|-------|
+| [Org A] | [Name] | [email] |
+| ... | ... | ... |
+
+---
+
+**Document Version:** 1.0.0
+**Last Updated:** January 2026

--- a/docs/governance/MEMBER-OUTREACH-STRATEGY.md
+++ b/docs/governance/MEMBER-OUTREACH-STRATEGY.md
@@ -1,0 +1,350 @@
+# Privacy Standards Working Group - Member Outreach Strategy
+
+**Target:** 15-20 Founding Members by Q2 2026
+**Goal:** Diverse, credible coalition representing the blockchain privacy ecosystem
+
+---
+
+## Target Member Categories
+
+### Tier 1: Essential Founding Members (Target: 5-7)
+
+These organizations provide immediate credibility and are critical for launch.
+
+| Organization | Category | Why Essential | Contact Strategy |
+|--------------|----------|---------------|------------------|
+| **Zcash Foundation** | Privacy Protocol | OG privacy expertise, credibility | Direct outreach via Josh Swihart |
+| **Aztec Network** | Privacy L2 | ZK privacy leaders, active development | Intro via DeFi connections |
+| **Electric Coin Company** | Privacy Protocol | Zcash creators, deep expertise | Conference introduction |
+| **Phantom** | Wallet | Top Solana wallet, UX focus | Direct partnership channel |
+| **MetaMask** | Wallet | Largest EVM wallet, industry standard | ConsenSys relationship |
+| **Jupiter** | DEX | #1 Solana DEX, privacy feature interest | Direct via Meow |
+| **Chainalysis** | Compliance | Industry compliance leader | Enterprise sales channel |
+
+### Tier 2: Strategic Members (Target: 5-7)
+
+Expand coalition across ecosystem segments.
+
+| Organization | Category | Value Add | Priority |
+|--------------|----------|-----------|----------|
+| **Uniswap Labs** | DEX | EVM DEX standard | High |
+| **1inch** | DEX Aggregator | Multi-chain reach | High |
+| **Solana Foundation** | Foundation | Chain support, grants | High |
+| **NEAR Foundation** | Foundation | Intents ecosystem | High |
+| **Ethereum Foundation** | Foundation | EIP process connection | Medium |
+| **Safe (Gnosis Safe)** | Wallet | Institutional custody | Medium |
+| **Ledger** | Hardware Wallet | Security credibility | Medium |
+| **Range Protocol** | Compliance | DeFi compliance | High |
+| **Elliptic** | Compliance | Alternative to Chainalysis | Medium |
+
+### Tier 3: Ecosystem Members (Target: 5-6)
+
+Broaden adoption and implementation coverage.
+
+| Organization | Category | Value Add |
+|--------------|----------|-----------|
+| **Arcium** | Privacy Infra | Confidential computing |
+| **Inco Network** | Privacy L1 | FHE expertise |
+| **Mina Foundation** | Privacy Protocol | Succinct proofs |
+| **Secret Network** | Privacy L1 | TEE-based privacy |
+| **Oasis Network** | Privacy L1 | Confidential smart contracts |
+| **Fireblocks** | Custody | Institutional adoption |
+| **BitGo** | Custody | Enterprise custody |
+| **Coinbase Custody** | Custody | Regulatory relationships |
+
+---
+
+## Outreach Sequence
+
+### Phase 1: Warm Introductions (Weeks 1-4)
+
+**Objective:** Secure 3-5 Tier 1 commitments
+
+```
+OUTREACH SEQUENCE - TIER 1
+
+Week 1: Research & Preparation
+├── Identify decision-maker at each target
+├── Research current privacy initiatives
+├── Prepare customized one-pagers
+└── Draft personalized outreach messages
+
+Week 2: Initial Contact
+├── Send personalized emails to decision-makers
+├── LinkedIn connection requests with context
+├── Twitter/X DM for those active on platform
+└── Request warm introductions from network
+
+Week 3: Follow-Up
+├── Second touch for non-responders
+├── Share charter draft with interested parties
+├── Schedule intro calls
+└── Address initial questions
+
+Week 4: Conversion
+├── Conduct intro calls
+├── Share full materials
+├── Request formal commitment
+└── Begin onboarding committed members
+```
+
+### Phase 2: Expand Coalition (Weeks 5-8)
+
+**Objective:** Add 5-7 Tier 2 members, leverage Tier 1 relationships
+
+```
+OUTREACH SEQUENCE - TIER 2
+
+Week 5: Leverage Tier 1
+├── Request introductions from committed Tier 1 members
+├── Announce Tier 1 commitments (with permission)
+├── Update materials with founding member logos
+└── Begin Tier 2 outreach
+
+Week 6-7: Targeted Outreach
+├── Personalized outreach to Tier 2 targets
+├── Emphasize Tier 1 member participation
+├── Conduct intro calls
+└── Address specific concerns per category
+
+Week 8: Solidify
+├── Formal commitment requests
+├── Begin onboarding
+├── Plan founding meeting
+└── Prepare launch announcement
+```
+
+### Phase 3: Founding Event (Weeks 9-12)
+
+**Objective:** Launch Working Group publicly with 15+ members
+
+```
+LAUNCH SEQUENCE
+
+Week 9: Pre-Launch
+├── Finalize founding member list
+├── Confirm all signatures on charter
+├── Prepare press materials
+└── Brief members on messaging
+
+Week 10: Soft Launch
+├── Private announcement to crypto media
+├── Embargo briefings
+├── Final member coordination
+└── Technical setup (comms channels, repos)
+
+Week 11: Public Launch
+├── Press release distribution
+├── Social media announcement
+├── Founding member coordinated posts
+└── Community AMAs
+
+Week 12: Kickoff Meeting
+├── First Full Assembly meeting
+├── Elect initial Steering Committee
+├── Establish subgroups
+└── Set Q2 2026 work plan
+```
+
+---
+
+## Outreach Templates
+
+### Initial Email Template
+
+```
+Subject: Invitation: Privacy Standards Working Group - Founding Membership
+
+Hi [Name],
+
+I'm reaching out to invite [Organization] to become a founding member of the
+Privacy Standards Working Group, an industry coalition developing interoperable
+privacy standards for blockchain.
+
+Why this matters:
+• Privacy is becoming essential for institutional adoption
+• Fragmented approaches create integration burden
+• Regulators need standards they can reference
+• Users deserve privacy that works everywhere
+
+Why [Organization]:
+[1-2 sentences on their specific relevance and what they bring]
+
+Founding members will:
+• Shape the standards that define blockchain privacy
+• Ensure their use cases are represented
+• Get early access to specifications and implementations
+• Be recognized as industry leaders in privacy
+
+We're targeting 15-20 founding members representing privacy protocols,
+wallets, DEXs, foundations, and compliance providers.
+
+Would you be open to a 20-minute call to discuss?
+
+Best,
+[Name]
+SIP Protocol Team
+```
+
+### Follow-Up Template (No Response)
+
+```
+Subject: Re: Privacy Standards Working Group - Quick follow-up
+
+Hi [Name],
+
+Following up on my note about the Privacy Standards Working Group.
+
+I know you're busy, so here's the quick version:
+
+• Industry coalition for privacy standards
+• Founding members shape the direction
+• [Tier 1 Member] and [Tier 1 Member] are already committed
+• 20-minute call to see if it's a fit
+
+Worth a quick chat?
+
+Best,
+[Name]
+```
+
+### Follow-Up Template (Interested but Hesitant)
+
+```
+Subject: Re: Privacy Standards Working Group - Addressing your questions
+
+Hi [Name],
+
+Thanks for your interest in the Working Group. To address your concerns:
+
+[Specific concern 1]:
+[Direct response]
+
+[Specific concern 2]:
+[Direct response]
+
+The commitment is straightforward:
+• Quarterly full-group meetings (1 hour)
+• Optional subgroup participation
+• No dues or financial obligations
+• Charter ratification (attached)
+
+Ready to move forward?
+
+Best,
+[Name]
+```
+
+---
+
+## Objection Handling
+
+### "We're too busy"
+
+**Response:**
+"The time commitment is minimal—quarterly 1-hour meetings plus optional subgroup participation. The value is disproportionate: you shape standards your team would otherwise have to react to."
+
+### "We don't do privacy"
+
+**Response:**
+"Privacy is becoming table stakes. Even if you don't build privacy features today, standards will affect your integrations. Being at the table lets you ensure standards work for your architecture."
+
+### "What's in it for us?"
+
+**Response:**
+"Three things: (1) Influence over standards that will affect your product, (2) Early access to specifications before public release, (3) Recognition as a privacy leader in the industry."
+
+### "Who else is joining?"
+
+**Response:**
+"We're building a coalition across the ecosystem. [Currently committed members]. We're targeting [X] founding members including [categories]."
+
+### "We need to check with legal"
+
+**Response:**
+"Absolutely. Here's the charter document and IP policy for their review. The key points: all specs are CC0 (public domain), code is MIT, and there's a RAND-Z patent policy. Happy to jump on a call with your counsel if helpful."
+
+### "We have our own privacy approach"
+
+**Response:**
+"That's exactly why we want you involved. The Working Group isn't about picking winners—it's about ensuring interoperability. Your approach can inform the standards while ensuring they work with your implementation."
+
+---
+
+## Success Metrics
+
+### Founding Phase (Q1 2026)
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Tier 1 commitments | 5+ | Signed charter |
+| Total founding members | 15+ | Signed charter |
+| Category coverage | 5+ categories | Diverse representation |
+| Response rate | 40%+ | Replies to outreach |
+| Conversion rate | 30%+ | Commitment from engaged |
+
+### Launch Phase (Q2 2026)
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Launch coverage | 10+ outlets | Media mentions |
+| Social reach | 100K+ | Combined impressions |
+| Community interest | 500+ | Discord/mailing list signups |
+| Observer members | 50+ | Registered observers |
+
+---
+
+## Contact Tracking
+
+### Template: Outreach Tracker
+
+```
+| Organization | Contact | Email | Status | Last Touch | Next Step | Notes |
+|--------------|---------|-------|--------|------------|-----------|-------|
+| Zcash Found. | Josh S. | [email] | Contacted | 2026-01-15 | Follow-up | Warm |
+| Phantom | [Name] | [email] | Scheduled | 2026-01-18 | Call 1/22 | Via intro |
+| Jupiter | Meow | [email] | Pending | - | Initial | DM Twitter |
+| ... | ... | ... | ... | ... | ... | ... |
+```
+
+### Status Definitions
+
+| Status | Definition |
+|--------|------------|
+| Pending | Not yet contacted |
+| Contacted | Initial outreach sent |
+| Engaged | Responded, discussing |
+| Scheduled | Call/meeting scheduled |
+| Committed | Verbal commitment |
+| Signed | Charter signed |
+| Declined | Not participating |
+
+---
+
+## Resources
+
+### Materials Checklist
+
+- [ ] Working Group Charter (PDF)
+- [ ] One-Page Overview
+- [ ] FAQ Document
+- [ ] Founding Member Benefits Summary
+- [ ] Logo/Brand Assets
+- [ ] Standard Presentation Deck
+- [ ] Personalized Deck per Tier 1 Target
+
+### Channels
+
+| Channel | Purpose | Owner |
+|---------|---------|-------|
+| Email | Primary outreach | BD Lead |
+| LinkedIn | Professional networking | Team |
+| Twitter/X | Public engagement | Comms |
+| Telegram | Crypto-native contacts | BD Lead |
+| Discord | Community building | Community |
+| Conferences | In-person relationship | All |
+
+---
+
+**Document Version:** 1.0.0
+**Last Updated:** January 2026

--- a/docs/governance/PUBLIC-ANNOUNCEMENT.md
+++ b/docs/governance/PUBLIC-ANNOUNCEMENT.md
@@ -1,0 +1,456 @@
+# Privacy Standards Working Group - Public Announcement
+
+**Embargo:** [DATE] at [TIME] UTC
+**Distribution:** Upon embargo lift
+
+---
+
+## Press Release
+
+### FOR IMMEDIATE RELEASE
+
+# Industry Leaders Launch Privacy Standards Working Group
+
+**Cross-Chain Privacy Standard Initiative Unites Leading Blockchain Projects**
+
+**[CITY, DATE]** — A coalition of leading blockchain organizations today announced the formation of the Privacy Standards Working Group (PSWG), an open industry body dedicated to developing interoperable privacy standards for the blockchain ecosystem.
+
+The Working Group brings together [NUMBER] founding members spanning privacy protocols, wallets, decentralized exchanges, blockchain foundations, and compliance providers. The coalition aims to establish unified standards that enable privacy by default while maintaining regulatory compliance capabilities.
+
+"Privacy is becoming table stakes for blockchain adoption," said [QUOTE ATTRIBUTION]. "The Privacy Standards Working Group ensures the industry builds interoperable solutions rather than fragmented approaches that burden developers and users."
+
+### Founding Members
+
+The Working Group launches with the following founding members:
+
+**Privacy Protocols:**
+- [Member 1]
+- [Member 2]
+
+**Wallets:**
+- [Member 3]
+- [Member 4]
+
+**Decentralized Exchanges:**
+- [Member 5]
+- [Member 6]
+
+**Blockchain Foundations:**
+- [Member 7]
+- [Member 8]
+
+**Compliance Providers:**
+- [Member 9]
+- [Member 10]
+
+### Initial Focus
+
+The Working Group will initially focus on:
+
+1. **Stealth Address Standards** — Unified format for private recipient addresses across chains
+2. **Viewing Key Protocols** — Standards for selective disclosure and regulatory compliance
+3. **Cross-Chain Privacy** — Interoperable privacy for bridge and multi-chain transactions
+4. **Compliance Integration** — Frameworks for sanctions screening and audit trails
+
+### Shielded Intents Protocol (SIP)
+
+The Working Group builds on the Shielded Intents Protocol (SIP), an open privacy standard that enables:
+
+- **Stealth Addresses:** One-time recipient addresses for transaction privacy
+- **Pedersen Commitments:** Cryptographic hiding of transaction amounts
+- **Viewing Keys:** Selective disclosure for compliance and auditing
+- **Cross-Chain Support:** Privacy across 15+ blockchain networks
+
+Unlike mixing services, SIP is designed for regulatory compliance with built-in disclosure mechanisms.
+
+### Join the Working Group
+
+Organizations interested in participating can apply at [WEBSITE].
+
+**Full Member Benefits:**
+- Voting rights on standards
+- Early access to specifications
+- Industry recognition
+- Subgroup participation
+
+**Observer Membership** is open to all interested parties.
+
+### Quotes from Founding Members
+
+**[Member 1 Quote]:**
+> "Quote about importance of standards / why they joined."
+
+**[Member 2 Quote]:**
+> "Quote about compliance / institutional adoption."
+
+**[Member 3 Quote]:**
+> "Quote about user privacy / developer experience."
+
+### About the Privacy Standards Working Group
+
+The Privacy Standards Working Group is an open, neutral industry body developing interoperable privacy standards for blockchain. Governed by its member organizations, the Working Group produces open specifications, reference implementations, and compliance frameworks.
+
+**Website:** [URL]
+**Charter:** [URL]
+**Contact:** press@sip-protocol.org
+
+###
+
+**Media Contact:**
+[Name]
+[Email]
+[Phone]
+
+---
+
+## Social Media Kit
+
+### Twitter/X Announcement Thread
+
+**Tweet 1 (Main Announcement):**
+```
+Announcing the Privacy Standards Working Group
+
+[NUMBER] leading blockchain organizations have united to build interoperable privacy standards.
+
+Founding members include:
+• @[Member1]
+• @[Member2]
+• @[Member3]
+• + [X] more
+
+🧵 Here's what we're building:
+```
+
+**Tweet 2:**
+```
+The problem: Privacy in blockchain is fragmented.
+
+Every chain, every wallet, every DEX builds their own approach.
+
+This creates:
+❌ Integration burden for developers
+❌ Inconsistent UX for users
+❌ Confusion for regulators
+
+We're fixing this with open standards.
+```
+
+**Tweet 3:**
+```
+What we're standardizing:
+
+1️⃣ Stealth Addresses
+   One-time recipient addresses across all chains
+
+2️⃣ Viewing Keys
+   Selective disclosure for compliance
+
+3️⃣ Cross-Chain Privacy
+   Private transactions across bridges
+
+4️⃣ Compliance Frameworks
+   Audit trails that work
+```
+
+**Tweet 4:**
+```
+This is NOT another mixer.
+
+SIP (Shielded Intents Protocol) is privacy WITH compliance:
+
+✅ Private by default
+✅ Disclosed when required
+✅ Full audit capability
+✅ Sanctions screening supported
+
+Privacy that institutions can actually use.
+```
+
+**Tweet 5:**
+```
+The Working Group is open to all.
+
+Full Members: Voting rights, early access, subgroup participation
+
+Observers: Follow along, provide feedback
+
+Join us: [LINK]
+
+Together, we're making privacy the standard.
+```
+
+### LinkedIn Announcement
+
+```
+🔐 Announcing the Privacy Standards Working Group
+
+I'm excited to share that [NUMBER] leading blockchain organizations have come together to launch the Privacy Standards Working Group (PSWG).
+
+This coalition brings together:
+• Privacy protocols (Zcash, Aztec, ...)
+• Wallets (Phantom, MetaMask, ...)
+• DEXs (Jupiter, Uniswap, ...)
+• Foundations (Solana, NEAR, Ethereum)
+• Compliance providers (Chainalysis, ...)
+
+Our mission: Develop interoperable privacy standards that work across the entire blockchain ecosystem.
+
+Why this matters:
+→ Users deserve financial privacy
+→ Institutions need compliance-ready solutions
+→ Developers shouldn't rebuild privacy from scratch
+→ Regulators need standards to reference
+
+The Working Group builds on the Shielded Intents Protocol (SIP), which provides:
+• Stealth addresses for recipient privacy
+• Pedersen commitments for amount hiding
+• Viewing keys for selective disclosure
+• Cross-chain support for 15+ networks
+
+Unlike mixing services, SIP is designed for regulatory compliance from day one.
+
+Want to get involved? The Working Group welcomes new members:
+→ Full Members: Voting rights on standards
+→ Observers: Follow developments, provide feedback
+
+Learn more: [LINK]
+
+#blockchain #privacy #cryptocurrency #standards #defi
+```
+
+### Discord/Telegram Announcement
+
+```
+📢 **MAJOR ANNOUNCEMENT**
+
+The Privacy Standards Working Group is live! 🎉
+
+**What is it?**
+An industry coalition building open privacy standards for blockchain.
+
+**Who's involved?**
+[NUMBER] founding members including:
+• [List top 5-7 members]
+
+**What are we building?**
+• Stealth address standards
+• Viewing key protocols
+• Cross-chain privacy specs
+• Compliance frameworks
+
+**Why should you care?**
+Privacy is becoming the standard. This group ensures it's interoperable, compliant, and accessible.
+
+**Want to join?**
+→ Organizations: Apply for membership at [LINK]
+→ Developers: Contribute at [GITHUB]
+→ Everyone: Follow for updates
+
+This is the beginning of privacy as an industry standard. Let's build it together.
+
+📄 Charter: [LINK]
+🌐 Website: [LINK]
+🐦 Twitter: @[HANDLE]
+```
+
+---
+
+## Member Social Media Coordination
+
+### Suggested Member Post Template
+
+```
+We're proud to be a founding member of the Privacy Standards Working Group.
+
+Together with @[Member1], @[Member2], and [X] other leading organizations, we're building open privacy standards for blockchain.
+
+Why we joined:
+[1-2 sentences specific to your organization]
+
+Learn more: [LINK]
+
+#PrivacyStandards
+```
+
+### Hashtags
+
+Primary: `#PrivacyStandards`
+Secondary: `#BlockchainPrivacy` `#SIP` `#ShieldedIntents`
+
+### Coordinated Posting Schedule
+
+| Time (UTC) | Action |
+|------------|--------|
+| 14:00 | Main @SIPProtocol announcement |
+| 14:05 | Founding member posts begin |
+| 14:30 | Thread completion |
+| 15:00 | Blog post live |
+| 16:00 | Discord/Telegram announcements |
+
+---
+
+## Media Outreach
+
+### Target Publications
+
+**Tier 1 (Exclusive Offer):**
+- The Block
+- CoinDesk
+- Decrypt
+
+**Tier 2 (Press Release):**
+- Cointelegraph
+- The Defiant
+- Bankless
+- DeFi Pulse
+
+**Tier 3 (Community):**
+- Crypto Twitter influencers
+- Newsletter authors
+- Podcast appearances
+
+### Pitch Email Template
+
+```
+Subject: Exclusive: Major blockchain orgs launch privacy standards coalition
+
+Hi [Name],
+
+I wanted to give you an exclusive first look at a major industry announcement:
+
+[NUMBER] leading blockchain organizations are launching the Privacy Standards
+Working Group to develop unified privacy standards.
+
+Founding members include: [Top 3-5 names]
+
+This is significant because:
+1. First cross-chain privacy standards initiative
+2. Major players from across the ecosystem
+3. Focus on compliance-ready privacy (not mixer-style anonymity)
+
+Key angles:
+• Industry unification after fragmented approaches
+• Regulatory positioning (privacy ≠ illicit activity)
+• Technical innovation in cross-chain privacy
+
+I can offer:
+• Embargoed press release
+• Exclusive interview with [Name], [Title]
+• Background briefing with founding members
+
+Embargo lifts: [DATE/TIME]
+
+Interested?
+
+Best,
+[Name]
+```
+
+---
+
+## FAQ for Media
+
+**Q: How is this different from Tornado Cash?**
+A: Tornado Cash was a mixer that permanently broke transaction links. SIP and the Working Group focus on privacy with built-in compliance—transactions can be disclosed to authorized parties via viewing keys. It's privacy with accountability, not anonymity.
+
+**Q: Why do we need standards for privacy?**
+A: Currently, every project builds privacy differently. This creates integration burden, inconsistent user experience, and regulatory confusion. Standards enable interoperability and give regulators a framework to reference.
+
+**Q: Who controls the Working Group?**
+A: The Working Group is governed by its member organizations through a Steering Committee elected by the full membership. No single organization controls it.
+
+**Q: Are the standards open source?**
+A: Yes. All specifications are CC0 (public domain), reference implementations are MIT licensed, and governance is transparent.
+
+**Q: How can my organization join?**
+A: Apply for membership at [WEBSITE]. Full members have voting rights; observer membership is open to all.
+
+---
+
+## Blog Post
+
+### Title: Introducing the Privacy Standards Working Group
+
+*Privacy is becoming the standard. Today, we're making it interoperable.*
+
+---
+
+Today, [NUMBER] leading blockchain organizations announced the formation of the Privacy Standards Working Group (PSWG), an open industry coalition dedicated to developing unified privacy standards for the blockchain ecosystem.
+
+**The Problem: Fragmentation**
+
+Privacy in blockchain is fragmented. Every chain, wallet, and application builds privacy differently:
+
+- Different address formats
+- Incompatible encryption schemes
+- Varying compliance approaches
+- No interoperability
+
+This creates problems for everyone:
+
+- **Developers** waste time rebuilding privacy from scratch
+- **Users** face inconsistent experiences across apps
+- **Institutions** can't adopt solutions that don't meet compliance needs
+- **Regulators** have no standards to reference
+
+**The Solution: Open Standards**
+
+The Privacy Standards Working Group brings together the ecosystem to build standards that work everywhere:
+
+**Founding Members:**
+[List with brief descriptions]
+
+**What We're Standardizing:**
+
+1. **Stealth Addresses (SIP-002)**
+   Universal format for one-time recipient addresses across all chains.
+
+2. **Viewing Keys (SIP-003)**
+   Selective disclosure protocol enabling compliance and auditing.
+
+3. **Cross-Chain Privacy (SIP-300)**
+   Interoperable privacy for bridge and multi-chain transactions.
+
+4. **Compliance Frameworks**
+   Standards for sanctions screening, audit trails, and Travel Rule.
+
+**Built on SIP**
+
+The Working Group builds on the Shielded Intents Protocol (SIP), which provides:
+
+- Stealth addresses for recipient privacy
+- Pedersen commitments for amount hiding
+- Viewing keys for selective disclosure
+- Support for 15+ blockchain networks
+
+Unlike mixers, SIP is designed for compliance. Transactions are private by default but can be disclosed to authorized parties—enabling privacy that institutions can actually use.
+
+**Open Governance**
+
+The Working Group is member-governed:
+
+- All specifications are CC0 (public domain)
+- Reference implementations are MIT licensed
+- Steering Committee elected by members
+- Open to new participants
+
+**Join Us**
+
+We're building the future of privacy. Whether you're a protocol, wallet, DEX, foundation, or compliance provider, there's a place for you.
+
+- **Full Membership:** Voting rights, early access, subgroup participation
+- **Observer Membership:** Open to all interested parties
+
+[APPLY NOW BUTTON]
+
+Privacy shouldn't be a feature. It should be the standard.
+
+---
+
+*The Privacy Standards Working Group is an open, neutral industry body developing interoperable privacy standards for blockchain.*
+
+---
+
+**Document Version:** 1.0.0
+**Last Updated:** January 2026

--- a/docs/governance/WORKING-GROUP-CHARTER.md
+++ b/docs/governance/WORKING-GROUP-CHARTER.md
@@ -1,0 +1,528 @@
+# Privacy Standards Working Group Charter
+
+**Shielded Intents Protocol Industry Working Group**
+
+**Version:** 1.0.0
+**Effective Date:** Q1 2026
+**Status:** Draft (Pending Founding Member Ratification)
+
+---
+
+## 1. Purpose and Mission
+
+### 1.1 Mission Statement
+
+The Privacy Standards Working Group (PSWG) is an open, collaborative body established to develop, promote, and maintain interoperable privacy standards for the blockchain industry. Our mission is to enable **privacy by default, disclosure by choice** across all chains and applications.
+
+### 1.2 Vision
+
+A blockchain ecosystem where:
+- Users have strong financial privacy protections
+- Regulatory compliance is built into privacy solutions
+- Standards enable interoperability across chains and applications
+- Privacy is accessible to all, not just technical experts
+
+### 1.3 Core Principles
+
+| Principle | Description |
+|-----------|-------------|
+| **Open** | Transparent processes, public specifications, permissionless participation |
+| **Neutral** | No single vendor or project controls outcomes |
+| **Practical** | Standards that can be implemented and adopted |
+| **Compliant** | Privacy that works within regulatory frameworks |
+| **Inclusive** | Diverse perspectives from across the ecosystem |
+
+---
+
+## 2. Scope
+
+### 2.1 In Scope
+
+The Working Group focuses on:
+
+1. **Privacy Standards Development**
+   - Stealth address specifications
+   - Commitment schemes and formats
+   - Viewing key standards
+   - Cross-chain privacy protocols
+
+2. **Interoperability**
+   - Cross-implementation compatibility
+   - Bridge integration standards
+   - Wallet integration standards
+   - RPC provider standards
+
+3. **Compliance Frameworks**
+   - Viewing key disclosure protocols
+   - Audit trail specifications
+   - Travel Rule integration
+   - Sanctions screening guidance
+
+4. **Reference Implementations**
+   - Open-source reference code
+   - Test vectors and suites
+   - Compliance testing tools
+
+### 2.2 Out of Scope
+
+The Working Group does NOT:
+
+- Develop proprietary or closed standards
+- Favor any single implementation over others
+- Provide legal advice or regulatory interpretation
+- Certify or audit specific implementations
+- Develop consensus mechanisms or L1 protocols
+
+---
+
+## 3. Membership
+
+### 3.1 Member Categories
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         MEMBERSHIP STRUCTURE                                │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  FOUNDING MEMBERS                                                           │
+│  ┌─────────────────────────────────────────────────────────────────────┐   │
+│  │ Initial signatories who ratify the charter                         │   │
+│  │ • Full voting rights                                                │   │
+│  │ • Steering committee eligibility                                    │   │
+│  │ • Charter amendment rights                                          │   │
+│  └─────────────────────────────────────────────────────────────────────┘   │
+│                                                                             │
+│  FULL MEMBERS                                                               │
+│  ┌─────────────────────────────────────────────────────────────────────┐   │
+│  │ Organizations actively implementing or using privacy standards      │   │
+│  │ • Full voting rights                                                │   │
+│  │ • Subgroup participation                                            │   │
+│  │ • Proposal submission rights                                        │   │
+│  └─────────────────────────────────────────────────────────────────────┘   │
+│                                                                             │
+│  OBSERVER MEMBERS                                                           │
+│  ┌─────────────────────────────────────────────────────────────────────┐   │
+│  │ Interested parties following standards development                  │   │
+│  │ • Meeting attendance (non-voting)                                   │   │
+│  │ • Public comment rights                                             │   │
+│  │ • Mailing list access                                               │   │
+│  └─────────────────────────────────────────────────────────────────────┘   │
+│                                                                             │
+│  INDIVIDUAL CONTRIBUTORS                                                    │
+│  ┌─────────────────────────────────────────────────────────────────────┐   │
+│  │ Independent developers and researchers                              │   │
+│  │ • Technical contribution rights                                     │   │
+│  │ • Public comment rights                                             │   │
+│  │ • Recognition for contributions                                     │   │
+│  └─────────────────────────────────────────────────────────────────────┘   │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 3.2 Membership Criteria
+
+**Founding Members** (Initial Formation):
+- Demonstrated commitment to privacy standards
+- Significant ecosystem presence
+- Signed charter agreement
+- Named representative(s)
+
+**Full Members** (Ongoing Admission):
+- Active implementation or adoption of standards
+- Demonstrated technical contribution
+- Membership application approved by Steering Committee
+- Annual commitment acknowledgment
+
+**Observer Members**:
+- Open registration
+- Agreement to conduct guidelines
+- No formal approval required
+
+### 3.3 Member Responsibilities
+
+| Responsibility | Founding | Full | Observer |
+|----------------|----------|------|----------|
+| Charter ratification | Required | N/A | N/A |
+| Meeting participation | Expected | Expected | Optional |
+| Technical contributions | Expected | Expected | Optional |
+| Voting | Full | Full | None |
+| Annual dues | None | None | None |
+| Public advocacy | Encouraged | Encouraged | Optional |
+
+### 3.4 Membership Termination
+
+Membership may be terminated for:
+- Violation of conduct guidelines
+- Extended inactivity (12+ months)
+- Voluntary withdrawal
+- Organization dissolution
+
+Termination requires:
+- Steering Committee majority vote
+- 30-day notice period
+- Opportunity to respond
+
+---
+
+## 4. Governance Structure
+
+### 4.1 Organizational Chart
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         GOVERNANCE STRUCTURE                                │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│                         ┌─────────────────┐                                 │
+│                         │   FULL MEMBER   │                                 │
+│                         │    ASSEMBLY     │                                 │
+│                         │  (All Members)  │                                 │
+│                         └────────┬────────┘                                 │
+│                                  │ Elects                                   │
+│                                  ▼                                          │
+│                         ┌─────────────────┐                                 │
+│                         │    STEERING     │                                 │
+│                         │   COMMITTEE     │                                 │
+│                         │  (7 Members)    │                                 │
+│                         └────────┬────────┘                                 │
+│                                  │ Appoints                                 │
+│           ┌──────────────────────┼──────────────────────┐                  │
+│           │                      │                      │                   │
+│           ▼                      ▼                      ▼                   │
+│  ┌─────────────────┐   ┌─────────────────┐   ┌─────────────────┐          │
+│  │   TECHNICAL     │   │   COMPLIANCE    │   │   ECOSYSTEM     │          │
+│  │   SUBGROUP      │   │   SUBGROUP      │   │   SUBGROUP      │          │
+│  │                 │   │                 │   │                 │          │
+│  │ • Specs         │   │ • Regulatory    │   │ • Adoption      │          │
+│  │ • Reference     │   │ • Audit         │   │ • Outreach      │          │
+│  │ • Testing       │   │ • Compliance    │   │ • Education     │          │
+│  └─────────────────┘   └─────────────────┘   └─────────────────┘          │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 4.2 Steering Committee
+
+**Composition:**
+- 7 members elected by Full Member Assembly
+- 2-year terms, staggered (3-4 seats per year)
+- Maximum 2 consecutive terms
+- No organization may hold more than 1 seat
+
+**Responsibilities:**
+- Strategic direction
+- Subgroup oversight
+- Membership decisions
+- Budget management (if applicable)
+- External representation
+
+**Officers:**
+- Chair: Leads meetings, external spokesperson
+- Vice-Chair: Supports Chair, succession
+- Secretary: Meeting minutes, records
+
+### 4.3 Subgroups
+
+**Technical Subgroup:**
+- Standards specification drafting
+- Reference implementation oversight
+- Test vector development
+- Technical review process
+
+**Compliance Subgroup:**
+- Regulatory engagement
+- Compliance framework development
+- Audit standard alignment
+- Legal liaison
+
+**Ecosystem Subgroup:**
+- Adoption tracking
+- Developer education
+- Public communications
+- Event coordination
+
+### 4.4 Decision Making
+
+**Consensus Preferred:**
+All decisions should first seek consensus among affected parties.
+
+**Voting (When Consensus Fails):**
+
+| Decision Type | Threshold | Quorum |
+|---------------|-----------|--------|
+| Technical standards | 2/3 majority | 50% of members |
+| Steering Committee | Simple majority | 5 of 7 |
+| Charter amendments | 3/4 majority | 66% of members |
+| New members | Steering Committee | 5 of 7 |
+| Subgroup creation | Steering Committee | 5 of 7 |
+
+---
+
+## 5. Standards Process
+
+### 5.1 Lifecycle
+
+```
+STANDARD LIFECYCLE
+
+┌─────────┐     ┌─────────┐     ┌─────────┐     ┌─────────┐     ┌─────────┐
+│ DRAFT   │────▶│ REVIEW  │────▶│ FINAL   │────▶│ ACTIVE  │────▶│ RETIRED │
+│         │     │ CALL    │     │ CALL    │     │         │     │         │
+└─────────┘     └─────────┘     └─────────┘     └─────────┘     └─────────┘
+     │               │               │               │               │
+     ▼               ▼               ▼               ▼               ▼
+ Initial          Public         Final vote      Official       Superseded
+ proposal         comment        and approval    standard       or obsolete
+```
+
+### 5.2 Stage Requirements
+
+**Draft:**
+- Any member may submit
+- Must include: problem statement, proposed solution, rationale
+- Technical Subgroup assigns editor
+- Iterative refinement
+
+**Review Call (30 days minimum):**
+- Public comment period
+- All feedback documented
+- Substantive changes restart timer
+- Technical Subgroup recommendation
+
+**Final Call (14 days):**
+- No substantive changes
+- Member vote
+- 2/3 majority required
+- Editorial corrections only
+
+**Active:**
+- Published as official standard
+- Reference implementation required
+- Test vectors available
+- Version controlled
+
+**Retired:**
+- Superseded by newer standard
+- Security issues discovered
+- No longer relevant
+- Archived for reference
+
+### 5.3 Standard Numbering
+
+```
+SIP-XXX: Core Protocol Standards
+  SIP-001: Core Protocol
+  SIP-002: Stealth Addresses
+  SIP-003: Viewing Keys
+  ...
+
+SIP-1XX: Integration Standards
+  SIP-100: Wallet Integration
+  SIP-101: DEX Integration
+  SIP-102: Bridge Integration
+  ...
+
+SIP-2XX: Compliance Standards
+  SIP-200: Audit Trail Format
+  SIP-201: Viewing Key Sharing
+  SIP-202: Travel Rule Payload
+  ...
+
+SIP-3XX: Cross-Chain Standards
+  SIP-300: Universal Meta-Address
+  SIP-301: Bridge Privacy Protocol
+  ...
+```
+
+---
+
+## 6. Intellectual Property
+
+### 6.1 Contribution License
+
+All contributions to Working Group standards are made under:
+
+- **Specifications:** CC0 (Public Domain Dedication)
+- **Reference Code:** MIT License
+- **Documentation:** CC-BY-4.0
+
+### 6.2 Patent Policy
+
+Members agree to:
+
+1. **RAND-Z Commitment:** License any essential patents royalty-free
+2. **Disclosure Obligation:** Disclose known essential patents
+3. **Defensive Use Only:** No offensive patent claims against implementers
+
+### 6.3 Trademark
+
+- "SIP" and "Shielded Intents Protocol" are open for use
+- Working Group may establish certification marks
+- Members may not imply endorsement without authorization
+
+---
+
+## 7. Meetings and Communication
+
+### 7.1 Meeting Cadence
+
+| Meeting Type | Frequency | Participants |
+|--------------|-----------|--------------|
+| Full Assembly | Quarterly | All members |
+| Steering Committee | Monthly | SC members |
+| Technical Subgroup | Bi-weekly | Subgroup members |
+| Compliance Subgroup | Monthly | Subgroup members |
+| Ecosystem Subgroup | Monthly | Subgroup members |
+
+### 7.2 Meeting Format
+
+- **Remote-first:** Video conferencing primary
+- **Recorded:** All meetings recorded for asynchronous access
+- **Minutes:** Published within 7 days
+- **Agenda:** Published 7 days in advance
+
+### 7.3 Communication Channels
+
+| Channel | Purpose |
+|---------|---------|
+| Mailing List | Official announcements, voting |
+| Discord/Slack | Day-to-day discussion |
+| GitHub | Specification development |
+| Public Forum | Community feedback |
+
+---
+
+## 8. Code of Conduct
+
+### 8.1 Expected Behavior
+
+Members shall:
+- Treat all participants with respect
+- Focus on technical merit, not personal attributes
+- Assume good faith in discussions
+- Maintain confidentiality when required
+- Disclose conflicts of interest
+
+### 8.2 Unacceptable Behavior
+
+- Personal attacks or harassment
+- Discrimination of any kind
+- Sharing confidential information
+- Sabotaging standards process
+- Misrepresenting Working Group positions
+
+### 8.3 Enforcement
+
+1. **Warning:** First violation, documented warning
+2. **Suspension:** Repeated violations, temporary ban
+3. **Expulsion:** Severe violations, permanent removal
+
+Steering Committee handles enforcement with right of appeal.
+
+---
+
+## 9. Amendment Process
+
+### 9.1 Proposing Amendments
+
+Any Full Member may propose charter amendments:
+
+1. Submit written proposal to Steering Committee
+2. 30-day comment period
+3. Steering Committee recommendation
+4. Full Assembly vote
+5. 3/4 majority required for adoption
+
+### 9.2 Emergency Amendments
+
+For urgent matters (security, legal):
+- Steering Committee may adopt temporary amendments
+- Full Assembly ratification within 60 days
+- Simple majority for temporary measures
+
+---
+
+## 10. Dissolution
+
+### 10.1 Conditions
+
+The Working Group may dissolve if:
+- Mission is complete (standards widely adopted)
+- Activity ceases (no meetings for 12 months)
+- Member vote (3/4 majority)
+
+### 10.2 Asset Disposition
+
+Upon dissolution:
+- All specifications remain public domain
+- Reference implementations remain MIT licensed
+- Documentation archived permanently
+- Any funds donated to open-source foundation
+
+---
+
+## Appendix A: Founding Member Commitment
+
+```
+FOUNDING MEMBER SIGNATURE BLOCK
+
+Organization: _________________________________
+
+Representative Name: _________________________________
+
+Title: _________________________________
+
+Email: _________________________________
+
+Date: _________________________________
+
+Signature: _________________________________
+
+
+By signing, the organization commits to:
+1. Ratifying this charter
+2. Active participation in Working Group activities
+3. Implementation or adoption of published standards
+4. Compliance with code of conduct
+5. Patent policy commitments
+```
+
+---
+
+## Appendix B: Initial Subgroup Mandates
+
+### Technical Subgroup Mandate
+
+**Scope:** Development and maintenance of privacy standards specifications
+
+**Initial Work Items:**
+- SIP-001 through SIP-003 review and finalization
+- EIP-5564/ERC-6538 compatibility verification
+- Cross-chain privacy protocol specification
+- Test vector development
+
+### Compliance Subgroup Mandate
+
+**Scope:** Regulatory alignment and compliance framework development
+
+**Initial Work Items:**
+- Regulatory landscape documentation
+- Viewing key disclosure protocol
+- Travel Rule integration standard
+- Audit trail format specification
+
+### Ecosystem Subgroup Mandate
+
+**Scope:** Adoption, education, and community building
+
+**Initial Work Items:**
+- Member onboarding program
+- Developer documentation
+- Public website and communications
+- Conference and event coordination
+
+---
+
+**Charter Version:** 1.0.0
+**Last Updated:** January 2026
+**Next Review:** July 2026


### PR DESCRIPTION
## Summary
- Add comprehensive materials for Privacy Standards Working Group formation
- Charter, outreach strategy, meeting agenda, and public announcement templates
- Final issue in M21 (Standard Proposal) milestone

## Files
- `docs/governance/WORKING-GROUP-CHARTER.md` - Full governance charter (+550 lines)
- `docs/governance/MEMBER-OUTREACH-STRATEGY.md` - Target members and outreach plan (+350 lines)
- `docs/governance/FIRST-MEETING-AGENDA.md` - 90-minute founding meeting (+300 lines)
- `docs/governance/PUBLIC-ANNOUNCEMENT.md` - Press release, social media, blog (+400 lines)

## Key Deliverables
- Governance structure (Steering Committee, subgroups)
- Tier 1/2/3 target member list
- 12-week outreach sequence
- Founding meeting procedures
- Press and social media kit

## Test plan
- [x] Charter sections are complete and consistent
- [x] Outreach templates are actionable
- [x] Meeting agenda fits 90-minute format
- [x] Announcement materials are ready to customize

Closes #467