### PR TITLE
docs: update Zypherpunk hackathon winnings to $6,500 (3 tracks)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,7 +267,7 @@ See [ROADMAP.md](ROADMAP.md) for detailed milestone tracking and priorities.
 
 **Status:** M16 Complete | 5,584+ tests (SDK: 5,076, React: 291, CLI: 45, API: 162, RN: 10) | Live at sip-protocol.org
 
-**🏆 Achievement:** Winner — [Zypherpunk Hackathon](https://zypherpunk.xyz) ($4,500: NEAR $4,000 + Tachyon $500) | Dec 2025 | #14 of 88 | [Devfolio](https://devfolio.co/projects/sip-protocol-2026)
+**🏆 Achievement:** Winner — [Zypherpunk Hackathon](https://zypherpunk.xyz) ($6,500: NEAR $4,000 + Tachyon $500 + pumpfun $2,000) | Dec 2025 | #14 of 88 | 3 Tracks | [Devfolio](https://devfolio.co/projects/sip-protocol-2026)
 
 **Endgame:** Privacy middleware between applications and blockchains. Chain-agnostic. Settlement-agnostic. The universal privacy layer.
 
@@ -670,5 +670,5 @@ ssh core  # Admin user for nginx/system config
 
 ---
 
-**Last Updated:** 2026-01-19
-**Status:** M16 Complete | Phase 4 Active (M17-M18) | 5,584+ Tests | 7 Packages | 🏆 Zypherpunk Winner ($4,500, #14/88)
+**Last Updated:** 2026-01-21
+**Status:** M16 Complete | Phase 4 Active (M17-M18) | 5,584+ Tests | 7 Packages | 🏆 Zypherpunk Winner ($6,500, #14/88, 3 tracks)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 [![pnpm](https://img.shields.io/badge/pnpm-Monorepo-F69220?logo=pnpm&logoColor=white)](https://pnpm.io/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
-**🏆 Winner — [Zypherpunk Hackathon](https://zypherpunk.xyz) ($4,500: NEAR $4,000 + Tachyon $500) | #14 of 88**
+**🏆 Winner — [Zypherpunk Hackathon](https://zypherpunk.xyz) ($6,500: NEAR $4,000 + Tachyon $500 + pumpfun $2,000) | #14 of 88 | 3 Tracks**
 
 </div>
 
@@ -598,7 +598,7 @@ SIP builds on the shoulders of giants:
 
 <div align="center">
 
-**🏆 Winner — [Zypherpunk Hackathon](https://zypherpunk.xyz) ($4,500) | #14 of 88**
+**🏆 Winner — [Zypherpunk Hackathon](https://zypherpunk.xyz) ($6,500) | #14 of 88 | 3 Tracks**
 
 *Privacy is not a feature. It's a right.*
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1379,7 +1379,7 @@ SIP is **chain-agnostic** — we enhance every chain, compete with none.
 
 ### Achievements
 
-- 🏆 **Zypherpunk Hackathon NEAR Track Winner** ($4,000) — Dec 2025
+- 🏆 **Zypherpunk Hackathon Winner — 3 Tracks** ($6,500: NEAR $4,000 + Tachyon $500 + pumpfun $2,000) — Dec 2025
 - 📦 **npm packages published** — @sip-protocol/sdk v0.6.0
 - 🌐 **Live sites** — sip-protocol.org, docs.sip-protocol.org
 - ✅ **Phase 1-3 complete** — M1-M15 done (2,757 tests)

--- a/docs/bounties/aztec-noir-submission.md
+++ b/docs/bounties/aztec-noir-submission.md
@@ -298,7 +298,7 @@ Demo 2: Solana Verification
 
 SIP Protocol is built by privacy enthusiasts committed to making Web3 private and compliant.
 
-**Previous Achievement**: Winner of Zypherpunk Hackathon 2025 ($4,500)
+**Previous Achievement**: Winner of Zypherpunk Hackathon 2025 ($6,500, 3 tracks)
 
 ---
 

--- a/docs/content/articles/09-sip-eip-standard-announcement.md
+++ b/docs/content/articles/09-sip-eip-standard-announcement.md
@@ -15,7 +15,7 @@ Today we're announcing **SIP-EIP**, a proposed Ethereum Improvement Proposal tha
 - ⚖️ **Compliance-ready**: Selective disclosure for auditors and regulators
 - 🔗 **Chain-agnostic**: Works on Ethereum, Solana, NEAR, and 15+ chains
 - 📦 **Production-ready**: 5,584+ tests, TypeScript SDK, React hooks
-- 🏆 **Battle-tested**: Zypherpunk Hackathon winner ($4,500)
+- 🏆 **Battle-tested**: Zypherpunk Hackathon winner ($6,500, 3 tracks)
 
 [Read the full SIP-EIP specification →](#)
 
@@ -617,8 +617,8 @@ Not vaporware. Working code.
 **11/15**
 Battle tested:
 
-🏆 Zypherpunk Hackathon Winner
-💰 $4,500 prize
+🏆 Zypherpunk Hackathon Winner (3 tracks)
+💰 $6,500 prize
 📊 #14 of 88 projects
 
 Judges included @zoaborake @aaborakeMoney @balaboraaji and more.

--- a/docs/partnerships/DEX-PARTNERSHIP-STRATEGY.md
+++ b/docs/partnerships/DEX-PARTNERSHIP-STRATEGY.md
@@ -507,7 +507,7 @@ stealth addresses + viewing keys for compliance.
 
 Quick context:
 • 5,584+ tests, production-ready SDK
-• Won Zypherpunk Hackathon ($4,500)
+• Won Zypherpunk Hackathon ($6,500, 3 tracks)
 • SIP-EIP standardization in progress
 
 I'd love to explore a partnership with [DEX]. The integration

--- a/docs/presentations/ETH-DENVER-2026.md
+++ b/docs/presentations/ETH-DENVER-2026.md
@@ -44,7 +44,7 @@ In this talk, I'll demonstrate how SIP enables:
 
 I'll show a live demo of integrating SIP into a DEX in under 10 minutes, transforming a public swap into a private one. We'll walk through the cryptography (don't worry, it's visual!), the SDK architecture, and the path to becoming an Ethereum standard (SIP-EIP).
 
-SIP won the Zypherpunk Hackathon ($4,500, #14 of 88 projects) by solving the "privacy vs compliance" dilemma. With 5,500+ tests and production-ready SDKs, it's ready for prime time.
+SIP won the Zypherpunk Hackathon ($6,500, #14 of 88 projects, 3 tracks) by solving the "privacy vs compliance" dilemma. With 5,500+ tests and production-ready SDKs, it's ready for prime time.
 
 Whether you're building a wallet, DEX, DAO, or enterprise application, you'll leave with practical knowledge to add privacy to your stack. The future of Web3 is private by default — let's build it together.
 
@@ -52,7 +52,7 @@ Whether you're building a wallet, DEX, DAO, or enterprise application, you'll le
 
 [Your Name] is a senior engineer and the creator of SIP (Shielded Intents Protocol), the privacy standard for Web3. With a background in cryptography and distributed systems, they've spent the past two years building privacy infrastructure that bridges the gap between anonymity and compliance.
 
-SIP won the Zypherpunk Hackathon (Dec 2025, $4,500, ranked #14 of 88), earning recognition from judges including Zooko Wilcox-O'Hearn (Zcash founder), Anatoly Yakovenko (Solana co-founder), and Balaji Srinivasan.
+SIP won the Zypherpunk Hackathon (Dec 2025, $6,500, ranked #14 of 88, 3 tracks), earning recognition from judges including Zooko Wilcox-O'Hearn (Zcash founder), Anatoly Yakovenko (Solana co-founder), and Balaji Srinivasan.
 
 Previously, [they] contributed to [previous work/projects]. [They] believe privacy is a fundamental right and that the next billion users won't onboard to Web3 until transactions are as private as WhatsApp messages.
 
@@ -375,7 +375,7 @@ console.log(txData)
 ### Slide 23: Traction
 **Momentum**
 
-- 🏆 **Zypherpunk Hackathon Winner** ($4,500, #14/88)
+- 🏆 **Zypherpunk Hackathon Winner** ($6,500, #14/88, 3 tracks)
 - 📦 **5,584+ tests** across 5 packages
 - 🌐 **Multi-chain** (Ethereum, Solana, NEAR, 15+ chains)
 - 📄 **SIP-EIP Draft** in preparation
@@ -556,7 +556,7 @@ A: SIP with viewing keys is more compliant than cash. You can't audit $100 bills
 │                                                            │
 │   ─────────────────────────────────────────────────────    │
 │                                                            │
-│   🏆 Zypherpunk Hackathon Winner ($4,500)                  │
+│   🏆 Zypherpunk Hackathon Winner ($6,500, 3 tracks)        │
 │   📊 5,584+ Tests | 15+ Chains | Production Ready          │
 │                                                            │
 │   [QR CODE]                                                │

--- a/docs/specs/WORKING-GROUP-CHARTER.md
+++ b/docs/specs/WORKING-GROUP-CHARTER.md
@@ -328,7 +328,7 @@ and viewing keys for compliant privacy across any chain.
 - Optional: contribute to implementation
 
 **Recent Achievements:**
-- Zypherpunk Hackathon Winner ($4,500, #14 of 88)
+- Zypherpunk Hackathon Winner ($6,500, #14 of 88, 3 tracks)
 - 5,500+ tests, production SDK
 - Multi-chain support (Ethereum, Solana, NEAR, Cosmos)
 


### PR DESCRIPTION
## Summary
- Update Zypherpunk Hackathon prize from $4,500 to **$6,500**
- Add pumpfun track ($2,000) to existing NEAR ($4,000) + Tachyon ($500)
- Total: 3 tracks won, #14 of 88

## Files Changed
- CLAUDE.md (2 locations)
- README.md (2 locations)
- ROADMAP.md
- docs/bounties/aztec-noir-submission.md
- docs/content/articles/09-sip-eip-standard-announcement.md
- docs/partnerships/DEX-PARTNERSHIP-STRATEGY.md
- docs/presentations/ETH-DENVER-2026.md
- docs/specs/WORKING-GROUP-CHARTER.md

## Test plan
- [x] Documentation only, no code changes