### PR TITLE
Phase 4a: devnet CPI upgrade + E2E test + emergency pause lever

### DIFF
--- a/programs/sipher-vault/DEPLOYMENT.md
+++ b/programs/sipher-vault/DEPLOYMENT.md
@@ -56,6 +56,19 @@ instruction (commit `0f701e5`) on top of the CPI binary.
   new instruction handler + accounts struct)
 - Authority signed: `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr`
 
+### Devnet — Phase 4a `VaultPausedEvent` Upgrade (2026-05-06)
+
+Third devnet upgrade in Phase 4a — adds the `VaultPausedEvent` emit to
+`set_paused` so off-chain monitoring tooling can subscribe to state
+changes. Same authority, same RPC, same config PDA.
+
+- Upgrade TX: `4xZyApH8pjb4rUerXmKL6oodC6JKHDTes2y1k5jKHPGnjTR59ADRCMXccAKsBftdgB7bijT84KpDF8vsDxTagi1T`
+- Previous deployed slot: `460374492` (set_paused upgrade)
+- New deployed slot: `460376111`
+- Binary size: `383144` bytes (Δ from `382112` reflects the
+  event struct + emit call)
+- Authority signed: `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr`
+
 ## Mainnet Deployments
 
 _Not deployed. See Phase 4b plan for mainnet rollout sequencing._

--- a/programs/sipher-vault/DEPLOYMENT.md
+++ b/programs/sipher-vault/DEPLOYMENT.md
@@ -1,0 +1,70 @@
+# Sipher Vault Deployment Guide
+
+Deployment records and procedures for the `sipher_vault` Anchor program — a privacy-preserving deposit/withdraw vault that performs a CPI into `sip_privacy::create_transfer_announcement` to materialize stealth transfer announcements on-chain.
+
+## Program Coordinates
+
+| Field | Value |
+|-------|-------|
+| Program ID | `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB` |
+| Program Keypair | `~/Documents/secret/sipher-vault-program-id.json` |
+| Authority Keypair | `~/Documents/secret/solana-devnet.json` |
+| Authority Address (devnet) | `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr` |
+| Loader | `BPFLoaderUpgradeab1e11111111111111111111111` |
+
+## Toolchain
+
+| Tool | Version |
+|------|---------|
+| Anchor CLI | `0.30.1` |
+| Solana CLI | `3.0.13` (Agave) |
+| platform-tools | `v1.51` (rustc `1.84.1`, target SBF) |
+| Host rustc | `1.94.1` (build only — IDL gen requires `--no-idl`) |
+
+> **Build note:** anchor 0.30.1's IDL generator depends on `proc_macro2::Span::source_file()`,
+> a nightly-only proc-macro API removed from current host rustc. Use `anchor build --no-idl`;
+> the on-chain SBF binary is unaffected. The IDL artifact at `target/idl/sipher_vault.json`
+> is regenerated from earlier compatible host toolchains.
+
+## Devnet Deployments
+
+### Devnet — Initial Deploy (2026-03-31)
+
+- First devnet deployment of pre-CPI binary (commit `ca3a5a7`)
+- Config PDA: `CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u`
+- Config: 10 bps fee, 86400s refund timeout
+- Authority: `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr` (devnet wallet)
+- Binary size: 353 KB (pre-CPI)
+
+### Devnet — Phase 4a CPI Upgrade (2026-05-06)
+
+- Upgraded from pre-CPI binary (Mar 31, 2026) to CPI version (commit `3c81ad0`)
+- Upgrade TX: `395LeypDVog8J6QuGxMKekFwG4WdhMgqq4MRB91EfG2LPAg4tcttTAVyWN6saqMjsjn7hZgpTMzpWy4nUhH3YDbp`
+- New deployed slot: `460367898`
+- Binary size: `376664` bytes
+- Authority signed: `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr` (devnet wallet)
+
+## Mainnet Deployments
+
+_Not deployed. See Phase 4b plan for mainnet rollout sequencing._
+
+## Procedures
+
+### Devnet Upgrade
+
+Use the atomic upgrade script:
+
+```bash
+cd programs/sipher-vault
+ANCHOR_WALLET=~/Documents/secret/solana-devnet.json \
+ANCHOR_PROVIDER_URL=https://api.devnet.solana.com \
+pnpm exec tsx scripts/upgrade-devnet.ts
+```
+
+The script verifies the program keypair, runs `anchor clean && anchor build --no-idl`,
+deploys via `BPFLoaderUpgradeable`, and prints the new deployed slot. Idempotent —
+running again redeploys.
+
+### Mainnet Upgrade
+
+_TODO: add `upgrade-mainnet.ts` in PR-B1._

--- a/programs/sipher-vault/DEPLOYMENT.md
+++ b/programs/sipher-vault/DEPLOYMENT.md
@@ -44,6 +44,18 @@ Deployment records and procedures for the `sipher_vault` Anchor program — a pr
 - Binary size: `376664` bytes
 - Authority signed: `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr` (devnet wallet)
 
+### Devnet — Phase 4a `set_paused` Upgrade (2026-05-06)
+
+Second devnet upgrade in Phase 4a — adds the authority-gated `set_paused`
+instruction (commit `0f701e5`) on top of the CPI binary.
+
+- Upgrade TX: `utoZnnbbaNz6X6VxybwpF6odKxDB8H28Kh3bwP3M3abJEHHdEBXv7tPcCaeJqAMT9vUJQazcUbLidPyNb2egkNy`
+- Previous deployed slot: `460367898` (CPI upgrade)
+- New deployed slot: `460374492`
+- Binary size: `382112` bytes (Δ from prior `376_664` reflects the
+  new instruction handler + accounts struct)
+- Authority signed: `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr`
+
 ## Mainnet Deployments
 
 _Not deployed. See Phase 4b plan for mainnet rollout sequencing._

--- a/programs/sipher-vault/DEPLOYMENT.md
+++ b/programs/sipher-vault/DEPLOYMENT.md
@@ -69,6 +69,18 @@ changes. Same authority, same RPC, same config PDA.
   event struct + emit call)
 - Authority signed: `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr`
 
+### Pause Runbook Rehearsed (Phase 4a, 2026-05-06)
+
+Authority-signed pause/unpause cycle exercised on devnet to verify the
+emergency lever works before mainnet (PR-B1 Risk B2/B3).
+
+- Pause TX: `2SPbNjyQ6Nib3csVmW9j7DnoS3RKgEifgKxYBvE7bT5U9kPsUm1vynSFqPsiTCV28oeq8W6GtPXzPhm26FdWa4KP`
+- Deposit attempt during paused state: failed as expected (`AnchorError thrown in programs/sipher-vault/src/lib.rs:92. Error Code: ProgramPaused. Error Number: 6000. Error Message: Program is paused.` — custom program error `0x1770`)
+- Unpause TX: `eSSaz7kCcCkYNGs1yoZ7uTGjWEDa7uVVEt4kfPcq6vughaiRKxqweTJxyEd5SBsYrfeTbtkMNpuKYpM9xJq2EfK`
+- Approximate downtime during rehearsal: `18 seconds` (block time delta between pause TX slot `460376982` and unpause TX slot `460377030`)
+- Verified script: `programs/sipher-vault/scripts/set-paused.ts`
+- Authority signed: `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr`
+
 ## Mainnet Deployments
 
 _Not deployed. See Phase 4b plan for mainnet rollout sequencing._

--- a/programs/sipher-vault/DEPLOYMENT.md
+++ b/programs/sipher-vault/DEPLOYMENT.md
@@ -98,9 +98,9 @@ ANCHOR_PROVIDER_URL=https://api.devnet.solana.com \
 pnpm exec tsx scripts/upgrade-devnet.ts
 ```
 
-The script verifies the program keypair, runs `anchor clean && anchor build --no-idl`,
-deploys via `BPFLoaderUpgradeable`, and prints the new deployed slot. Idempotent —
-running again redeploys.
+The script verifies the program keypair, runs `anchor build --no-idl` (incremental —
+preserves the IDL artifact), deploys via `BPFLoaderUpgradeable`, and prints the new
+deployed slot. Idempotent — running again redeploys.
 
 ### Mainnet Upgrade
 

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -379,6 +379,20 @@ pub mod sipher_vault {
     msg!("Collected {} fees", withdraw_amount);
     Ok(())
   }
+
+  /// Pause or unpause the vault. Authority-only.
+  ///
+  /// While paused (`config.paused == true`), `deposit`, `withdraw_private`, and
+  /// `authority_refund` revert with `VaultError::ProgramPaused`. The `refund` and
+  /// `collect_fee` paths intentionally remain available so depositors can recover
+  /// funds and the authority can still drain accumulated fees during an emergency.
+  ///
+  /// Idempotent — calling with the current state is a no-op success.
+  pub fn set_paused(ctx: Context<SetPaused>, paused: bool) -> Result<()> {
+    ctx.accounts.config.paused = paused;
+    msg!("Vault paused = {}", paused);
+    Ok(())
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -687,6 +701,19 @@ pub struct CollectFee<'info> {
   pub authority: Signer<'info>,
 
   pub token_program: Program<'info, Token>,
+}
+
+#[derive(Accounts)]
+pub struct SetPaused<'info> {
+  #[account(
+    mut,
+    seeds = [VAULT_CONFIG_SEED],
+    bump = config.bump,
+    has_one = authority @ VaultError::Unauthorized,
+  )]
+  pub config: Account<'info, VaultConfig>,
+
+  pub authority: Signer<'info>,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -388,9 +388,18 @@ pub mod sipher_vault {
   /// funds and the authority can still drain accumulated fees during an emergency.
   ///
   /// Idempotent — calling with the current state is a no-op success.
+  ///
+  /// Emits `VaultPausedEvent` so off-chain monitoring (SENTINEL, audit
+  /// log indexers, dashboards) can subscribe to state changes without
+  /// log-parsing.
   pub fn set_paused(ctx: Context<SetPaused>, paused: bool) -> Result<()> {
     ctx.accounts.config.paused = paused;
     msg!("Vault paused = {}", paused);
+    emit!(VaultPausedEvent {
+      authority: ctx.accounts.authority.key(),
+      paused,
+      timestamp: Clock::get()?.unix_timestamp,
+    });
     Ok(())
   }
 }
@@ -729,5 +738,12 @@ pub struct VaultWithdrawEvent {
   pub viewing_key_hash: [u8; 32],
   pub transfer_amount: u64,
   pub fee_amount: u64,
+  pub timestamp: i64,
+}
+
+#[event]
+pub struct VaultPausedEvent {
+  pub authority: Pubkey,
+  pub paused: bool,
   pub timestamp: i64,
 }

--- a/programs/sipher-vault/scripts/e2e-cpi-test.ts
+++ b/programs/sipher-vault/scripts/e2e-cpi-test.ts
@@ -1,0 +1,231 @@
+// programs/sipher-vault/scripts/e2e-cpi-test.ts
+//
+// End-to-end CPI validation on devnet:
+//   1. Wrap 0.001 SOL → wSOL into authority's ATA
+//   2. Deposit into sipher_vault
+//   3. Call withdraw_private with deterministic test stealth params
+//   4. Confirm sip_privacy.TransferRecord PDA exists with the expected commitment
+//
+// This is structural validation — the test does NOT scan/claim. The goal is
+// to prove the CPI from withdraw_private to sip_privacy.create_transfer_announcement
+// fires correctly on the network where it will run on mainnet.
+//
+// Usage: cd programs/sipher-vault && pnpm exec tsx scripts/e2e-cpi-test.ts
+//
+// Requires:
+//   - ~/Documents/secret/solana-devnet.json  (depositor + authority on devnet)
+//   - Devnet vault config already initialized
+//   - Devnet vault_token + fee_token PDAs already created for wSOL
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+  sendAndConfirmTransaction,
+} from '@solana/web3.js'
+import {
+  createAssociatedTokenAccountIdempotentInstruction,
+  getAssociatedTokenAddressSync,
+  createSyncNativeInstruction,
+  TOKEN_PROGRAM_ID,
+} from '@solana/spl-token'
+import { readFileSync } from 'fs'
+import { homedir } from 'os'
+import { createHash, randomBytes } from 'crypto'
+
+const VAULT_PROGRAM_ID = new PublicKey('S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB')
+const SIP_PRIVACY_PROGRAM_ID = new PublicKey('S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at')
+const WSOL_MINT = new PublicKey('So11111111111111111111111111111111111111112')
+
+const VAULT_CONFIG_SEED = Buffer.from('vault_config')
+const DEPOSIT_RECORD_SEED = Buffer.from('deposit_record')
+const VAULT_TOKEN_SEED = Buffer.from('vault_token')
+const FEE_TOKEN_SEED = Buffer.from('fee_token')
+const SIP_CONFIG_SEED = Buffer.from('config')
+const SIP_TRANSFER_RECORD_SEED = Buffer.from('transfer_record')
+
+const RPC = 'https://api.devnet.solana.com'
+const DEPOSIT_LAMPORTS = 1_000_000n // 0.001 SOL
+const WITHDRAW_LAMPORTS = 500_000n  // 0.0005 SOL — half of deposit, leaves remainder for the refund-script if rerun
+
+function disc(name: string): Buffer {
+  return createHash('sha256').update(`global:${name}`).digest().subarray(0, 8)
+}
+
+async function main() {
+  const conn = new Connection(RPC, 'confirmed')
+  const wallet = Keypair.fromSecretKey(
+    Uint8Array.from(JSON.parse(readFileSync(`${homedir()}/Documents/secret/solana-devnet.json`, 'utf-8')))
+  )
+  console.log('Depositor:', wallet.publicKey.toString())
+
+  const wsolAta = getAssociatedTokenAddressSync(WSOL_MINT, wallet.publicKey)
+
+  const [vaultConfigPda] = PublicKey.findProgramAddressSync([VAULT_CONFIG_SEED], VAULT_PROGRAM_ID)
+  const [vaultTokenPda] = PublicKey.findProgramAddressSync(
+    [VAULT_TOKEN_SEED, WSOL_MINT.toBuffer()],
+    VAULT_PROGRAM_ID
+  )
+  const [feeTokenPda] = PublicKey.findProgramAddressSync(
+    [FEE_TOKEN_SEED, WSOL_MINT.toBuffer()],
+    VAULT_PROGRAM_ID
+  )
+  const [depositRecordPda] = PublicKey.findProgramAddressSync(
+    [DEPOSIT_RECORD_SEED, wallet.publicKey.toBuffer(), WSOL_MINT.toBuffer()],
+    VAULT_PROGRAM_ID
+  )
+  const [sipConfigPda] = PublicKey.findProgramAddressSync(
+    [SIP_CONFIG_SEED],
+    SIP_PRIVACY_PROGRAM_ID
+  )
+
+  // Deterministic stealth test params
+  const stealthRecipient = Keypair.generate().publicKey // ed25519 dummy stealth
+  const ephemeralPubkey = Buffer.concat([Buffer.from([0x02]), randomBytes(32)]) // 33-byte secp256k1 fake
+  const amountCommitment = Buffer.concat([Buffer.from([0x02]), randomBytes(32)])  // 33-byte commitment
+  const viewingKeyHash = randomBytes(32)
+  const encryptedAmount = Buffer.from([]) // empty for test
+
+  // TransferRecord PDA seeds match sip_privacy::CreateTransferAnnouncement:
+  //   [TRANSFER_RECORD_SEED, sender.key(), config.total_transfers.to_le_bytes()]
+  // We must read total_transfers from sip_privacy::Config now (CPI passes
+  // depositor as sender, so seeds[1] = depositor pubkey).
+  const sipConfigInfo = await conn.getAccountInfo(sipConfigPda)
+  if (!sipConfigInfo) {
+    throw new Error('sip_privacy config PDA not found')
+  }
+  // Config layout: 8 (disc) + 32 (authority) + 2 (fee_bps) + 1 (paused) + 8 (total_transfers) + 1 (bump)
+  const totalTransfers = sipConfigInfo.data.readBigUInt64LE(8 + 32 + 2 + 1)
+  const totalTransfersLeBytes = Buffer.alloc(8)
+  totalTransfersLeBytes.writeBigUInt64LE(totalTransfers, 0)
+  console.log('sip_privacy total_transfers:', totalTransfers.toString())
+
+  const [sipTransferRecordPda] = PublicKey.findProgramAddressSync(
+    [SIP_TRANSFER_RECORD_SEED, wallet.publicKey.toBuffer(), totalTransfersLeBytes],
+    SIP_PRIVACY_PROGRAM_ID
+  )
+  console.log('TransferRecord PDA (expected):', sipTransferRecordPda.toString())
+
+  // ─── 1. Wrap 0.001 SOL ───────────────────────────────────────────────────────
+  const wrapTx = new Transaction()
+  wrapTx.add(
+    createAssociatedTokenAccountIdempotentInstruction(wallet.publicKey, wsolAta, wallet.publicKey, WSOL_MINT)
+  )
+  wrapTx.add(
+    SystemProgram.transfer({
+      fromPubkey: wallet.publicKey,
+      toPubkey: wsolAta,
+      lamports: DEPOSIT_LAMPORTS,
+    })
+  )
+  wrapTx.add(createSyncNativeInstruction(wsolAta))
+  const wrapSig = await sendAndConfirmTransaction(conn, wrapTx, [wallet])
+  console.log('Wrap TX:', wrapSig)
+
+  // ─── 2. Deposit ──────────────────────────────────────────────────────────────
+  // deposit(amount: u64) — discriminator + u64
+  const depositData = Buffer.alloc(8 + 8)
+  disc('deposit').copy(depositData, 0)
+  depositData.writeBigUInt64LE(DEPOSIT_LAMPORTS, 8)
+
+  const depositIx = new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: vaultConfigPda, isSigner: false, isWritable: true },
+      { pubkey: depositRecordPda, isSigner: false, isWritable: true },
+      { pubkey: vaultTokenPda, isSigner: false, isWritable: true },
+      { pubkey: wsolAta, isSigner: false, isWritable: true },
+      { pubkey: WSOL_MINT, isSigner: false, isWritable: false },
+      { pubkey: wallet.publicKey, isSigner: true, isWritable: true },
+      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data: depositData,
+  })
+
+  const depositSig = await sendAndConfirmTransaction(conn, new Transaction().add(depositIx), [wallet])
+  console.log('Deposit TX:', depositSig)
+
+  // ─── 3. withdraw_private with CPI ────────────────────────────────────────────
+  // Layout: discriminator(8) + amount(u64) + amount_commitment(33) +
+  //         stealth_pubkey(32) + ephemeral_pubkey(33) + viewing_key_hash(32) +
+  //         encrypted_amount(Vec<u8>: 4-byte len + bytes) + proof(Vec<u8>: 4-byte len + bytes)
+  const wpData = Buffer.concat([
+    disc('withdraw_private'),
+    Buffer.from(new BigUint64Array([WITHDRAW_LAMPORTS]).buffer),
+    amountCommitment,
+    stealthRecipient.toBuffer(),
+    ephemeralPubkey,
+    viewingKeyHash,
+    Buffer.from(new Uint32Array([encryptedAmount.length]).buffer),
+    encryptedAmount,
+    Buffer.from(new Uint32Array([0]).buffer), // empty proof
+  ])
+
+  const stealthAta = getAssociatedTokenAddressSync(WSOL_MINT, stealthRecipient)
+
+  // Stealth ATA creation must precede withdraw_private (program does not auto-create)
+  const ensureStealthAtaIx = createAssociatedTokenAccountIdempotentInstruction(
+    wallet.publicKey,
+    stealthAta,
+    stealthRecipient,
+    WSOL_MINT
+  )
+
+  // Account order matches sipher-vault::WithdrawPrivate struct exactly:
+  //   config, deposit_record, vault_token, fee_token, stealth_token,
+  //   token_mint, depositor, token_program, sip_config, sip_transfer_record,
+  //   sip_privacy_program, system_program
+  const wpIx = new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: vaultConfigPda, isSigner: false, isWritable: false },
+      { pubkey: depositRecordPda, isSigner: false, isWritable: true },
+      { pubkey: vaultTokenPda, isSigner: false, isWritable: true },
+      { pubkey: feeTokenPda, isSigner: false, isWritable: true },
+      { pubkey: stealthAta, isSigner: false, isWritable: true },
+      { pubkey: WSOL_MINT, isSigner: false, isWritable: false },
+      { pubkey: wallet.publicKey, isSigner: true, isWritable: true },
+      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      // CPI accounts
+      { pubkey: sipConfigPda, isSigner: false, isWritable: true },
+      { pubkey: sipTransferRecordPda, isSigner: false, isWritable: true },
+      { pubkey: SIP_PRIVACY_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data: wpData,
+  })
+
+  const wpTx = new Transaction().add(ensureStealthAtaIx).add(wpIx)
+  const wpSig = await sendAndConfirmTransaction(conn, wpTx, [wallet], { skipPreflight: true, maxRetries: 3 })
+  console.log('withdraw_private TX:', wpSig)
+
+  // ─── 4. Verify TransferRecord PDA exists on sip_privacy ──────────────────────
+  const transferRecord = await conn.getAccountInfo(sipTransferRecordPda)
+  if (!transferRecord) {
+    console.error('FAIL — TransferRecord PDA not created. CPI did not fire as expected.')
+    process.exit(1)
+  }
+  console.log('TransferRecord PDA created. Size:', transferRecord.data.length, 'bytes')
+  console.log('Owner:', transferRecord.owner.toString())
+  if (!transferRecord.owner.equals(SIP_PRIVACY_PROGRAM_ID)) {
+    console.error('FAIL — TransferRecord owner is not sip_privacy.')
+    process.exit(1)
+  }
+
+  console.log('\n✓ Devnet CPI E2E PASSED.')
+  console.log({
+    wrapSig,
+    depositSig,
+    withdrawPrivateSig: wpSig,
+    transferRecordPda: sipTransferRecordPda.toString(),
+    stealthRecipient: stealthRecipient.toString(),
+  })
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/programs/sipher-vault/scripts/e2e-cpi-test.ts
+++ b/programs/sipher-vault/scripts/e2e-cpi-test.ts
@@ -46,7 +46,7 @@ const FEE_TOKEN_SEED = Buffer.from('fee_token')
 const SIP_CONFIG_SEED = Buffer.from('config')
 const SIP_TRANSFER_RECORD_SEED = Buffer.from('transfer_record')
 
-const RPC = 'https://api.devnet.solana.com'
+const RPC = process.env.ANCHOR_PROVIDER_URL ?? 'https://api.devnet.solana.com'
 const DEPOSIT_LAMPORTS = 1_000_000n // 0.001 SOL
 const WITHDRAW_LAMPORTS = 500_000n  // 0.0005 SOL — half of deposit, leaves remainder for the refund-script if rerun
 
@@ -56,8 +56,9 @@ function disc(name: string): Buffer {
 
 async function main() {
   const conn = new Connection(RPC, 'confirmed')
+  const walletPath = process.env.ANCHOR_WALLET ?? `${homedir()}/Documents/secret/solana-devnet.json`
   const wallet = Keypair.fromSecretKey(
-    Uint8Array.from(JSON.parse(readFileSync(`${homedir()}/Documents/secret/solana-devnet.json`, 'utf-8')))
+    Uint8Array.from(JSON.parse(readFileSync(walletPath, 'utf-8')))
   )
   console.log('Depositor:', wallet.publicKey.toString())
 
@@ -108,6 +109,12 @@ async function main() {
   )
   console.log('TransferRecord PDA (expected):', sipTransferRecordPda.toString())
 
+  // Snapshot fee_token balance before the test for the fee-accumulation assertion.
+  // The fee_token PDA was created during Phase 3 init for wSOL on devnet, so it exists.
+  const feeBefore = await conn.getTokenAccountBalance(feeTokenPda)
+  const feeBeforeAmount = BigInt(feeBefore.value.amount)
+  console.log('fee_token wSOL before:', feeBeforeAmount.toString(), 'lamports')
+
   // ─── 1. Wrap 0.001 SOL ───────────────────────────────────────────────────────
   const wrapTx = new Transaction()
   wrapTx.add(
@@ -152,16 +159,20 @@ async function main() {
   // Layout: discriminator(8) + amount(u64) + amount_commitment(33) +
   //         stealth_pubkey(32) + ephemeral_pubkey(33) + viewing_key_hash(32) +
   //         encrypted_amount(Vec<u8>: 4-byte len + bytes) + proof(Vec<u8>: 4-byte len + bytes)
+  const amountBuf = Buffer.alloc(8); amountBuf.writeBigUInt64LE(WITHDRAW_LAMPORTS)
+  const encLenBuf = Buffer.alloc(4); encLenBuf.writeUInt32LE(encryptedAmount.length)
+  const proofLenBuf = Buffer.alloc(4); proofLenBuf.writeUInt32LE(0)
+
   const wpData = Buffer.concat([
     disc('withdraw_private'),
-    Buffer.from(new BigUint64Array([WITHDRAW_LAMPORTS]).buffer),
+    amountBuf,
     amountCommitment,
     stealthRecipient.toBuffer(),
     ephemeralPubkey,
     viewingKeyHash,
-    Buffer.from(new Uint32Array([encryptedAmount.length]).buffer),
+    encLenBuf,
     encryptedAmount,
-    Buffer.from(new Uint32Array([0]).buffer), // empty proof
+    proofLenBuf, // empty proof len
   ])
 
   const stealthAta = getAssociatedTokenAddressSync(WSOL_MINT, stealthRecipient)
@@ -214,6 +225,18 @@ async function main() {
     console.error('FAIL — TransferRecord owner is not sip_privacy.')
     process.exit(1)
   }
+
+  // ─── 5. Verify fee_token accounting ──────────────────────────────────────────
+  const feeAfter = await conn.getTokenAccountBalance(feeTokenPda)
+  const feeAfterAmount = BigInt(feeAfter.value.amount)
+  const feeDelta = feeAfterAmount - feeBeforeAmount
+  const expectedFee = WITHDRAW_LAMPORTS * 10n / 10_000n // 10 bps
+  console.log('fee_token wSOL after:', feeAfterAmount.toString(), 'lamports (Δ', feeDelta.toString(), ')')
+  if (feeDelta !== expectedFee) {
+    console.error(`FAIL — fee_token delta ${feeDelta} != expected ${expectedFee} (10 bps of ${WITHDRAW_LAMPORTS})`)
+    process.exit(1)
+  }
+  console.log(`fee_token Δ matches expected ${expectedFee} lamports (10 bps of ${WITHDRAW_LAMPORTS})`)
 
   console.log('\n✓ Devnet CPI E2E PASSED.')
   console.log({

--- a/programs/sipher-vault/scripts/set-paused.ts
+++ b/programs/sipher-vault/scripts/set-paused.ts
@@ -1,0 +1,96 @@
+// programs/sipher-vault/scripts/set-paused.ts
+//
+// Set or clear the paused flag on the sipher_vault config PDA.
+// Authority-only — the signing keypair must equal config.authority.
+//
+// Usage: cd programs/sipher-vault && pnpm exec tsx scripts/set-paused.ts <true|false>
+//
+// Network and authority are env-driven:
+//   ANCHOR_PROVIDER_URL  — RPC endpoint (default: https://api.devnet.solana.com)
+//   ANCHOR_WALLET        — path to authority keypair JSON (REQUIRED — no default)
+//
+// Re-reads the paused byte from the config PDA after the TX so the
+// operator sees confirmed state, not just transaction success. Emits
+// VaultPausedEvent on-chain (subscribers can listen via program log).
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+  sendAndConfirmTransaction,
+} from '@solana/web3.js'
+import { readFileSync } from 'fs'
+import { createHash } from 'crypto'
+
+const PROGRAM_ID = new PublicKey('S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB')
+const VAULT_CONFIG_SEED = Buffer.from('vault_config')
+
+function discriminator(name: string): Buffer {
+  return createHash('sha256').update(`global:${name}`).digest().subarray(0, 8)
+}
+
+async function main() {
+  const arg = process.argv[2]
+  if (arg !== 'true' && arg !== 'false') {
+    console.error('Usage: tsx scripts/set-paused.ts <true|false>')
+    process.exit(1)
+  }
+  const targetPaused = arg === 'true'
+
+  const rpc = process.env.ANCHOR_PROVIDER_URL ?? 'https://api.devnet.solana.com'
+  const walletPath = process.env.ANCHOR_WALLET
+  if (!walletPath) {
+    console.error('ANCHOR_WALLET env var required (path to authority keypair JSON)')
+    process.exit(1)
+  }
+
+  const connection = new Connection(rpc, 'confirmed')
+  const authority = Keypair.fromSecretKey(
+    Uint8Array.from(JSON.parse(readFileSync(walletPath, 'utf-8')))
+  )
+  const [configPDA] = PublicKey.findProgramAddressSync([VAULT_CONFIG_SEED], PROGRAM_ID)
+
+  console.log('Network:    ', rpc)
+  console.log('Authority:  ', authority.publicKey.toString())
+  console.log('Config PDA: ', configPDA.toString())
+  console.log('Target:     paused =', targetPaused)
+
+  // Build set_paused instruction: discriminator + bool(u8)
+  const data = Buffer.alloc(8 + 1)
+  discriminator('set_paused').copy(data, 0)
+  data.writeUInt8(targetPaused ? 1 : 0, 8)
+
+  // Account order matches sipher_vault::SetPaused struct exactly:
+  //   config (mut, has_one = authority), authority (Signer)
+  const ix = new TransactionInstruction({
+    programId: PROGRAM_ID,
+    keys: [
+      { pubkey: configPDA, isSigner: false, isWritable: true },
+      { pubkey: authority.publicKey, isSigner: true, isWritable: false },
+    ],
+    data,
+  })
+
+  const tx = new Transaction().add(ix)
+  const sig = await sendAndConfirmTransaction(connection, tx, [authority])
+  console.log('TX:', sig)
+
+  // Verify by re-reading the config PDA. Layout:
+  //   8 disc + 32 authority + 2 fee_bps + 8 refund_timeout + 1 paused + ...
+  // → paused byte at offset 50.
+  const account = await connection.getAccountInfo(configPDA)
+  if (!account) throw new Error('Config PDA missing post-tx')
+  const observed = account.data[50] !== 0
+  console.log('Observed paused =', observed)
+  if (observed !== targetPaused) {
+    console.error('Mismatch! Expected', targetPaused, 'got', observed)
+    process.exit(1)
+  }
+  console.log('OK — pause state confirmed.')
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/programs/sipher-vault/scripts/upgrade-devnet.ts
+++ b/programs/sipher-vault/scripts/upgrade-devnet.ts
@@ -1,0 +1,72 @@
+// programs/sipher-vault/scripts/upgrade-devnet.ts
+//
+// Build the program and deploy the resulting binary to devnet under the
+// existing program ID. Idempotent — running again redeploys (Solana's
+// program upgrade pattern).
+//
+// Usage: pnpm exec tsx scripts/upgrade-devnet.ts
+import { execSync } from 'child_process'
+import { existsSync } from 'fs'
+import { homedir } from 'os'
+
+const PROGRAM_ID = 'S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB'
+const PROGRAM_KEYPAIR = `${homedir()}/Documents/secret/sipher-vault-program-id.json`
+const AUTHORITY_KEYPAIR = `${homedir()}/Documents/secret/solana-devnet.json`
+const SO_FILE = 'target/deploy/sipher_vault.so'
+const RPC = 'https://api.devnet.solana.com'
+
+function run(cmd: string): string {
+  console.log('$', cmd)
+  const out = execSync(cmd, { stdio: ['inherit', 'pipe', 'inherit'] }).toString()
+  console.log(out)
+  return out
+}
+
+async function main() {
+  if (!existsSync(PROGRAM_KEYPAIR)) {
+    throw new Error(`Program keypair not found: ${PROGRAM_KEYPAIR}`)
+  }
+  if (!existsSync(AUTHORITY_KEYPAIR)) {
+    throw new Error(`Authority keypair not found: ${AUTHORITY_KEYPAIR}`)
+  }
+
+  // 1. Sanity: program ID matches the keypair
+  const idFromKey = run(`solana address -k ${PROGRAM_KEYPAIR}`).trim()
+  if (idFromKey !== PROGRAM_ID) {
+    throw new Error(`Program keypair ID ${idFromKey} != expected ${PROGRAM_ID}`)
+  }
+
+  // 2. Clean + build
+  // Note: `--no-idl` is required because anchor 0.30.1's IDL generator
+  // depends on `proc_macro2::Span::source_file()`, a nightly-only proc-macro
+  // API that has been removed from current host rustc (1.94+). The on-chain
+  // SBF binary builds correctly via Solana's pinned platform-tools toolchain;
+  // only the host-side IDL generation is affected. The IDL artifact already
+  // exists at target/idl/sipher_vault.json and is regenerated whenever a
+  // compatible host toolchain is available.
+  run('anchor clean')
+  run('anchor build --no-idl')
+
+  if (!existsSync(SO_FILE)) {
+    throw new Error(`Build artifact missing: ${SO_FILE}`)
+  }
+
+  // 3. Deploy
+  run(
+    `solana program deploy ${SO_FILE} ` +
+      `--program-id ${PROGRAM_KEYPAIR} ` +
+      `--keypair ${AUTHORITY_KEYPAIR} ` +
+      `--url ${RPC} ` +
+      `--with-compute-unit-price 10000`
+  )
+
+  // 4. Verify deployed slot
+  run(`solana program show ${PROGRAM_ID} --url ${RPC}`)
+
+  console.log('Devnet upgrade complete.')
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/programs/sipher-vault/scripts/upgrade-devnet.ts
+++ b/programs/sipher-vault/scripts/upgrade-devnet.ts
@@ -11,9 +11,9 @@ import { homedir } from 'os'
 
 const PROGRAM_ID = 'S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB'
 const PROGRAM_KEYPAIR = `${homedir()}/Documents/secret/sipher-vault-program-id.json`
-const AUTHORITY_KEYPAIR = `${homedir()}/Documents/secret/solana-devnet.json`
+const AUTHORITY_KEYPAIR = process.env.ANCHOR_WALLET ?? `${homedir()}/Documents/secret/solana-devnet.json`
 const SO_FILE = 'target/deploy/sipher_vault.so'
-const RPC = 'https://api.devnet.solana.com'
+const RPC = process.env.ANCHOR_PROVIDER_URL ?? 'https://api.devnet.solana.com'
 
 // Run a command with live stdout/stderr streamed to the terminal. No return value.
 // Use this for build, deploy, and post-deploy show — where the operator needs to

--- a/programs/sipher-vault/scripts/upgrade-devnet.ts
+++ b/programs/sipher-vault/scripts/upgrade-devnet.ts
@@ -4,7 +4,7 @@
 // existing program ID. Idempotent — running again redeploys (Solana's
 // program upgrade pattern).
 //
-// Usage: pnpm exec tsx scripts/upgrade-devnet.ts
+// Usage: cd programs/sipher-vault && pnpm exec tsx scripts/upgrade-devnet.ts
 import { execSync } from 'child_process'
 import { existsSync } from 'fs'
 import { homedir } from 'os'
@@ -15,11 +15,20 @@ const AUTHORITY_KEYPAIR = `${homedir()}/Documents/secret/solana-devnet.json`
 const SO_FILE = 'target/deploy/sipher_vault.so'
 const RPC = 'https://api.devnet.solana.com'
 
-function run(cmd: string): string {
+// Run a command with live stdout/stderr streamed to the terminal. No return value.
+// Use this for build, deploy, and post-deploy show — where the operator needs to
+// see progress in real time. `anchor build` (10-30s) and `solana program deploy`
+// (30s-5min) would otherwise leave the terminal frozen until completion.
+function run(cmd: string): void {
   console.log('$', cmd)
-  const out = execSync(cmd, { stdio: ['inherit', 'pipe', 'inherit'] }).toString()
-  console.log(out)
-  return out
+  execSync(cmd, { stdio: 'inherit' })
+}
+
+// Run a command and capture stdout as a trimmed string. Stderr still inherits.
+// Use this when the script needs to parse the command's output.
+function capture(cmd: string): string {
+  console.log('$', cmd)
+  return execSync(cmd, { stdio: ['inherit', 'pipe', 'inherit'], encoding: 'utf-8' }).trim()
 }
 
 async function main() {
@@ -31,20 +40,23 @@ async function main() {
   }
 
   // 1. Sanity: program ID matches the keypair
-  const idFromKey = run(`solana address -k ${PROGRAM_KEYPAIR}`).trim()
+  const idFromKey = capture(`solana address -k ${PROGRAM_KEYPAIR}`)
   if (idFromKey !== PROGRAM_ID) {
     throw new Error(`Program keypair ID ${idFromKey} != expected ${PROGRAM_ID}`)
   }
 
-  // 2. Clean + build
+  // 2. Build
   // Note: `--no-idl` is required because anchor 0.30.1's IDL generator
   // depends on `proc_macro2::Span::source_file()`, a nightly-only proc-macro
   // API that has been removed from current host rustc (1.94+). The on-chain
   // SBF binary builds correctly via Solana's pinned platform-tools toolchain;
-  // only the host-side IDL generation is affected. The IDL artifact already
-  // exists at target/idl/sipher_vault.json and is regenerated whenever a
-  // compatible host toolchain is available.
-  run('anchor clean')
+  // only the host-side IDL generation is affected.
+  //
+  // We deliberately skip `anchor clean` here: clean would wipe `target/idl/sipher_vault.json`
+  // (which downstream consumers like the agent SDK and UI depend on), and the `--no-idl`
+  // flag means we cannot regenerate it from this script. `anchor build` is incremental
+  // and reliable; a stale `.so` is not a realistic risk on a deploy script that already
+  // verifies the artifact's existence afterward.
   run('anchor build --no-idl')
 
   if (!existsSync(SO_FILE)) {

--- a/programs/sipher-vault/tests/sipher-vault/02-deposit.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/02-deposit.test.ts
@@ -158,11 +158,13 @@ describe('sipher-vault: deposit', () => {
   })
 
   // ── Test 4: Deposit when paused ────────────────────────────────────────
-  // No `pause` instruction exists in Phase 1. Marking as pending.
-  // When a `set_paused` instruction is added, this test should:
-  // 1. Call set_paused(true) as authority
-  // 2. Attempt deposit -> expect ProgramPaused error
-  // 3. Call set_paused(false) to restore state for subsequent tests
+  // The set_paused instruction lands in commit X (PR-A1 / Task A1.2.5).
+  // This Anchor-client unit test stays skipped because regenerating the IDL
+  // requires `anchor build` without `--no-idl`, which currently fails on the
+  // host toolchain (proc_macro2::Span::source_file removed from rustc 1.94+;
+  // see programs/sipher-vault/DEPLOYMENT.md "Build note"). Operational test
+  // coverage comes from scripts/set-paused.ts rehearsal evidence on devnet
+  // (DEPLOYMENT.md "Pause Runbook Rehearsed" section).
 
-  it.skip('rejects deposit when paused (pending: no pause instruction in Phase 1)')
+  it.skip('rejects deposit when paused (pending: IDL regeneration blocked on host toolchain)')
 })

--- a/programs/sipher-vault/tests/sipher-vault/02-deposit.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/02-deposit.test.ts
@@ -158,7 +158,7 @@ describe('sipher-vault: deposit', () => {
   })
 
   // ── Test 4: Deposit when paused ────────────────────────────────────────
-  // The set_paused instruction lands in commit X (PR-A1 / Task A1.2.5).
+  // The set_paused instruction landed in PR-A1 / Task A1.2.5 (this branch).
   // This Anchor-client unit test stays skipped because regenerating the IDL
   // requires `anchor build` without `--no-idl`, which currently fails on the
   // host toolchain (proc_macro2::Span::source_file removed from rustc 1.94+;


### PR DESCRIPTION
## Summary

First sip-protocol PR of Phase 4a (Devnet Beta). Upgrades devnet `sipher_vault` to the CPI version of `withdraw_private`, validates the full deposit → withdraw_private → transfer_record cycle on a live cluster, lands the `set_paused` emergency lever (with structured `VaultPausedEvent` for off-chain monitoring), and rehearses pause/unpause to prove the lever works before mainnet.

## What this PR adds

**Operational scripts** (`programs/sipher-vault/scripts/`):
- `upgrade-devnet.ts` — atomic devnet upgrade via `BPFLoaderUpgradeable`
- `e2e-cpi-test.ts` — full CPI flow validation (wrap → deposit → withdraw_private → fee_token + TransferRecord assertions)
- `set-paused.ts` — authority-signed emergency pause/unpause runbook

**Program changes** (`programs/sipher-vault/programs/sipher-vault/src/lib.rs`, additive only):
- `pub fn set_paused(ctx, paused: bool) -> Result<()>` — authority-gated kill switch
- `pub struct SetPaused<'info>` — `has_one = authority` accounts struct (mirrors `collect_fee` pattern)
- `pub struct VaultPausedEvent { authority, paused, timestamp }` — structured event for SENTINEL / monitoring tooling

**Documentation** (`programs/sipher-vault/DEPLOYMENT.md`, new file):
- Program coordinates + toolchain reference (including the `--no-idl` host-toolchain workaround)
- Devnet deployment ledger: Initial → CPI Upgrade → set_paused Upgrade → VaultPausedEvent Upgrade
- Pause Runbook Rehearsed evidence (TXs, observed `ProgramPaused` cite, downtime metric)

## Why now

Three deliverables for the public devnet beta soak window:
1. The CPI version of `withdraw_private` (commit `79133d0`, built April but never deployed) needed first programmatic confirmation on a live cluster.
2. The `paused: bool` field in `VaultConfig` was already gated in three flows but never writable — no kill switch existed. Phase 4 plan assumed `set_paused` existed; spec reviewer caught the gap, RECTOR chose to add it in PR-A1 rather than defer to a follow-up before PR-B1 mainnet.
3. The lever needs rehearsal evidence before mainnet so PR-B1 ships with a copy-paste-ready emergency response runbook.

## On-chain evidence (devnet)

| Action | TX | Slot | Notes |
|---|---|---|---|
| CPI binary upgrade | `395Leyp...YDbp` | 460367898 | 376,664 bytes |
| E2E CPI test | `2AJs8aTL...VTX4` | — | TransferRecord PDA `8VCV7r35...rXoeU` (281 bytes, owned by `sip_privacy`) |
| set_paused redeploy | `utoZnnbb...gkNy` | 460374492 | 382,112 bytes (+5,448 for new ix + struct) |
| VaultPausedEvent redeploy | `4xZyApH8...gi1T` | 460376111 | 383,144 bytes (+1,032 for event struct + emit) |
| Pause TX | `2SPbNjy...a4KP` | 460376982 | `Observed paused = true` |
| Unpause TX | `eSSaz7k...2EfK` | 460377030 | `Observed paused = false` |

Vault end state: **UNPAUSED** (paused byte at offset 50 of config PDA = 0). Final binary on devnet program `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB` at slot **460376111**.

## Notable deviations + decisions

- **`anchor build --no-idl`**: anchor 0.30.1's IDL generator depends on `proc_macro2::Span::source_file()`, removed from current host rustc (1.94+). The on-chain SBF binary is unaffected (Solana platform-tools pins rustc 1.84.1). Documented inline in scripts and in DEPLOYMENT.md "Build note".
- **`e2e-cpi-test.ts` corrects three bugs in the predecessor plan's verbatim script**: TransferRecord PDA seeds (33-byte seeds exceeded Solana's 32-byte cap; actual seeds are `[seed, sender, total_transfers_le_bytes]`), WithdrawPrivate account ordering (`fee_token` before `stealth_token`, not after), and `vault_config` writability (no `mut` annotation in struct). Verified against on-chain Rust source; documented in commit body.
- **No new Anchor unit tests for `set_paused`**: existing tests use IDL-derived `Program<SipherVault>` types; we can't regenerate the IDL on the current host toolchain. The skipped `02-deposit.test.ts` test 4 stays skipped with an updated comment. Operational coverage comes from the rehearsal evidence in DEPLOYMENT.md.

## Test plan

- [x] `pnpm exec tsc --noEmit scripts/upgrade-devnet.ts` — silent
- [x] `pnpm exec tsc --noEmit scripts/e2e-cpi-test.ts` — silent
- [x] `pnpm exec tsc --noEmit scripts/set-paused.ts` — silent
- [x] `anchor build --no-idl` — clean Finished release profile, binary 383,144 bytes
- [x] Devnet upgrade deployed; `solana program show` reports new slot 460376111
- [x] E2E CPI test PASSED on devnet — TransferRecord PDA materialized + owned by `sip_privacy`, fee_token gained 500 lamports (10 bps of 500_000 withdrawn)
- [x] Pause TX confirmed on devnet; `Observed paused = true`
- [x] Deposit attempt during paused state failed with `AnchorError ... Error Code: ProgramPaused. Error Number: 6000` (`0x1770`) at lib.rs:92
- [x] Unpause TX confirmed; `Observed paused = false`
- [x] `VaultPausedEvent` confirmed firing in pause TX log (`Program log: Vault paused = true` + base64 `Program data:`)
- [x] No AI attribution in any commit message
- [x] Vault end state: UNPAUSED

## Spec + plan

- Spec: `docs/superpowers/specs/2026-05-05-phase4-split-devnet-beta-mainnet-design.md` (sipher repo)
- Plan: `docs/superpowers/plans/2026-05-05-phase4-split-devnet-beta-mainnet.md` (sipher repo)

PR-A1 is one of three Phase 4a PRs (A1 sip-protocol, A2 sipher, A3 blog-sip). After this lands, A2 + A3 + a 3-7 day soak window precede the gate-pass for Phase 4b mainnet.