### PR TITLE
feat(sns-stealth): add @sip-protocol/sns-stealth package (Phase A of sip.sol foundation)

### DIFF
--- a/packages/sns-stealth/README.md
+++ b/packages/sns-stealth/README.md
@@ -2,7 +2,7 @@
 
 SNS-based stealth address resolution and publishing for SIP Protocol.
 
-Publish a `SIP-STEALTH` record on your `.sol` domain → receive private payments by name. Any SIP-aware app can resolve `rector.sol` to a one-time stealth address.
+Publish a `SIP-STEALTH` record on your `.sol` domain once. After that, any SIP-aware app can route private payments to you by name (`rector.sol`) instead of requiring senders to copy-paste a 140-character `sip:solana:<spending>:<viewing>` URI out of band.
 
 See the design spec at `docs/superpowers/specs/2026-05-11-sip-sol-foundation-design.md`.
 
@@ -12,17 +12,100 @@ See the design spec at `docs/superpowers/specs/2026-05-11-sip-sol-foundation-des
 pnpm add @sip-protocol/sns-stealth
 ```
 
-## Usage
+## Sender flow
+
+Resolve a `.sol` domain to its stealth meta-address, then route a private payment to it.
 
 ```typescript
-import { resolveSIPStealth, buildPublishTx, deriveStealthKeys, MetaAddress } from '@sip-protocol/sns-stealth'
+import { Connection } from '@solana/web3.js'
+import {
+  resolveSIPStealth,
+  MetaAddress,
+  NotFound,
+  Malformed,
+} from '@sip-protocol/sns-stealth'
 
-// Sender
-const meta = await resolveSIPStealth(connection, 'rector.sol')
-if (meta instanceof MetaAddress) { /* send privately */ }
+const connection = new Connection('https://api.mainnet-beta.solana.com')
 
-// Receiver (one-time setup)
-const keys = await deriveStealthKeys(wallet, 'rector.sol')
-const tx = await buildPublishTx(connection, 'rector.sol', keys, wallet.publicKey)
-await wallet.sendTransaction(tx)
+const result = await resolveSIPStealth(connection, 'rector.sol')
+
+if (result instanceof MetaAddress) {
+  // result.spending  — 32-byte ed25519 pubkey
+  // result.viewing   — 32-byte ed25519 pubkey
+  // result.chain     — 'solana'
+  // result.domain    — 'rector.sol' (normalized)
+  // Pass to your SIP stealth-payment flow.
+} else if (result instanceof NotFound) {
+  if (result.subject === 'domain') {
+    // The .sol name itself does not exist on SNS.
+    // Block: show "no such name" and stop.
+  } else {
+    // Domain exists, but the owner has not published a SIP-STEALTH record.
+    // Warn + offer explicit public downgrade: [Send Public] / [Cancel].
+  }
+} else if (result instanceof Malformed) {
+  // result.reason === 'json-parse'  — record exists but isn't valid JSON
+  // result.reason === 'schema'      — record is JSON but fails v1 schema
+  // Treat as a recoverable error and surface to the user.
+}
 ```
+
+## Receiver flow
+
+Derive per-domain stealth keys, then publish them as a `SIP-STEALTH` record on your `.sol`.
+
+```typescript
+import { Connection } from '@solana/web3.js'
+import { buildPublishTx, deriveStealthKeys } from '@sip-protocol/sns-stealth'
+
+// `wallet` exposes signMessage + publicKey (matches @solana/wallet-adapter-base)
+const connection = new Connection('https://api.mainnet-beta.solana.com')
+
+const keys = await deriveStealthKeys(wallet, 'rector.sol')
+
+const tx = await buildPublishTx(connection, 'rector.sol', {
+  spending: keys.spending,
+  viewing: keys.viewing,
+}, wallet.publicKey)
+
+await wallet.sendTransaction(tx, connection)
+```
+
+Keys are derived per-domain via HKDF-SHA256 over a wallet signature of `sip-stealth-v1:<normalized-domain>`. Same wallet + same domain → identical keys (deterministic, idempotent). Different domain → uncorrelatable keys.
+
+Hold on to `keys.spendingPrivate` and `keys.viewingPrivate` — you will need them later to scan for and claim incoming payments.
+
+## Cache
+
+Resolution results are cached in-memory for 60 seconds per normalized domain, including negative results (`NotFound`, `Malformed`). To force a re-fetch:
+
+```typescript
+import { invalidateCache } from '@sip-protocol/sns-stealth'
+
+invalidateCache('rector.sol')  // clear one domain
+invalidateCache()               // clear all entries
+```
+
+## Record schema (v1)
+
+The on-chain `SIP-STEALTH` record is canonical JSON:
+
+```json
+{"v":1,"spending":"<64-char lowercase hex>","viewing":"<64-char lowercase hex>"}
+```
+
+Strict validation rejects uppercase hex, wrong-length keys, missing `v`, or `v != 1`. The format is versioned for future forward-incompatible upgrades.
+
+## Errors
+
+```typescript
+import {
+  NotFound,        // discriminated: subject = 'domain' | 'record'
+  Malformed,       // discriminated: reason = 'json-parse' | 'schema'
+  NetworkError,    // wraps underlying RPC failure (thrown, not returned)
+  UserRejected,    // wallet signature flow declined
+  OnChainError,    // tx failed; exposes signature
+} from '@sip-protocol/sns-stealth'
+```
+
+`NetworkError` is **thrown** from `resolveSIPStealth`. The other not-found/malformed variants are **returned** so callers can branch without try/catch.

--- a/packages/sns-stealth/README.md
+++ b/packages/sns-stealth/README.md
@@ -1,0 +1,28 @@
+# @sip-protocol/sns-stealth
+
+SNS-based stealth address resolution and publishing for SIP Protocol.
+
+Publish a `SIP-STEALTH` record on your `.sol` domain → receive private payments by name. Any SIP-aware app can resolve `rector.sol` to a one-time stealth address.
+
+See the design spec at `docs/superpowers/specs/2026-05-11-sip-sol-foundation-design.md`.
+
+## Install
+
+```bash
+pnpm add @sip-protocol/sns-stealth
+```
+
+## Usage
+
+```typescript
+import { resolveSIPStealth, buildPublishTx, deriveStealthKeys } from '@sip-protocol/sns-stealth'
+
+// Sender
+const meta = await resolveSIPStealth(connection, 'rector.sol')
+if (meta instanceof MetaAddress) { /* send privately */ }
+
+// Receiver (one-time setup)
+const keys = await deriveStealthKeys(wallet, 'rector.sol')
+const tx = await buildPublishTx(connection, 'rector.sol', keys, wallet.publicKey)
+await wallet.sendTransaction(tx)
+```

--- a/packages/sns-stealth/README.md
+++ b/packages/sns-stealth/README.md
@@ -15,7 +15,7 @@ pnpm add @sip-protocol/sns-stealth
 ## Usage
 
 ```typescript
-import { resolveSIPStealth, buildPublishTx, deriveStealthKeys } from '@sip-protocol/sns-stealth'
+import { resolveSIPStealth, buildPublishTx, deriveStealthKeys, MetaAddress } from '@sip-protocol/sns-stealth'
 
 // Sender
 const meta = await resolveSIPStealth(connection, 'rector.sol')

--- a/packages/sns-stealth/package.json
+++ b/packages/sns-stealth/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@sip-protocol/sns-stealth",
+  "version": "0.1.0",
+  "description": "SNS-based stealth address resolution and publishing for SIP Protocol",
+  "author": "SIP Protocol <hello@sip-protocol.org>",
+  "homepage": "https://sip-protocol.org",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sip-protocol/sip-protocol.git",
+    "directory": "packages/sns-stealth"
+  },
+  "bugs": {
+    "url": "https://github.com/sip-protocol/sip-protocol/issues"
+  },
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@bonfida/spl-name-service": "^3.0.21",
+    "@noble/curves": "^1.3.0",
+    "@noble/hashes": "^1.3.3",
+    "@solana/web3.js": "^1.98.4",
+    "zod": "^4.3.5"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.0",
+    "vitest": "^1.1.0"
+  },
+  "keywords": [
+    "sip",
+    "sns",
+    "solana",
+    "stealth-addresses",
+    "privacy"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/sns-stealth/package.json
+++ b/packages/sns-stealth/package.json
@@ -41,6 +41,7 @@
     "zod": "^4.3.5"
   },
   "devDependencies": {
+    "@vitest/coverage-v8": "1.6.1",
     "tsup": "^8.0.0",
     "typescript": "^5.3.0",
     "vitest": "^1.1.0"

--- a/packages/sns-stealth/package.json
+++ b/packages/sns-stealth/package.json
@@ -18,7 +18,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "README.md"
+    "src"
   ],
   "exports": {
     ".": {

--- a/packages/sns-stealth/src/cache.ts
+++ b/packages/sns-stealth/src/cache.ts
@@ -1,0 +1,33 @@
+interface Entry<T> {
+  value: T
+  expiresAt: number
+}
+
+export class TTLCache<T> {
+  private store = new Map<string, Entry<T>>()
+
+  constructor(private readonly defaultTtlMs: number) {}
+
+  get(key: string): T | undefined {
+    const entry = this.store.get(key)
+    if (!entry) return undefined
+    if (Date.now() >= entry.expiresAt) {
+      this.store.delete(key)
+      return undefined
+    }
+    return entry.value
+  }
+
+  set(key: string, value: T, ttlMs?: number): void {
+    const ttl = ttlMs ?? this.defaultTtlMs
+    this.store.set(key, { value, expiresAt: Date.now() + ttl })
+  }
+
+  invalidate(key: string): void {
+    this.store.delete(key)
+  }
+
+  clear(): void {
+    this.store.clear()
+  }
+}

--- a/packages/sns-stealth/src/derive.ts
+++ b/packages/sns-stealth/src/derive.ts
@@ -1,0 +1,46 @@
+import { hkdf } from '@noble/hashes/hkdf'
+import { sha256 } from '@noble/hashes/sha2'
+import { ed25519 } from '@noble/curves/ed25519'
+import { utf8ToBytes } from '@noble/hashes/utils'
+
+export interface Signer {
+  signMessage(message: Uint8Array): Promise<Uint8Array>
+}
+
+export interface DerivedStealthKeys {
+  spending: Uint8Array         // 32-byte ed25519 pubkey
+  viewing: Uint8Array          // 32-byte ed25519 pubkey
+  spendingPrivate: Uint8Array  // 32-byte seed (keep secret)
+  viewingPrivate: Uint8Array   // 32-byte seed (keep secret)
+}
+
+export function normalizeDomain(domain: string): string {
+  return domain.toLowerCase().replace(/\.$/, '')
+}
+
+export function deriveSeed(
+  signature: Uint8Array,
+  info: 'spending' | 'viewing',
+): Uint8Array {
+  // HKDF-SHA256(ikm=signature, salt=undefined, info=<utf8>, length=32)
+  return hkdf(sha256, signature, undefined, info, 32)
+}
+
+export async function deriveStealthKeys(
+  wallet: Signer,
+  domain: string,
+): Promise<DerivedStealthKeys> {
+  const normalized = normalizeDomain(domain)
+  const message = utf8ToBytes(`sip-stealth-v1:${normalized}`)
+  const signature = await wallet.signMessage(message)
+
+  const spendingPrivate = deriveSeed(signature, 'spending')
+  const viewingPrivate = deriveSeed(signature, 'viewing')
+
+  return {
+    spending: ed25519.getPublicKey(spendingPrivate),
+    viewing: ed25519.getPublicKey(viewingPrivate),
+    spendingPrivate,
+    viewingPrivate,
+  }
+}

--- a/packages/sns-stealth/src/errors.ts
+++ b/packages/sns-stealth/src/errors.ts
@@ -1,0 +1,43 @@
+export type NotFoundSubject = 'domain' | 'record'
+export type MalformedReason = 'json-parse' | 'schema'
+
+export class NotFound extends Error {
+  readonly name = 'NotFound'
+  constructor(public readonly subject: NotFoundSubject) {
+    super(`Not found: ${subject}`)
+  }
+}
+
+export class Malformed extends Error {
+  readonly name = 'Malformed'
+  constructor(
+    public readonly reason: MalformedReason,
+    public override readonly cause?: unknown,
+  ) {
+    super(`Malformed record: ${reason}`)
+  }
+}
+
+export class NetworkError extends Error {
+  readonly name = 'NetworkError'
+  constructor(message: string, public override readonly cause?: unknown) {
+    super(message)
+  }
+}
+
+export class UserRejected extends Error {
+  readonly name = 'UserRejected'
+  constructor(message = 'User rejected the signature request') {
+    super(message)
+  }
+}
+
+export class OnChainError extends Error {
+  readonly name = 'OnChainError'
+  constructor(
+    public readonly signature: string,
+    message: string,
+  ) {
+    super(`On-chain error (${signature}): ${message}`)
+  }
+}

--- a/packages/sns-stealth/src/index.ts
+++ b/packages/sns-stealth/src/index.ts
@@ -1,2 +1,23 @@
-// Public API surface — populated in subsequent tasks
-export {}
+// Core resolution + publish API
+export { resolveSIPStealth, invalidateCache, MetaAddress } from './resolve'
+export type { ResolveResult } from './resolve'
+
+export { buildPublishTx } from './publish'
+export type { PublishKeys } from './publish'
+
+export { deriveStealthKeys, normalizeDomain, deriveSeed } from './derive'
+export type { Signer, DerivedStealthKeys } from './derive'
+
+// Record schema
+export { SIPStealthRecordV1, parseRecord, encodeRecord } from './schema'
+export type { SIPStealthRecord, ParseResult } from './schema'
+
+// Typed errors
+export {
+  NotFound,
+  Malformed,
+  NetworkError,
+  UserRejected,
+  OnChainError,
+} from './errors'
+export type { NotFoundSubject, MalformedReason } from './errors'

--- a/packages/sns-stealth/src/index.ts
+++ b/packages/sns-stealth/src/index.ts
@@ -1,0 +1,2 @@
+// Public API surface — populated in subsequent tasks
+export {}

--- a/packages/sns-stealth/src/publish.ts
+++ b/packages/sns-stealth/src/publish.ts
@@ -1,0 +1,83 @@
+import type { Connection, PublicKey } from '@solana/web3.js'
+import { Transaction } from '@solana/web3.js'
+import { createRecordInstruction } from '@bonfida/spl-name-service'
+import { bytesToHex } from '@noble/hashes/utils'
+import { normalizeDomain } from './derive'
+import { encodeRecord } from './schema'
+
+// SNS record key for SIP stealth metadata. Mirrors `resolve.ts`: cast bypasses
+// Bonfida's closed `Record` enum because at runtime the SDK passes this string
+// through to `getDomainKeySync` which composes it as a subdomain
+// `<RECORD>.<DOMAIN>`, so arbitrary strings work.
+const SIP_STEALTH_RECORD = 'SIP-STEALTH' as never
+
+// Ed25519 public keys are always 32 bytes — same shape we publish in the
+// record's `spending`/`viewing` fields.
+const ED25519_PUBKEY_BYTES = 32
+
+export interface PublishKeys {
+  spending: Uint8Array  // 32-byte ed25519 pubkey
+  viewing: Uint8Array   // 32-byte ed25519 pubkey
+}
+
+/**
+ * Build an unsigned Solana transaction that writes the caller's stealth meta-address
+ * to the SIP-STEALTH record on their `.sol` domain. The caller signs and sends
+ * via their wallet (the function deliberately stays signing-free so it works
+ * across hot/cold/hardware wallets and meta-tx relayers).
+ *
+ * Uses V1 records (mirrors the reader in `resolve.ts` which calls `getRecord`).
+ * V2 would require switching both reader and writer in lockstep — out of scope
+ * for the foundation milestone.
+ *
+ * @param connection Solana RPC connection (used for rent-exemption lookup + blockhash)
+ * @param domain     The `.sol` domain (case-insensitive; normalized internally)
+ * @param keys       The 32-byte ed25519 spending/viewing public keys to publish
+ * @param payer      The domain owner / fee payer (single wallet for self-publish flow)
+ */
+export async function buildPublishTx(
+  connection: Connection,
+  domain: string,
+  keys: PublishKeys,
+  payer: PublicKey,
+): Promise<Transaction> {
+  if (keys.spending.length !== ED25519_PUBKEY_BYTES) {
+    throw new Error(
+      `Spending key must be 32 bytes (got ${keys.spending.length})`,
+    )
+  }
+  if (keys.viewing.length !== ED25519_PUBKEY_BYTES) {
+    throw new Error(
+      `Viewing key must be 32 bytes (got ${keys.viewing.length})`,
+    )
+  }
+
+  const normalized = normalizeDomain(domain)
+  const recordValue = encodeRecord({
+    v: 1,
+    spending: bytesToHex(keys.spending),
+    viewing: bytesToHex(keys.viewing),
+  })
+
+  // V1 createRecordInstruction signature:
+  //   (connection, domain, record, data, owner, payer) => Promise<TransactionInstruction>
+  // For the self-publish flow `owner === payer` (the user writing to their own
+  // domain). If we ever need separate signers (e.g., relayer pays gas for a
+  // hardware wallet owner), expose `owner` as a distinct parameter — but until
+  // then collapsing them keeps the API simple and matches the common case.
+  const ix = await createRecordInstruction(
+    connection,
+    normalized,
+    SIP_STEALTH_RECORD,
+    recordValue,
+    payer,
+    payer,
+  )
+
+  const tx = new Transaction()
+  tx.add(ix)
+  const { blockhash } = await connection.getLatestBlockhash()
+  tx.recentBlockhash = blockhash
+  tx.feePayer = payer
+  return tx
+}

--- a/packages/sns-stealth/src/resolve.ts
+++ b/packages/sns-stealth/src/resolve.ts
@@ -1,0 +1,122 @@
+import type { Connection } from '@solana/web3.js'
+import {
+  getRecord,
+  getDomainKeySync,
+  NameRegistryState,
+  AccountDoesNotExistError,
+  NoRecordDataError,
+} from '@bonfida/spl-name-service'
+import { TTLCache } from './cache'
+import { parseRecord } from './schema'
+import { normalizeDomain } from './derive'
+import { NotFound, Malformed, NetworkError } from './errors'
+
+// Per spec: 60-second TTL per domain. Tunable during integration testing.
+const CACHE_TTL_MS = 60_000
+
+// SNS record key for SIP stealth metadata. Matches the chain-record convention
+// (uppercase, hyphen separator). Cast bypasses Bonfida's closed `Record` enum:
+// at runtime the SDK passes this string through to `getRecordKeySync` which
+// composes it as a subdomain `RECORD.DOMAIN`, so arbitrary strings work.
+const SIP_STEALTH_RECORD = 'SIP-STEALTH' as never
+
+export class MetaAddress {
+  constructor(
+    public readonly spending: Uint8Array,
+    public readonly viewing: Uint8Array,
+    public readonly chain: 'solana',
+    public readonly domain: string,
+  ) {}
+}
+
+export type ResolveResult = MetaAddress | NotFound | Malformed
+
+const cache = new TTLCache<ResolveResult>(CACHE_TTL_MS)
+
+export async function resolveSIPStealth(
+  connection: Connection,
+  domain: string,
+): Promise<ResolveResult> {
+  const normalized = normalizeDomain(domain)
+
+  const cached = cache.get(normalized)
+  if (cached !== undefined) return cached
+
+  // Step 1: confirm the domain itself exists. Bonfida's `getRecord` derives a
+  // subdomain key for the record PDA; if either the parent domain OR the
+  // record is missing, it throws `AccountDoesNotExistError` with the same
+  // shape. We probe the parent domain first to disambiguate NotFound('domain')
+  // vs NotFound('record') — the spec requires distinct UX for each.
+  try {
+    const { pubkey } = getDomainKeySync(normalized)
+    await NameRegistryState.retrieve(connection, pubkey)
+  } catch (e) {
+    if (e instanceof AccountDoesNotExistError) {
+      const result = new NotFound('domain')
+      cache.set(normalized, result)
+      return result
+    }
+    throw new NetworkError(
+      `SNS domain lookup failed: ${(e as Error).message ?? 'unknown error'}`,
+      e,
+    )
+  }
+
+  // Step 2: fetch the SIP-STEALTH record. `deserialize: true` returns the
+  // record content as a UTF-8 string directly.
+  let raw: string | undefined
+  try {
+    raw = await getRecord(connection, normalized, SIP_STEALTH_RECORD, true)
+  } catch (e) {
+    if (
+      e instanceof AccountDoesNotExistError ||
+      e instanceof NoRecordDataError
+    ) {
+      const result = new NotFound('record')
+      cache.set(normalized, result)
+      return result
+    }
+    throw new NetworkError(
+      `SNS record lookup failed: ${(e as Error).message ?? 'unknown error'}`,
+      e,
+    )
+  }
+
+  if (raw === undefined) {
+    const result = new NotFound('record')
+    cache.set(normalized, result)
+    return result
+  }
+
+  const parsed = parseRecord(raw)
+  if (!parsed.ok) {
+    const result = new Malformed(parsed.reason, parsed.error)
+    cache.set(normalized, result)
+    return result
+  }
+
+  const meta = new MetaAddress(
+    hexToBytes(parsed.data.spending),
+    hexToBytes(parsed.data.viewing),
+    'solana',
+    normalized,
+  )
+  cache.set(normalized, meta)
+  return meta
+}
+
+export function invalidateCache(domain?: string): void {
+  if (domain === undefined) {
+    cache.clear()
+    return
+  }
+  cache.invalidate(normalizeDomain(domain))
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  }
+  return out
+}

--- a/packages/sns-stealth/src/resolve.ts
+++ b/packages/sns-stealth/src/resolve.ts
@@ -57,7 +57,7 @@ export async function resolveSIPStealth(
       return result
     }
     throw new NetworkError(
-      `SNS domain lookup failed: ${(e as Error).message ?? 'unknown error'}`,
+      `SNS domain lookup failed: ${e instanceof Error ? e.message : String(e)}`,
       e,
     )
   }
@@ -77,7 +77,7 @@ export async function resolveSIPStealth(
       return result
     }
     throw new NetworkError(
-      `SNS record lookup failed: ${(e as Error).message ?? 'unknown error'}`,
+      `SNS record lookup failed: ${e instanceof Error ? e.message : String(e)}`,
       e,
     )
   }
@@ -113,6 +113,8 @@ export function invalidateCache(domain?: string): void {
   cache.invalidate(normalizeDomain(domain))
 }
 
+// Input is validated upstream by the Zod `Hex32` regex (`^[0-9a-f]{64}$`),
+// so we trust even length + valid hex chars here. No defensive guards.
 function hexToBytes(hex: string): Uint8Array {
   const out = new Uint8Array(hex.length / 2)
   for (let i = 0; i < out.length; i++) {

--- a/packages/sns-stealth/src/schema.ts
+++ b/packages/sns-stealth/src/schema.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+
+const Hex32 = z.string().regex(/^[0-9a-f]{64}$/)
+
+export const SIPStealthRecordV1 = z.object({
+  v: z.literal(1),
+  spending: Hex32,
+  viewing: Hex32,
+})
+
+export type SIPStealthRecord = z.infer<typeof SIPStealthRecordV1>
+
+export type ParseResult =
+  | { ok: true; data: SIPStealthRecord }
+  | { ok: false; reason: 'json-parse'; error: unknown }
+  | { ok: false; reason: 'schema'; error: z.ZodError }
+
+export function parseRecord(raw: string): ParseResult {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (error) {
+    return { ok: false, reason: 'json-parse', error }
+  }
+
+  const result = SIPStealthRecordV1.safeParse(parsed)
+  if (!result.success) {
+    return { ok: false, reason: 'schema', error: result.error }
+  }
+  return { ok: true, data: result.data }
+}
+
+export function encodeRecord(record: SIPStealthRecord): string {
+  // Canonical JSON: stable key order, no whitespace.
+  return JSON.stringify({
+    v: record.v,
+    spending: record.spending,
+    viewing: record.viewing,
+  })
+}

--- a/packages/sns-stealth/tests/cache.test.ts
+++ b/packages/sns-stealth/tests/cache.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { TTLCache } from '../src/cache'
+
+describe('TTLCache', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  it('returns undefined on miss', () => {
+    const cache = new TTLCache<string>(1000)
+    expect(cache.get('nope')).toBeUndefined()
+  })
+
+  it('returns value within TTL', () => {
+    const cache = new TTLCache<string>(1000)
+    cache.set('key', 'value')
+    expect(cache.get('key')).toBe('value')
+  })
+
+  it('expires after TTL', () => {
+    const cache = new TTLCache<string>(1000)
+    cache.set('key', 'value')
+    vi.advanceTimersByTime(1001)
+    expect(cache.get('key')).toBeUndefined()
+  })
+
+  it('invalidates explicitly', () => {
+    const cache = new TTLCache<string>(1000)
+    cache.set('key', 'value')
+    cache.invalidate('key')
+    expect(cache.get('key')).toBeUndefined()
+  })
+
+  it('clears all entries', () => {
+    const cache = new TTLCache<string>(1000)
+    cache.set('a', '1')
+    cache.set('b', '2')
+    cache.clear()
+    expect(cache.get('a')).toBeUndefined()
+    expect(cache.get('b')).toBeUndefined()
+  })
+
+  it('per-entry TTL overrides default', () => {
+    const cache = new TTLCache<string>(1000)
+    cache.set('short', 'v', 500)
+    vi.advanceTimersByTime(600)
+    expect(cache.get('short')).toBeUndefined()
+  })
+})

--- a/packages/sns-stealth/tests/derive.test.ts
+++ b/packages/sns-stealth/tests/derive.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { deriveStealthKeys, normalizeDomain, deriveSeed } from '../src/derive'
+import { sha256 } from '@noble/hashes/sha2'
+import { utf8ToBytes, bytesToHex } from '@noble/hashes/utils'
+
+// Mock signer: returns deterministic "signature" = sha256(label || message)
+const mockSigner = (label: string) => ({
+  signMessage: async (msg: Uint8Array) => {
+    return sha256(new Uint8Array([...utf8ToBytes(label), ...msg]))
+  },
+})
+
+describe('normalizeDomain', () => {
+  it('lowercases', () => {
+    expect(normalizeDomain('RECTOR.sol')).toBe('rector.sol')
+  })
+
+  it('strips trailing dot', () => {
+    expect(normalizeDomain('rector.sol.')).toBe('rector.sol')
+  })
+
+  it('handles already-normalized', () => {
+    expect(normalizeDomain('rector.sol')).toBe('rector.sol')
+  })
+
+  it('handles subdomain', () => {
+    expect(normalizeDomain('AUDITOR.Rector.sol')).toBe('auditor.rector.sol')
+  })
+})
+
+describe('deriveSeed', () => {
+  it('produces 32-byte seed', () => {
+    const sig = new Uint8Array(64).fill(1)
+    expect(deriveSeed(sig, 'spending')).toHaveLength(32)
+  })
+
+  it('spending and viewing seeds differ for same signature', () => {
+    const sig = new Uint8Array(64).fill(1)
+    const sp = bytesToHex(deriveSeed(sig, 'spending'))
+    const vw = bytesToHex(deriveSeed(sig, 'viewing'))
+    expect(sp).not.toBe(vw)
+  })
+})
+
+describe('deriveStealthKeys', () => {
+  it('produces 32-byte spending and viewing pubkeys', async () => {
+    const wallet = mockSigner('alice')
+    const keys = await deriveStealthKeys(wallet, 'rector.sol')
+    expect(keys.spending).toHaveLength(32)
+    expect(keys.viewing).toHaveLength(32)
+  })
+
+  it('is deterministic for same (wallet, domain)', async () => {
+    const wallet = mockSigner('alice')
+    const a = await deriveStealthKeys(wallet, 'rector.sol')
+    const b = await deriveStealthKeys(wallet, 'rector.sol')
+    expect(bytesToHex(a.spending)).toBe(bytesToHex(b.spending))
+    expect(bytesToHex(a.viewing)).toBe(bytesToHex(b.viewing))
+  })
+
+  it('produces different keys for different domains (per-domain uniqueness)', async () => {
+    const wallet = mockSigner('alice')
+    const a = await deriveStealthKeys(wallet, 'rector.sol')
+    const b = await deriveStealthKeys(wallet, 'sipher.sol')
+    expect(bytesToHex(a.spending)).not.toBe(bytesToHex(b.spending))
+    expect(bytesToHex(a.viewing)).not.toBe(bytesToHex(b.viewing))
+  })
+
+  it('produces different keys for different wallets', async () => {
+    const a = await deriveStealthKeys(mockSigner('alice'), 'rector.sol')
+    const b = await deriveStealthKeys(mockSigner('bob'), 'rector.sol')
+    expect(bytesToHex(a.spending)).not.toBe(bytesToHex(b.spending))
+  })
+
+  it('normalizes domain before signing', async () => {
+    const wallet = mockSigner('alice')
+    const a = await deriveStealthKeys(wallet, 'rector.sol')
+    const b = await deriveStealthKeys(wallet, 'RECTOR.SOL')
+    expect(bytesToHex(a.spending)).toBe(bytesToHex(b.spending))
+  })
+})

--- a/packages/sns-stealth/tests/errors.test.ts
+++ b/packages/sns-stealth/tests/errors.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import {
+  NotFound,
+  Malformed,
+  NetworkError,
+  UserRejected,
+  OnChainError,
+} from '../src/errors'
+
+describe('NotFound', () => {
+  it('discriminates on subject', () => {
+    const e = new NotFound('domain')
+    expect(e.subject).toBe('domain')
+    expect(e).toBeInstanceOf(NotFound)
+    expect(e.name).toBe('NotFound')
+  })
+
+  it('accepts record subject', () => {
+    expect(new NotFound('record').subject).toBe('record')
+  })
+})
+
+describe('Malformed', () => {
+  it('captures reason and cause', () => {
+    const cause = new Error('parse failure')
+    const e = new Malformed('json-parse', cause)
+    expect(e.reason).toBe('json-parse')
+    expect(e.cause).toBe(cause)
+  })
+
+  it('supports schema reason', () => {
+    const e = new Malformed('schema')
+    expect(e.reason).toBe('schema')
+  })
+})
+
+describe('NetworkError', () => {
+  it('wraps underlying transport error', () => {
+    const inner = new Error('connection refused')
+    const e = new NetworkError('rpc unreachable', inner)
+    expect(e.cause).toBe(inner)
+    expect(e.message).toContain('rpc unreachable')
+  })
+})
+
+describe('UserRejected and OnChainError', () => {
+  it('are distinct constructors', () => {
+    expect(new UserRejected()).toBeInstanceOf(UserRejected)
+    expect(new OnChainError('signature', 'tx failed')).toBeInstanceOf(OnChainError)
+    expect(new UserRejected()).not.toBeInstanceOf(OnChainError)
+  })
+
+  it('OnChainError exposes signature', () => {
+    const e = new OnChainError('abc123', 'tx failed')
+    expect(e.signature).toBe('abc123')
+  })
+})

--- a/packages/sns-stealth/tests/integration.test.ts
+++ b/packages/sns-stealth/tests/integration.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { Connection, Keypair, sendAndConfirmTransaction } from '@solana/web3.js'
+import { ed25519 } from '@noble/curves/ed25519'
+import { readFileSync, existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import {
+  resolveSIPStealth,
+  buildPublishTx,
+  deriveStealthKeys,
+  MetaAddress,
+  invalidateCache,
+} from '../src/index'
+
+// Devnet round-trip integration test.
+//
+// Skips automatically when:
+//   - The shared devnet keypair is not on disk (CI / contributors without it)
+//   - `SIP_SKIP_INTEGRATION=1` is set (local opt-out for fast iteration)
+//
+// When it runs, it exercises the full public API surface — derive → publish →
+// resolve — against a real .sol domain. The test domain must already be
+// provisioned (owned by the devnet wallet) on Bonfida's devnet UI; if not, the
+// publish step will fail at `sendAndConfirmTransaction`. We do NOT try to
+// register the domain here — that's a one-time setup the operator handles.
+
+const RPC = process.env.SOLANA_DEVNET_RPC ?? 'https://api.devnet.solana.com'
+const TEST_DOMAIN = process.env.SIP_TEST_DOMAIN ?? 'test.sipher.sol'
+const KEYPAIR_PATH = `${homedir()}/Documents/secret/solana-devnet.json`
+
+const skipReason = (): string | false => {
+  if (!existsSync(KEYPAIR_PATH)) return 'no devnet keypair'
+  if (process.env.SIP_SKIP_INTEGRATION === '1') return 'SIP_SKIP_INTEGRATION=1'
+  return false
+}
+
+describe.skipIf(skipReason() !== false)('integration: devnet round-trip', () => {
+  let connection: Connection
+  let payer: Keypair
+
+  beforeAll(() => {
+    connection = new Connection(RPC, 'confirmed')
+    const secret = JSON.parse(readFileSync(KEYPAIR_PATH, 'utf8'))
+    payer = Keypair.fromSecretKey(new Uint8Array(secret))
+  })
+
+  it('publishes and resolves a SIP-STEALTH record', async () => {
+    // Solana `Keypair.secretKey` is the 64-byte expanded form (seed || pubkey).
+    // `@noble/curves` `ed25519.sign` expects the 32-byte seed, so we slice.
+    const seed = payer.secretKey.slice(0, 32)
+    const signer = {
+      signMessage: async (msg: Uint8Array): Promise<Uint8Array> =>
+        ed25519.sign(msg, seed),
+    }
+
+    const keys = await deriveStealthKeys(signer, TEST_DOMAIN)
+
+    const tx = await buildPublishTx(
+      connection,
+      TEST_DOMAIN,
+      { spending: keys.spending, viewing: keys.viewing },
+      payer.publicKey,
+    )
+
+    const sig = await sendAndConfirmTransaction(connection, tx, [payer])
+    expect(sig).toBeTruthy()
+
+    // Bypass the 60s TTL cache so we read fresh state after publishing.
+    invalidateCache(TEST_DOMAIN)
+    const result = await resolveSIPStealth(connection, TEST_DOMAIN)
+
+    expect(result).toBeInstanceOf(MetaAddress)
+    if (result instanceof MetaAddress) {
+      expect(Buffer.from(result.spending).equals(Buffer.from(keys.spending))).toBe(true)
+      expect(Buffer.from(result.viewing).equals(Buffer.from(keys.viewing))).toBe(true)
+      expect(result.chain).toBe('solana')
+      expect(result.domain).toBe(TEST_DOMAIN.toLowerCase())
+    }
+  }, 60_000)
+})

--- a/packages/sns-stealth/tests/publish.test.ts
+++ b/packages/sns-stealth/tests/publish.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Connection, PublicKey, Transaction, TransactionInstruction, SystemProgram } from '@solana/web3.js'
+import { bytesToHex } from '@noble/hashes/utils'
+
+// Mock the Bonfida API surface we use:
+//   - createRecordInstruction: async (connection, domain, record, data, owner, payer) => TransactionInstruction
+// The SDK derives a PDA for the subdomain <RECORD>.<DOMAIN> and returns a single
+// `createInstruction` against the SNS program. We don't care about its internal
+// shape — only that buildPublishTx passes the right arguments and produces a
+// well-formed Transaction.
+vi.mock('@bonfida/spl-name-service', () => ({
+  createRecordInstruction: vi.fn(),
+}))
+
+import { createRecordInstruction } from '@bonfida/spl-name-service'
+import { buildPublishTx } from '../src/publish'
+
+const mockBlockhash = 'EkSnNWid2cYwsbqzdGyaDkjyAa3pYBtjwjsJqDxN1RfV'
+const mockConnection = {
+  getLatestBlockhash: vi.fn(),
+} as unknown as Connection
+
+// A valid base58 PublicKey for tests
+const payer = new PublicKey('11111111111111111111111111111111')
+
+// Build a no-op TransactionInstruction we can return from the mocked SDK call.
+// SystemProgram.transfer gives us a real, valid instruction without any side
+// effects when we add it to a Transaction.
+const noopIx = (): TransactionInstruction =>
+  SystemProgram.transfer({
+    fromPubkey: payer,
+    toPubkey: payer,
+    lamports: 0,
+  })
+
+describe('buildPublishTx', () => {
+  beforeEach(() => {
+    vi.mocked(createRecordInstruction).mockReset()
+    vi.mocked(createRecordInstruction).mockResolvedValue(noopIx())
+    vi.mocked(mockConnection.getLatestBlockhash).mockReset()
+    vi.mocked(mockConnection.getLatestBlockhash).mockResolvedValue({
+      blockhash: mockBlockhash,
+      lastValidBlockHeight: 100,
+    })
+  })
+
+  it('builds a Transaction with the publisher set as fee payer and a fresh blockhash', async () => {
+    const keys = {
+      spending: new Uint8Array(32).fill(1),
+      viewing: new Uint8Array(32).fill(2),
+    }
+
+    const tx = await buildPublishTx(mockConnection, 'rector.sol', keys, payer)
+
+    expect(tx).toBeInstanceOf(Transaction)
+    expect(tx.feePayer?.toBase58()).toBe(payer.toBase58())
+    expect(tx.recentBlockhash).toBe(mockBlockhash)
+    expect(tx.instructions).toHaveLength(1)
+  })
+
+  it('normalizes the domain before writing the record', async () => {
+    const keys = {
+      spending: new Uint8Array(32).fill(1),
+      viewing: new Uint8Array(32).fill(2),
+    }
+
+    await buildPublishTx(mockConnection, 'RECTOR.SOL', keys, payer)
+
+    const callArgs = vi.mocked(createRecordInstruction).mock.calls.at(-1)!
+    expect(callArgs[1]).toBe('rector.sol')
+  })
+
+  it('encodes the record as canonical JSON with hex-encoded keys', async () => {
+    const keys = {
+      spending: new Uint8Array(32).fill(0xaa),
+      viewing: new Uint8Array(32).fill(0xbb),
+    }
+
+    await buildPublishTx(mockConnection, 'rector.sol', keys, payer)
+
+    const callArgs = vi.mocked(createRecordInstruction).mock.calls.at(-1)!
+    const recordValue = callArgs[3]
+    // Canonical JSON: stable key order, no whitespace.
+    expect(recordValue).toBe(
+      `{"v":1,"spending":"${bytesToHex(keys.spending)}","viewing":"${bytesToHex(keys.viewing)}"}`,
+    )
+  })
+
+  it('passes the SIP-STEALTH record key and uses payer for both owner and fee payer', async () => {
+    const keys = {
+      spending: new Uint8Array(32).fill(1),
+      viewing: new Uint8Array(32).fill(2),
+    }
+
+    await buildPublishTx(mockConnection, 'rector.sol', keys, payer)
+
+    const callArgs = vi.mocked(createRecordInstruction).mock.calls.at(-1)!
+    // Args: (connection, domain, record, data, owner, payer)
+    expect(callArgs[0]).toBe(mockConnection)
+    expect(callArgs[2]).toBe('SIP-STEALTH')
+    // Owner and payer default to the same caller — self-publish flow.
+    expect((callArgs[4] as PublicKey).toBase58()).toBe(payer.toBase58())
+    expect((callArgs[5] as PublicKey).toBase58()).toBe(payer.toBase58())
+  })
+
+  it('rejects non-32-byte spending key', async () => {
+    const keys = {
+      spending: new Uint8Array(20),
+      viewing: new Uint8Array(32),
+    }
+    await expect(buildPublishTx(mockConnection, 'rector.sol', keys, payer))
+      .rejects.toThrow(/spending key must be 32 bytes/i)
+    expect(createRecordInstruction).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-32-byte viewing key', async () => {
+    const keys = {
+      spending: new Uint8Array(32),
+      viewing: new Uint8Array(33),
+    }
+    await expect(buildPublishTx(mockConnection, 'rector.sol', keys, payer))
+      .rejects.toThrow(/viewing key must be 32 bytes/i)
+    expect(createRecordInstruction).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sns-stealth/tests/resolve.test.ts
+++ b/packages/sns-stealth/tests/resolve.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Connection } from '@solana/web3.js'
+import { resolveSIPStealth, MetaAddress, invalidateCache } from '../src/resolve'
+import { NotFound, Malformed } from '../src/errors'
+
+// Mock the Bonfida API surface we use:
+//   - getRecord (v1 records, with deserialize:true returns the raw JSON string)
+//   - getDomainKeySync (sync, returns { pubkey, ... })
+//   - NameRegistryState.retrieve (async, throws AccountDoesNotExistError if domain missing)
+//   - AccountDoesNotExistError / NoRecordDataError (error classes used for branch matching)
+vi.mock('@bonfida/spl-name-service', () => {
+  class AccountDoesNotExistError extends Error {
+    readonly type = 'AccountDoesNotExist'
+    constructor(message: string) {
+      super(message)
+      this.name = 'SNSError'
+    }
+  }
+  class NoRecordDataError extends Error {
+    readonly type = 'NoRecordData'
+    constructor(message: string) {
+      super(message)
+      this.name = 'SNSError'
+    }
+  }
+  return {
+    AccountDoesNotExistError,
+    NoRecordDataError,
+    getRecord: vi.fn(),
+    getDomainKeySync: vi.fn(() => ({ pubkey: { toBase58: () => 'fake' } })),
+    NameRegistryState: {
+      retrieve: vi.fn(),
+    },
+  }
+})
+
+import {
+  getRecord,
+  NameRegistryState,
+  AccountDoesNotExistError,
+  NoRecordDataError,
+} from '@bonfida/spl-name-service'
+
+const mockConnection = {} as Connection
+const validHex = 'a'.repeat(64)
+
+describe('resolveSIPStealth', () => {
+  beforeEach(() => {
+    vi.mocked(getRecord).mockReset()
+    vi.mocked(NameRegistryState.retrieve).mockReset()
+    // Default: domain exists (NameRegistryState.retrieve succeeds).
+    vi.mocked(NameRegistryState.retrieve).mockResolvedValue({} as never)
+    invalidateCache()
+  })
+
+  it('returns MetaAddress on valid record', async () => {
+    vi.mocked(getRecord).mockResolvedValueOnce(
+      JSON.stringify({ v: 1, spending: validHex, viewing: validHex }),
+    )
+
+    const result = await resolveSIPStealth(mockConnection, 'rector.sol')
+
+    expect(result).toBeInstanceOf(MetaAddress)
+    if (result instanceof MetaAddress) {
+      expect(result.domain).toBe('rector.sol')
+      expect(result.chain).toBe('solana')
+      expect(result.spending).toHaveLength(32)
+      expect(result.viewing).toHaveLength(32)
+    }
+  })
+
+  it('returns NotFound("domain") when domain does not exist', async () => {
+    vi.mocked(NameRegistryState.retrieve).mockRejectedValueOnce(
+      new AccountDoesNotExistError('The name account does not exist'),
+    )
+
+    const result = await resolveSIPStealth(mockConnection, 'nonexistent.sol')
+
+    expect(result).toBeInstanceOf(NotFound)
+    if (result instanceof NotFound) expect(result.subject).toBe('domain')
+  })
+
+  it('returns NotFound("record") when AccountDoesNotExistError on record fetch', async () => {
+    vi.mocked(getRecord).mockRejectedValueOnce(
+      new AccountDoesNotExistError('The name account does not exist'),
+    )
+
+    const result = await resolveSIPStealth(mockConnection, 'rector.sol')
+
+    expect(result).toBeInstanceOf(NotFound)
+    if (result instanceof NotFound) expect(result.subject).toBe('record')
+  })
+
+  it('returns NotFound("record") when NoRecordDataError on record fetch', async () => {
+    vi.mocked(getRecord).mockRejectedValueOnce(
+      new NoRecordDataError('The record data is empty'),
+    )
+
+    const result = await resolveSIPStealth(mockConnection, 'rector.sol')
+
+    expect(result).toBeInstanceOf(NotFound)
+    if (result instanceof NotFound) expect(result.subject).toBe('record')
+  })
+
+  it('returns Malformed on bad JSON', async () => {
+    vi.mocked(getRecord).mockResolvedValueOnce('{not json}')
+
+    const result = await resolveSIPStealth(mockConnection, 'rector.sol')
+
+    expect(result).toBeInstanceOf(Malformed)
+    if (result instanceof Malformed) expect(result.reason).toBe('json-parse')
+  })
+
+  it('returns Malformed on schema mismatch', async () => {
+    vi.mocked(getRecord).mockResolvedValueOnce(
+      JSON.stringify({ v: 99, spending: 'x', viewing: 'y' }),
+    )
+
+    const result = await resolveSIPStealth(mockConnection, 'rector.sol')
+
+    expect(result).toBeInstanceOf(Malformed)
+    if (result instanceof Malformed) expect(result.reason).toBe('schema')
+  })
+
+  it('normalizes domain before lookup', async () => {
+    vi.mocked(getRecord).mockResolvedValueOnce(
+      JSON.stringify({ v: 1, spending: validHex, viewing: validHex }),
+    )
+
+    await resolveSIPStealth(mockConnection, 'RECTOR.SOL')
+
+    const callArgs = vi.mocked(getRecord).mock.calls[0]
+    expect(callArgs[1]).toBe('rector.sol')
+  })
+
+  it('uses cache on second call within TTL (same reference)', async () => {
+    vi.mocked(getRecord).mockResolvedValueOnce(
+      JSON.stringify({ v: 1, spending: validHex, viewing: validHex }),
+    )
+
+    const a = await resolveSIPStealth(mockConnection, 'rector.sol')
+    const b = await resolveSIPStealth(mockConnection, 'rector.sol')
+
+    expect(a).toBe(b)
+    expect(getRecord).toHaveBeenCalledTimes(1)
+  })
+
+  it('invalidateCache(domain) forces re-fetch', async () => {
+    vi.mocked(getRecord)
+      .mockResolvedValueOnce(
+        JSON.stringify({ v: 1, spending: validHex, viewing: validHex }),
+      )
+      .mockResolvedValueOnce(
+        JSON.stringify({ v: 1, spending: 'b'.repeat(64), viewing: validHex }),
+      )
+
+    const a = await resolveSIPStealth(mockConnection, 'rector.sol')
+    invalidateCache('rector.sol')
+    const b = await resolveSIPStealth(mockConnection, 'rector.sol')
+
+    expect(a).not.toBe(b)
+    expect(getRecord).toHaveBeenCalledTimes(2)
+  })
+
+  it('invalidateCache() with no args clears all entries', async () => {
+    vi.mocked(getRecord)
+      .mockResolvedValueOnce(
+        JSON.stringify({ v: 1, spending: validHex, viewing: validHex }),
+      )
+      .mockResolvedValueOnce(
+        JSON.stringify({ v: 1, spending: validHex, viewing: 'c'.repeat(64) }),
+      )
+      .mockResolvedValueOnce(
+        JSON.stringify({ v: 1, spending: 'd'.repeat(64), viewing: validHex }),
+      )
+
+    const a = await resolveSIPStealth(mockConnection, 'alice.sol')
+    const b = await resolveSIPStealth(mockConnection, 'bob.sol')
+    invalidateCache()
+    const aAgain = await resolveSIPStealth(mockConnection, 'alice.sol')
+
+    expect(a).not.toBe(aAgain)
+    // alice + bob + alice-again = 3 fetches
+    expect(getRecord).toHaveBeenCalledTimes(3)
+    // sanity: b was cached before clear, fresh fetch wouldn't be triggered
+    void b
+  })
+})

--- a/packages/sns-stealth/tests/resolve.test.ts
+++ b/packages/sns-stealth/tests/resolve.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { Connection } from '@solana/web3.js'
 import { resolveSIPStealth, MetaAddress, invalidateCache } from '../src/resolve'
-import { NotFound, Malformed } from '../src/errors'
+import { NotFound, Malformed, NetworkError } from '../src/errors'
 
 // Mock the Bonfida API surface we use:
 //   - getRecord (v1 records, with deserialize:true returns the raw JSON string)
@@ -156,6 +156,44 @@ describe('resolveSIPStealth', () => {
 
     const a = await resolveSIPStealth(mockConnection, 'rector.sol')
     invalidateCache('rector.sol')
+    const b = await resolveSIPStealth(mockConnection, 'rector.sol')
+
+    expect(a).not.toBe(b)
+    expect(getRecord).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws NetworkError on unexpected error during domain probe', async () => {
+    vi.mocked(NameRegistryState.retrieve).mockRejectedValueOnce(
+      new Error('connection reset'),
+    )
+
+    await expect(resolveSIPStealth(mockConnection, 'rector.sol'))
+      .rejects.toThrow(NetworkError)
+  })
+
+  it('throws NetworkError on unexpected error during record fetch', async () => {
+    vi.mocked(getRecord).mockRejectedValueOnce(
+      new Error('rpc timeout'),
+    )
+
+    await expect(resolveSIPStealth(mockConnection, 'rector.sol'))
+      .rejects.toThrow(NetworkError)
+  })
+
+  it('invalidateCache normalizes the domain argument', async () => {
+    vi.mocked(getRecord)
+      .mockResolvedValueOnce(
+        JSON.stringify({ v: 1, spending: validHex, viewing: validHex }),
+      )
+      .mockResolvedValueOnce(
+        JSON.stringify({ v: 1, spending: 'e'.repeat(64), viewing: validHex }),
+      )
+
+    // Cache stores under normalized key 'rector.sol'
+    const a = await resolveSIPStealth(mockConnection, 'rector.sol')
+    // Invalidate with non-normalized argument
+    invalidateCache('RECTOR.SOL.')
+    // Next lookup should bypass cache and re-fetch
     const b = await resolveSIPStealth(mockConnection, 'rector.sol')
 
     expect(a).not.toBe(b)

--- a/packages/sns-stealth/tests/schema.test.ts
+++ b/packages/sns-stealth/tests/schema.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { SIPStealthRecordV1, parseRecord } from '../src/schema'
+
+const validHex = 'a'.repeat(64)
+
+describe('SIPStealthRecordV1', () => {
+  it('accepts a valid v1 record', () => {
+    const result = SIPStealthRecordV1.safeParse({
+      v: 1,
+      spending: validHex,
+      viewing: validHex,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing v', () => {
+    const result = SIPStealthRecordV1.safeParse({
+      spending: validHex,
+      viewing: validHex,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects v=2 (forward-incompatible)', () => {
+    const result = SIPStealthRecordV1.safeParse({
+      v: 2,
+      spending: validHex,
+      viewing: validHex,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects non-hex spending key', () => {
+    const result = SIPStealthRecordV1.safeParse({
+      v: 1,
+      spending: 'g'.repeat(64),
+      viewing: validHex,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects wrong-length viewing key', () => {
+    const result = SIPStealthRecordV1.safeParse({
+      v: 1,
+      spending: validHex,
+      viewing: 'a'.repeat(63),
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects uppercase hex (must be lowercase)', () => {
+    const result = SIPStealthRecordV1.safeParse({
+      v: 1,
+      spending: 'A'.repeat(64),
+      viewing: validHex,
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('parseRecord', () => {
+  it('parses a valid JSON record', () => {
+    const json = JSON.stringify({ v: 1, spending: validHex, viewing: validHex })
+    const result = parseRecord(json)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.v).toBe(1)
+    }
+  })
+
+  it('returns json-parse error for malformed JSON', () => {
+    const result = parseRecord('{not json}')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('json-parse')
+  })
+
+  it('returns schema error for invalid record', () => {
+    const json = JSON.stringify({ v: 1, spending: 'bad' })
+    const result = parseRecord(json)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('schema')
+  })
+})

--- a/packages/sns-stealth/tsconfig.json
+++ b/packages/sns-stealth/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "incremental": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,6 +407,34 @@ importers:
         specifier: ^1.1.0
         version: 1.6.1(@types/node@25.2.3)(jsdom@27.4.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(terser@5.46.0)
 
+  packages/sns-stealth:
+    dependencies:
+      '@bonfida/spl-name-service':
+        specifier: ^3.0.21
+        version: 3.0.21(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@noble/curves':
+        specifier: ^1.3.0
+        version: 1.9.7
+      '@noble/hashes':
+        specifier: ^1.3.3
+        version: 1.8.0
+      '@solana/web3.js':
+        specifier: ^1.98.4
+        version: 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      zod:
+        specifier: ^4.3.5
+        version: 4.3.5
+    devDependencies:
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.1.0
+        version: 1.6.1(@types/node@25.2.3)(jsdom@27.4.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(terser@5.46.0)
+
   packages/types:
     devDependencies:
       tsup:
@@ -637,6 +665,16 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@bonfida/sns-records@0.1.0':
+    resolution: {integrity: sha512-/viuqvsjvAUjFxzqX0L3ZntfK1S5K1Nj+j2avxq2tCXhA2Ee7Qt0gPCaQKuMv3hh8cKAEMaZ8crZHomns3UuqA==}
+    peerDependencies:
+      '@solana/web3.js': ^1.87.3
+
+  '@bonfida/spl-name-service@3.0.21':
+    resolution: {integrity: sha512-dYKZwG2ColaDUvX+ZrzcPtE6sQcNNwXywMsLit57Z+bKSEYQdIFxncrDSSzjLKcxQRFPUQObptaSEcv+ZwcMQA==}
+    peerDependencies:
+      '@solana/web3.js': ^1.98.2
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
@@ -1595,6 +1633,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
   '@scure/base@2.0.0':
     resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
 
@@ -1709,6 +1750,9 @@ packages:
     resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
     engines: {node: '>=5.10'}
 
+  '@solana/codecs-core@2.0.0-preview.2':
+    resolution: {integrity: sha512-gLhCJXieSCrAU7acUJjbXl+IbGnqovvxQLlimztPoGgfLQ1wFYu+XJswrEVQqknZYK1pgxpxH3rZ+OKFs0ndQg==}
+
   '@solana/codecs-core@2.0.0-rc.1':
     resolution: {integrity: sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==}
     peerDependencies:
@@ -1729,6 +1773,9 @@ packages:
       typescript:
         optional: true
 
+  '@solana/codecs-data-structures@2.0.0-preview.2':
+    resolution: {integrity: sha512-Xf5vIfromOZo94Q8HbR04TbgTwzigqrKII0GjYr21K7rb3nba4hUW2ir8kguY7HWFBcjHGlU5x3MevKBOLp3Zg==}
+
   '@solana/codecs-data-structures@2.0.0-rc.1':
     resolution: {integrity: sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==}
     peerDependencies:
@@ -1742,6 +1789,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/codecs-numbers@2.0.0-preview.2':
+    resolution: {integrity: sha512-aLZnDTf43z4qOnpTcDsUVy1Ci9im1Md8thWipSWbE+WM9ojZAx528oAql+Cv8M8N+6ALKwgVRhPZkto6E59ARw==}
 
   '@solana/codecs-numbers@2.0.0-rc.1':
     resolution: {integrity: sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==}
@@ -1763,6 +1813,11 @@ packages:
       typescript:
         optional: true
 
+  '@solana/codecs-strings@2.0.0-preview.2':
+    resolution: {integrity: sha512-EgBwY+lIaHHgMJIqVOGHfIfpdmmUDNoNO/GAUGeFPf+q0dF+DtwhJPEMShhzh64X2MeCZcmSO6Kinx0Bvmmz2g==}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+
   '@solana/codecs-strings@2.0.0-rc.1':
     resolution: {integrity: sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==}
     peerDependencies:
@@ -1780,6 +1835,9 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  '@solana/codecs@2.0.0-preview.2':
+    resolution: {integrity: sha512-4HHzCD5+pOSmSB71X6w9ptweV48Zj1Vqhe732+pcAQ2cMNnN0gMPMdDq7j3YwaZDZ7yrILVV/3+HTnfT77t2yA==}
 
   '@solana/codecs@2.0.0-rc.1':
     resolution: {integrity: sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==}
@@ -1803,6 +1861,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/errors@2.0.0-preview.2':
+    resolution: {integrity: sha512-H2DZ1l3iYF5Rp5pPbJpmmtCauWeQXRJapkDg8epQ8BJ7cA2Ut/QEtC3CMmw/iMTcuS6uemFNLcWvlOfoQhvQuA==}
+    hasBin: true
 
   '@solana/errors@2.0.0-rc.1':
     resolution: {integrity: sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==}
@@ -1898,6 +1960,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/options@2.0.0-preview.2':
+    resolution: {integrity: sha512-FAHqEeH0cVsUOTzjl5OfUBw2cyT8d5Oekx4xcn5hn+NyPAfQJgM3CEThzgRD6Q/4mM5pVUnND3oK/Mt1RzSE/w==}
 
   '@solana/options@2.0.0-rc.1':
     resolution: {integrity: sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==}
@@ -2057,6 +2122,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/spl-token-group@0.0.4':
+    resolution: {integrity: sha512-7+80nrEMdUKlK37V6kOe024+T7J4nNss0F8LQ9OOPYdWCCfJmsGUzVx2W3oeizZR4IHM6N4yC9v1Xqwc3BTPWw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.91.6
+
   '@solana/spl-token-group@0.0.7':
     resolution: {integrity: sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==}
     engines: {node: '>=16'}
@@ -2074,6 +2145,16 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.95.5
+
+  '@solana/spl-token@0.4.6':
+    resolution: {integrity: sha512-1nCnUqfHVtdguFciVWaY/RKcQz1IF4b31jnKgAmjU9QVN1q7dRUkTEWJZgTYIEtsULjVnC9jRqlhgGN39WbKKA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.91.6
+
+  '@solana/spl-type-length-value@0.1.0':
+    resolution: {integrity: sha512-JBMGB0oR4lPttOZ5XiUGyvylwLQjt1CPJa6qQ5oM+MBCndfjz2TKKkw0eATlLLcYmq1jBVsNlJ2cD6ns2GR7lA==}
+    engines: {node: '>=16'}
 
   '@solana/subscribable@5.4.0':
     resolution: {integrity: sha512-72LmfNX7UENgA24sn/xjlWpPAOsrxkWb9DQhuPZxly/gq8rl/rvr7Xu9qBkvFF2po9XpdUrKlccqY4awvfpltA==}
@@ -2664,6 +2745,12 @@ packages:
 
   borsh@0.7.0:
     resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
+
+  borsh@1.0.0:
+    resolution: {integrity: sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==}
+
+  borsh@2.0.0:
+    resolution: {integrity: sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -3441,6 +3528,9 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  graphemesplit@2.6.0:
+    resolution: {integrity: sha512-rG9w2wAfkpg0DILa1pjnjNfucng3usON360shisqIMUBw/87pojcBSrHmeE4UwryAuBih7g8m1oilf5/u8EWdQ==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -3579,6 +3669,10 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
+    engines: {node: '>= 10'}
 
   is-docker@2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
@@ -3726,6 +3820,9 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-base64@3.7.8:
+    resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
   js-tiktoken@1.0.21:
     resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
@@ -4378,6 +4475,9 @@ packages:
 
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
+
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
 
   pako@2.1.0:
     resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
@@ -5091,6 +5191,9 @@ packages:
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
 
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -5277,6 +5380,9 @@ packages:
 
   undici-types@7.22.0:
     resolution: {integrity: sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw==}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
   unique-filename@2.0.1:
     resolution: {integrity: sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==}
@@ -5830,6 +5936,34 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@bonfida/sns-records@0.1.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      borsh: 1.0.0
+      bs58: 5.0.0
+      buffer: 6.0.3
+
+  '@bonfida/spl-name-service@3.0.21(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@bonfida/sns-records': 0.1.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@noble/curves': 1.9.7
+      '@scure/base': 1.2.6
+      '@solana/spl-token': 0.4.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      borsh: 2.0.0
+      buffer: 6.0.3
+      graphemesplit: 2.6.0
+      ipaddr.js: 2.4.0
+      punycode: 2.3.1
+    transitivePeerDependencies:
+      - bluebird
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
 
   '@cfworker/json-schema@4.1.1': {}
 
@@ -6875,6 +7009,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.53.3':
     optional: true
 
+  '@scure/base@1.2.6': {}
+
   '@scure/base@2.0.0': {}
 
   '@scure/bip32@2.0.1':
@@ -7046,6 +7182,10 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
+  '@solana/codecs-core@2.0.0-preview.2':
+    dependencies:
+      '@solana/errors': 2.0.0-preview.2
+
   '@solana/codecs-core@2.0.0-rc.1(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
@@ -7062,6 +7202,12 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@solana/codecs-data-structures@2.0.0-preview.2':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/codecs-numbers': 2.0.0-preview.2
+      '@solana/errors': 2.0.0-preview.2
+
   '@solana/codecs-data-structures@2.0.0-rc.1(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
@@ -7076,6 +7222,11 @@ snapshots:
       '@solana/errors': 5.4.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
+
+  '@solana/codecs-numbers@2.0.0-preview.2':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/errors': 2.0.0-preview.2
 
   '@solana/codecs-numbers@2.0.0-rc.1(typescript@5.9.3)':
     dependencies:
@@ -7096,6 +7247,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@solana/codecs-strings@2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/codecs-numbers': 2.0.0-preview.2
+      '@solana/errors': 2.0.0-preview.2
+      fastestsmallesttextencoderdecoder: 1.0.22
+
   '@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
@@ -7112,6 +7270,16 @@ snapshots:
     optionalDependencies:
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.9.3
+
+  '@solana/codecs@2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/codecs-data-structures': 2.0.0-preview.2
+      '@solana/codecs-numbers': 2.0.0-preview.2
+      '@solana/codecs-strings': 2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/options': 2.0.0-preview.2
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
 
   '@solana/codecs@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -7148,6 +7316,11 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/errors@2.0.0-preview.2':
+    dependencies:
+      chalk: 5.6.2
+      commander: 12.1.0
 
   '@solana/errors@2.0.0-rc.1(typescript@5.9.3)':
     dependencies:
@@ -7257,6 +7430,11 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/options@2.0.0-preview.2':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/codecs-numbers': 2.0.0-preview.2
 
   '@solana/options@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -7453,6 +7631,14 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/spl-token-group@0.0.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)':
+    dependencies:
+      '@solana/codecs': 2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/spl-type-length-value': 0.1.0
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/spl-token-group@0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -7485,6 +7671,27 @@ snapshots:
       - supports-color
       - typescript
       - utf-8-validate
+
+  '@solana/spl-token@0.4.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/spl-token-group': 0.0.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - bluebird
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@solana/spl-type-length-value@0.1.0':
+    dependencies:
+      buffer: 6.0.3
 
   '@solana/subscribable@5.4.0(typescript@5.9.3)':
     dependencies:
@@ -8258,6 +8465,10 @@ snapshots:
       bn.js: 5.2.2
       bs58: 4.0.1
       text-encoding-utf-8: 1.0.2
+
+  borsh@1.0.0: {}
+
+  borsh@2.0.0: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -9113,6 +9324,11 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  graphemesplit@2.6.0:
+    dependencies:
+      js-base64: 3.7.8
+      unicode-trie: 2.0.0
+
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
@@ -9259,6 +9475,8 @@ snapshots:
   ip-address@10.0.1: {}
 
   ipaddr.js@1.9.1: {}
+
+  ipaddr.js@2.4.0: {}
 
   is-docker@2.2.1: {}
 
@@ -9442,6 +9660,8 @@ snapshots:
       supports-color: 8.1.1
 
   joycon@3.1.1: {}
+
+  js-base64@3.7.8: {}
 
   js-tiktoken@1.0.21:
     dependencies:
@@ -10236,6 +10456,8 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  pako@0.2.9: {}
+
   pako@2.1.0: {}
 
   parent-module@1.0.1:
@@ -11029,6 +11251,8 @@ snapshots:
 
   throat@5.0.0: {}
 
+  tiny-inflate@1.0.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -11186,6 +11410,11 @@ snapshots:
   undici-types@7.16.0: {}
 
   undici-types@7.22.0: {}
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
 
   unique-filename@2.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,10 +310,10 @@ importers:
         version: 6.0.48
       '@langchain/core':
         specifier: ^0.3.30
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))
       '@langchain/openai':
         specifier: ^0.4.2
-        version: 0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+        version: 0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@magicblock-labs/ephemeral-rollups-sdk':
         specifier: ^0.8.5
         version: 0.8.5(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
@@ -370,7 +370,7 @@ importers:
         version: 4.0.2
       langchain:
         specifier: ^1.2.10
-        version: 1.2.10(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.25.1(zod@4.3.5))
+        version: 1.2.10(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.25.1(zod@4.3.5))
       pino:
         specifier: ^10.2.0
         version: 10.2.0
@@ -425,6 +425,9 @@ importers:
         specifier: ^4.3.5
         version: 4.3.5
     devDependencies:
+      '@vitest/coverage-v8':
+        specifier: 1.6.1
+        version: 1.6.1(vitest@1.6.1(@types/node@25.2.3)(jsdom@27.4.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(terser@5.46.0))
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -537,11 +540,6 @@ packages:
     resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.28.5':
-    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.28.6':
     resolution: {integrity: sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==}
     engines: {node: '>=6.0.0'}
@@ -649,10 +647,6 @@ packages:
 
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.28.5':
-    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.28.6':
@@ -5799,10 +5793,6 @@ snapshots:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
 
-  '@babel/parser@7.28.5':
-    dependencies:
-      '@babel/types': 7.28.6
-
   '@babel/parser@7.28.6':
     dependencies:
       '@babel/types': 7.28.6
@@ -5919,11 +5909,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.28.5':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.28.6':
     dependencies:
@@ -6401,14 +6386,14 @@ snapshots:
 
   '@jup-ag/api@6.0.48': {}
 
-  '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))':
+  '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.4.7(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))
+      langsmith: 0.4.7(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -6421,26 +6406,26 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
 
-  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))':
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.5.4(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@langchain/langgraph-sdk@1.5.4(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       p-queue: 9.1.0
       p-retry: 7.1.1
       uuid: 13.0.0
     optionalDependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@langchain/langgraph@1.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.25.1(zod@4.3.5))(zod@4.3.5)':
+  '@langchain/langgraph@1.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.25.1(zod@4.3.5))(zod@4.3.5)':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))
-      '@langchain/langgraph-sdk': 1.5.4(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))
+      '@langchain/langgraph-sdk': 1.5.4(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       uuid: 10.0.0
       zod: 4.3.5
     optionalDependencies:
@@ -6449,11 +6434,11 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))
       js-tiktoken: 1.0.21
-      openai: 4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      openai: 4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
@@ -9736,12 +9721,12 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  langchain@1.2.10(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.25.1(zod@4.3.5)):
+  langchain@1.2.10(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.25.1(zod@4.3.5)):
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))
-      '@langchain/langgraph': 1.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.25.1(zod@4.3.5))(zod@4.3.5)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))
-      langsmith: 0.4.7(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))
+      '@langchain/langgraph': 1.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.25.1(zod@4.3.5))(zod@4.3.5)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)))
+      langsmith: 0.4.7(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5))
       uuid: 10.0.0
       zod: 4.3.5
     transitivePeerDependencies:
@@ -9753,7 +9738,7 @@ snapshots:
       - react-dom
       - zod-to-json-schema
 
-  langsmith@0.4.7(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)):
+  langsmith@0.4.7(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -9764,7 +9749,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/sdk-trace-base': 2.4.0(@opentelemetry/api@1.9.0)
-      openai: 4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)
+      openai: 4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)
 
   leven@3.1.0: {}
 
@@ -9853,13 +9838,13 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
 
   make-fetch-happen@10.2.1:
     dependencies:
@@ -10335,7 +10320,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
+  openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -10345,12 +10330,12 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0(encoding@0.1.13)
     optionalDependencies:
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
 
-  openai@4.104.0(encoding@0.1.13)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5):
+  openai@4.104.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -10360,7 +10345,7 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0(encoding@0.1.13)
     optionalDependencies:
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod: 4.3.5
     transitivePeerDependencies:
       - encoding


### PR DESCRIPTION
## Summary

- New monorepo package `@sip-protocol/sns-stealth` — Phase A of the sip.sol foundation
- Resolves and publishes `SIP-STEALTH` SNS records so `.sol` names work as private payment recipients
- Per-domain DKSAP key derivation via HKDF-SHA256 over a wallet signature (same wallet + same domain → same keys; different domain → uncorrelatable)
- 60s in-memory cache + warn-and-downgrade fallback semantics

## Package Surface

```typescript
import {
  resolveSIPStealth,    // → MetaAddress | NotFound | Malformed (throws NetworkError on RPC failure)
  buildPublishTx,       // → unsigned Transaction with SIP-STEALTH record
  deriveStealthKeys,    // → per-domain ed25519 keypair pair via HKDF
  invalidateCache,      // cache management
  normalizeDomain,
  SIPStealthRecordV1, parseRecord, encodeRecord,
  MetaAddress, NotFound, Malformed, NetworkError, UserRejected, OnChainError,
} from '@sip-protocol/sns-stealth'
```

## Test plan

- [x] 52 unit tests pass — 98.97% statement coverage / 94.91% branch coverage / 100% function coverage on `src/`
- [x] Package builds clean: CJS (8.38 KB) + ESM (6.57 KB) + `.d.ts` (3.87 KB)
- [x] Public API surface verified via direct dist import smoke test (15 exports resolve)
- [ ] **Devnet round-trip test committed but skipped pending one-time domain registration.** Test attempts to publish + resolve `test.sipher.sol` (default) on devnet under the shared wallet `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr`. Provision a `.sol` on Bonfida devnet UI, then run with `pnpm --filter @sip-protocol/sns-stealth test:run integration` (or override via `SIP_TEST_DOMAIN` env). Skipped automatically in CI (no keypair).
- [ ] Awaiting Phase B (sip-app integration) for end-to-end UX validation
- [ ] Mainnet smoke test deferred to Phase E

## Notable Decisions

- **V1 SNS records**, not V2 — reader and writer must match on the same protocol version. Both `getRecord` (read) and `createRecordInstruction` (write) come from V1 in `@bonfida/spl-name-service@^3.0.21`. V2 lives at a different PDA family and would require flipping both sides in lockstep.
- **Two-step probe in `resolveSIPStealth`** to disambiguate `NotFound('domain')` vs `NotFound('record')`. Bonfida's `getRecord` alone throws the same `AccountDoesNotExistError` for both cases. The spec's UX explicitly needs distinct branching (block vs warn-and-downgrade), so we pay one extra RPC on cache miss to preserve that distinction. Negative results are cached too, so the cost only hits on first lookup per domain.
- **`instanceof` over string-matching** for Bonfida error discrimination — survives upstream copy changes and locale.
- **HKDF info strings** `'spending'` and `'viewing'` are baked into the cryptographic derivation. Pre-mainnet collision-resistance review tracked in spec.

## Coverage Report

```
File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
------------|---------|----------|---------|---------|------------------
All files   |   98.97 |    94.91 |     100 |   98.97 |
 cache.ts   |     100 |      100 |     100 |     100 |
 derive.ts  |     100 |      100 |     100 |     100 |
 errors.ts  |     100 |      100 |     100 |     100 |
 index.ts   |     100 |      100 |     100 |     100 |
 publish.ts |     100 |      100 |     100 |     100 |
 resolve.ts |   96.77 |       88 |     100 |   96.77 | 86-89
 schema.ts  |     100 |      100 |     100 |     100 |
```

Uncovered lines 86-89 in `resolve.ts` are a defensive `if (raw === undefined)` branch — `getRecord` with `deserialize: true` typed as `Promise<string | undefined>`, but in practice Bonfida throws `NoRecordDataError` before reaching the `undefined` path. Left as a guardrail.

## References

- Spec: `docs/superpowers/specs/2026-05-11-sip-sol-foundation-design.md`
- Plan: `docs/superpowers/plans/2026-05-11-sip-sol-foundation.md`

## Next

- Phase B → integrate into `sip-app` (publish UI + `.sol` recipient resolution)
- Phase C → integrate into `sip-mobile` (Settings screen + Send tab)
- Phase D → integrate into `sipher` (resolveSNS + sendPrivateToSNS agent tools)
- Phase E → npm publish + mainnet smoke