### PR TITLE
fix(sns-stealth): emit update instruction so publish actually writes data (v0.1.1)

### DIFF
--- a/packages/sns-stealth/CHANGELOG.md
+++ b/packages/sns-stealth/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+## 0.1.1
+
+### Fixed
+
+- `buildPublishTx` now writes the record value to the SNS account. v0.1.0 only
+  emitted Bonfida's `createInstruction`, which allocates the record account but
+  passes `undefined` as initial data — the published record was N bytes of
+  zeros and `resolveSIPStealth` returned `NotFound('record')`. Confirmed on
+  mainnet against `therector.sol`: TX
+  [`62fc8WSK…pwj`](https://solscan.io/tx/62fc8WSKtjhK5tZGhn7nccTej2akxWf5RGvH5tE1DccbyYGyTGo7VC51hfjT6yFmLxmVoxwR2Hq67Tq7YJTnpwj)
+  succeeded but the resulting record account
+  [`3Vu5iLwr…NhkH`](https://solscan.io/account/3Vu5iLwrdgaU8gA3tJFY6rao9mXNnGicTVCkkXzhNhkH)
+  held 162 bytes of zeros.
+
+  The fix mirrors Bonfida's own `updateRecordInstruction` flow:
+  - account missing → `createInstruction` (allocate) + `updateInstruction` (write)
+  - account size matches → `updateInstruction` only
+  - account size differs → `deleteInstruction` + `createInstruction` + `updateInstruction`
+
+  Republishing on a domain that holds an empty record from v0.1.0 succeeds
+  without manual cleanup — the matching-size path overwrites the zeros in
+  place.
+
+### Tests
+
+- Added wire-format unit tests that decode the resulting `Transaction` and
+  assert on Bonfida's documented instruction discriminators (0/1/3) for all
+  three account-state paths. Phase A's mock-based tests passed against the
+  broken code because they only verified arguments to `createRecordInstruction`,
+  never read the on-chain record back.
+- Tightened `tests/integration.test.ts` to require an explicit
+  `SIP_TEST_DOMAIN` env var. The previous default (`test.sipher.sol`) wasn't
+  provisioned on devnet so the test failed for anyone with the shared keypair.
+
+## 0.1.0
+
+Initial release. SNS-based stealth address resolution and publishing.

--- a/packages/sns-stealth/package.json
+++ b/packages/sns-stealth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sip-protocol/sns-stealth",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "SNS-based stealth address resolution and publishing for SIP Protocol",
   "author": "SIP Protocol <hello@sip-protocol.org>",
   "homepage": "https://sip-protocol.org",

--- a/packages/sns-stealth/src/publish.ts
+++ b/packages/sns-stealth/src/publish.ts
@@ -1,13 +1,22 @@
-import type { Connection, PublicKey } from '@solana/web3.js'
+import type { Connection, PublicKey, TransactionInstruction } from '@solana/web3.js'
 import { Transaction } from '@solana/web3.js'
-import { createRecordInstruction } from '@bonfida/spl-name-service'
+import {
+  createRecordInstruction,
+  updateInstruction,
+  deleteInstruction,
+  getRecordKeySync,
+  serializeRecord,
+  NAME_PROGRAM_ID,
+  Numberu32,
+  NameRegistryState,
+} from '@bonfida/spl-name-service'
 import { bytesToHex } from '@noble/hashes/utils'
 import { normalizeDomain } from './derive'
 import { encodeRecord } from './schema'
 
 // SNS record key for SIP stealth metadata. Mirrors `resolve.ts`: cast bypasses
 // Bonfida's closed `Record` enum because at runtime the SDK passes this string
-// through to `getDomainKeySync` which composes it as a subdomain
+// through to `getRecordKeySync` which composes it as a subdomain
 // `<RECORD>.<DOMAIN>`, so arbitrary strings work.
 const SIP_STEALTH_RECORD = 'SIP-STEALTH' as never
 
@@ -30,7 +39,16 @@ export interface PublishKeys {
  * V2 would require switching both reader and writer in lockstep — out of scope
  * for the foundation milestone.
  *
- * @param connection Solana RPC connection (used for rent-exemption lookup + blockhash)
+ * Three on-chain paths, mirroring Bonfida's own `updateRecordInstruction` flow:
+ *   • account missing      → allocate (create) + write (update)
+ *   • account size matches → write only (update)
+ *   • account size differs → free (delete) + reallocate (create) + write (update)
+ *
+ * `createRecordInstruction` ONLY allocates the record account; it never writes
+ * the record value. Without a follow-up `updateInstruction` the published
+ * record is `data.length` bytes of zeros — that was the v0.1.0 bug.
+ *
+ * @param connection Solana RPC connection (used for account lookup, rent, blockhash)
  * @param domain     The `.sol` domain (case-insensitive; normalized internally)
  * @param keys       The 32-byte ed25519 spending/viewing public keys to publish
  * @param payer      The domain owner / fee payer (single wallet for self-publish flow)
@@ -59,25 +77,68 @@ export async function buildPublishTx(
     viewing: bytesToHex(keys.viewing),
   })
 
-  // V1 createRecordInstruction signature:
-  //   (connection, domain, record, data, owner, payer) => Promise<TransactionInstruction>
-  // For the self-publish flow `owner === payer` (the user writing to their own
-  // domain). If we ever need separate signers (e.g., relayer pays gas for a
-  // hardware wallet owner), expose `owner` as a distinct parameter — but until
-  // then collapsing them keeps the API simple and matches the common case.
-  const ix = await createRecordInstruction(
+  const recordKey = getRecordKeySync(normalized, SIP_STEALTH_RECORD)
+  const data = serializeRecord(recordValue, SIP_STEALTH_RECORD)
+  const existing = await connection.getAccountInfo(recordKey)
+
+  const ixs: TransactionInstruction[] = []
+
+  if (existing === null) {
+    // Fresh: allocate the account at the right size, then write the value.
+    ixs.push(await buildCreateIx(connection, normalized, recordValue, payer))
+    ixs.push(buildUpdateIx(recordKey, data, payer))
+  } else if (
+    existing.data.slice(NameRegistryState.HEADER_LEN).length === data.length
+  ) {
+    // Existing account, matching data area size — just overwrite.
+    ixs.push(buildUpdateIx(recordKey, data, payer))
+  } else {
+    // Existing account, mismatched size — free + reallocate + write. Bonfida's
+    // `updateInstruction` rejects writes when the new payload doesn't fit the
+    // allocated space, so a stale account from a different schema version
+    // would otherwise wedge the domain.
+    ixs.push(deleteInstruction(NAME_PROGRAM_ID, recordKey, payer, payer))
+    ixs.push(await buildCreateIx(connection, normalized, recordValue, payer))
+    ixs.push(buildUpdateIx(recordKey, data, payer))
+  }
+
+  const tx = new Transaction()
+  tx.add(...ixs)
+  const { blockhash } = await connection.getLatestBlockhash()
+  tx.recentBlockhash = blockhash
+  tx.feePayer = payer
+  return tx
+}
+
+// `createRecordInstruction` signature: (connection, domain, record, value, owner, payer).
+// Self-publish flow collapses owner === payer; if a relayer-paid flow is ever
+// needed, expose `owner` as a distinct parameter on `buildPublishTx`.
+function buildCreateIx(
+  connection: Connection,
+  normalizedDomain: string,
+  recordValue: string,
+  payer: PublicKey,
+): Promise<TransactionInstruction> {
+  return createRecordInstruction(
     connection,
-    normalized,
+    normalizedDomain,
     SIP_STEALTH_RECORD,
     recordValue,
     payer,
     payer,
   )
+}
 
-  const tx = new Transaction()
-  tx.add(ix)
-  const { blockhash } = await connection.getLatestBlockhash()
-  tx.recentBlockhash = blockhash
-  tx.feePayer = payer
-  return tx
+function buildUpdateIx(
+  recordKey: PublicKey,
+  data: Buffer,
+  payer: PublicKey,
+): TransactionInstruction {
+  return updateInstruction(
+    NAME_PROGRAM_ID,
+    recordKey,
+    new Numberu32(0),
+    data,
+    payer,
+  )
 }

--- a/packages/sns-stealth/tests/integration.test.ts
+++ b/packages/sns-stealth/tests/integration.test.ts
@@ -13,22 +13,29 @@ import {
 
 // Devnet round-trip integration test.
 //
+// Opt-in: requires BOTH the shared devnet keypair on disk AND an explicit
+// `SIP_TEST_DOMAIN` env var pointing at a `.sol` already owned by that wallet.
+// We don't ship a default domain because Bonfida's create instruction errors
+// out with "given name account is incorrect" when the parent doesn't exist —
+// that surfaces as a confusing failure for anyone who has the keypair but
+// never provisioned the domain.
+//
 // Skips automatically when:
 //   - The shared devnet keypair is not on disk (CI / contributors without it)
+//   - `SIP_TEST_DOMAIN` is not set (operator hasn't provisioned a domain)
 //   - `SIP_SKIP_INTEGRATION=1` is set (local opt-out for fast iteration)
 //
 // When it runs, it exercises the full public API surface — derive → publish →
-// resolve — against a real .sol domain. The test domain must already be
-// provisioned (owned by the devnet wallet) on Bonfida's devnet UI; if not, the
-// publish step will fail at `sendAndConfirmTransaction`. We do NOT try to
-// register the domain here — that's a one-time setup the operator handles.
+// resolve — against the real .sol. We do NOT try to register the domain here;
+// that's a one-time setup the operator handles via Bonfida's devnet UI.
 
 const RPC = process.env.SOLANA_DEVNET_RPC ?? 'https://api.devnet.solana.com'
-const TEST_DOMAIN = process.env.SIP_TEST_DOMAIN ?? 'test.sipher.sol'
+const TEST_DOMAIN = process.env.SIP_TEST_DOMAIN
 const KEYPAIR_PATH = `${homedir()}/Documents/secret/solana-devnet.json`
 
 const skipReason = (): string | false => {
   if (!existsSync(KEYPAIR_PATH)) return 'no devnet keypair'
+  if (!TEST_DOMAIN) return 'SIP_TEST_DOMAIN not set'
   if (process.env.SIP_SKIP_INTEGRATION === '1') return 'SIP_SKIP_INTEGRATION=1'
   return false
 }

--- a/packages/sns-stealth/tests/publish.test.ts
+++ b/packages/sns-stealth/tests/publish.test.ts
@@ -1,125 +1,209 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { Connection, PublicKey, Transaction, TransactionInstruction, SystemProgram } from '@solana/web3.js'
+import {
+  Connection,
+  PublicKey,
+  Transaction,
+  type AccountInfo,
+} from '@solana/web3.js'
+import {
+  getRecordKeySync,
+  serializeRecord,
+  NAME_PROGRAM_ID,
+  NameRegistryState,
+} from '@bonfida/spl-name-service'
 import { bytesToHex } from '@noble/hashes/utils'
-
-// Mock the Bonfida API surface we use:
-//   - createRecordInstruction: async (connection, domain, record, data, owner, payer) => TransactionInstruction
-// The SDK derives a PDA for the subdomain <RECORD>.<DOMAIN> and returns a single
-// `createInstruction` against the SNS program. We don't care about its internal
-// shape — only that buildPublishTx passes the right arguments and produces a
-// well-formed Transaction.
-vi.mock('@bonfida/spl-name-service', () => ({
-  createRecordInstruction: vi.fn(),
-}))
-
-import { createRecordInstruction } from '@bonfida/spl-name-service'
 import { buildPublishTx } from '../src/publish'
 
-const mockBlockhash = 'EkSnNWid2cYwsbqzdGyaDkjyAa3pYBtjwjsJqDxN1RfV'
-const mockConnection = {
-  getLatestBlockhash: vi.fn(),
-} as unknown as Connection
+// Tests use the REAL Bonfida API surface and only mock the `Connection` RPC
+// methods. This catches wire-format regressions (e.g. the v0.1.0 bug where
+// `buildPublishTx` emitted a single `createInstruction` and silently published
+// 162 bytes of zeros) by decoding the resulting Transaction's instruction
+// bytes — Bonfida's instruction discriminators are stable and documented:
+//   0 = create, 1 = update, 3 = delete (see `instructions/*Instruction.js`).
 
-// A valid base58 PublicKey for tests
-const payer = new PublicKey('11111111111111111111111111111111')
+const SIP_STEALTH_RECORD = 'SIP-STEALTH' as never
 
-// Build a no-op TransactionInstruction we can return from the mocked SDK call.
-// SystemProgram.transfer gives us a real, valid instruction without any side
-// effects when we add it to a Transaction.
-const noopIx = (): TransactionInstruction =>
-  SystemProgram.transfer({
-    fromPubkey: payer,
-    toPubkey: payer,
-    lamports: 0,
-  })
+const PAYER = new PublicKey('11111111111111111111111111111111')
+const MOCK_BLOCKHASH = 'EkSnNWid2cYwsbqzdGyaDkjyAa3pYBtjwjsJqDxN1RfV'
+
+const SPENDING_BYTES = new Uint8Array(32).fill(0xaa)
+const VIEWING_BYTES = new Uint8Array(32).fill(0xbb)
+const KEYS = { spending: SPENDING_BYTES, viewing: VIEWING_BYTES }
+
+const EXPECTED_RECORD_JSON =
+  `{"v":1,"spending":"${bytesToHex(SPENDING_BYTES)}","viewing":"${bytesToHex(VIEWING_BYTES)}"}`
+const EXPECTED_DATA_BYTES = serializeRecord(
+  EXPECTED_RECORD_JSON,
+  SIP_STEALTH_RECORD,
+)
+
+function mockConnection(opts: {
+  account?: AccountInfo<Buffer> | null
+} = {}): Connection {
+  return {
+    getAccountInfo: vi.fn().mockResolvedValue(opts.account ?? null),
+    getMinimumBalanceForRentExemption: vi.fn().mockResolvedValue(1_000_000),
+    getLatestBlockhash: vi.fn().mockResolvedValue({
+      blockhash: MOCK_BLOCKHASH,
+      lastValidBlockHeight: 100,
+    }),
+  } as unknown as Connection
+}
+
+function fakeRecordAccount(dataAreaLen: number): AccountInfo<Buffer> {
+  return {
+    data: Buffer.alloc(NameRegistryState.HEADER_LEN + dataAreaLen),
+    executable: false,
+    lamports: 1_000_000,
+    owner: NAME_PROGRAM_ID,
+    rentEpoch: 0,
+  }
+}
+
+// Bonfida's update instruction body layout (from `updateInstruction.js`):
+//   [u8 discriminator=1][u32 offset][u32 data_length][data...]
+function decodeUpdateData(ixData: Buffer): Buffer {
+  const discriminator = ixData[0]
+  expect(discriminator).toBe(1)
+  // Skip 1-byte discriminator + 4-byte offset + 4-byte length prefix.
+  return ixData.subarray(1 + 4 + 4)
+}
 
 describe('buildPublishTx', () => {
   beforeEach(() => {
-    vi.mocked(createRecordInstruction).mockReset()
-    vi.mocked(createRecordInstruction).mockResolvedValue(noopIx())
-    vi.mocked(mockConnection.getLatestBlockhash).mockReset()
-    vi.mocked(mockConnection.getLatestBlockhash).mockResolvedValue({
-      blockhash: mockBlockhash,
-      lastValidBlockHeight: 100,
+    vi.clearAllMocks()
+  })
+
+  describe('fresh domain (no existing record account)', () => {
+    it('builds a Transaction with the publisher as fee payer and a fresh blockhash', async () => {
+      const conn = mockConnection({ account: null })
+
+      const tx = await buildPublishTx(conn, 'rector.sol', KEYS, PAYER)
+
+      expect(tx).toBeInstanceOf(Transaction)
+      expect(tx.feePayer?.toBase58()).toBe(PAYER.toBase58())
+      expect(tx.recentBlockhash).toBe(MOCK_BLOCKHASH)
+    })
+
+    it('emits BOTH a create (allocate) AND an update (write) instruction', async () => {
+      // This is the v0.1.0 regression test: the bug was that only the create
+      // instruction was emitted, leaving the record account allocated but
+      // empty. Without the update instruction, `getRecord` returns undefined
+      // and `resolveSIPStealth` returns NotFound('record').
+      const conn = mockConnection({ account: null })
+
+      const tx = await buildPublishTx(conn, 'rector.sol', KEYS, PAYER)
+
+      expect(tx.instructions).toHaveLength(2)
+      expect(tx.instructions[0]!.data[0]).toBe(0) // create discriminator
+      expect(tx.instructions[1]!.data[0]).toBe(1) // update discriminator
+    })
+
+    it('writes the canonical JSON payload as the update instruction data', async () => {
+      const conn = mockConnection({ account: null })
+
+      const tx = await buildPublishTx(conn, 'rector.sol', KEYS, PAYER)
+
+      const updateIx = tx.instructions[1]!
+      expect(updateIx.programId.toBase58()).toBe(NAME_PROGRAM_ID.toBase58())
+
+      const payload = decodeUpdateData(updateIx.data)
+      expect(payload.equals(EXPECTED_DATA_BYTES)).toBe(true)
+    })
+
+    it('targets the SIP-STEALTH record account derived from the normalized domain', async () => {
+      const conn = mockConnection({ account: null })
+
+      const tx = await buildPublishTx(conn, 'RECTOR.SOL', KEYS, PAYER)
+
+      // Normalized domain → 'rector.sol'.
+      const expectedRecordKey = getRecordKeySync('rector.sol', SIP_STEALTH_RECORD)
+      const updateIx = tx.instructions[1]!
+      expect(updateIx.keys[0]!.pubkey.toBase58()).toBe(
+        expectedRecordKey.toBase58(),
+      )
+      expect(updateIx.keys[0]!.isWritable).toBe(true)
+    })
+
+    it('uses the payer as both update signer and create owner/payer', async () => {
+      const conn = mockConnection({ account: null })
+
+      const tx = await buildPublishTx(conn, 'rector.sol', KEYS, PAYER)
+
+      // Update ix: account 1 is the signer (== payer for self-publish).
+      const updateIx = tx.instructions[1]!
+      expect(updateIx.keys[1]!.pubkey.toBase58()).toBe(PAYER.toBase58())
+      expect(updateIx.keys[1]!.isSigner).toBe(true)
     })
   })
 
-  it('builds a Transaction with the publisher set as fee payer and a fresh blockhash', async () => {
-    const keys = {
-      spending: new Uint8Array(32).fill(1),
-      viewing: new Uint8Array(32).fill(2),
-    }
+  describe('existing record account with matching data length', () => {
+    it('emits ONLY an update instruction (no create — account already allocated)', async () => {
+      // The current v=1 schema always serializes to 162 bytes, so this is the
+      // path that lands when re-publishing on a domain whose previous publish
+      // was the v0.1.0 bug (allocated 162 bytes of zeros).
+      const conn = mockConnection({
+        account: fakeRecordAccount(EXPECTED_DATA_BYTES.length),
+      })
 
-    const tx = await buildPublishTx(mockConnection, 'rector.sol', keys, payer)
+      const tx = await buildPublishTx(conn, 'rector.sol', KEYS, PAYER)
 
-    expect(tx).toBeInstanceOf(Transaction)
-    expect(tx.feePayer?.toBase58()).toBe(payer.toBase58())
-    expect(tx.recentBlockhash).toBe(mockBlockhash)
-    expect(tx.instructions).toHaveLength(1)
+      expect(tx.instructions).toHaveLength(1)
+      expect(tx.instructions[0]!.data[0]).toBe(1) // update discriminator
+      const payload = decodeUpdateData(tx.instructions[0]!.data)
+      expect(payload.equals(EXPECTED_DATA_BYTES)).toBe(true)
+    })
   })
 
-  it('normalizes the domain before writing the record', async () => {
-    const keys = {
-      spending: new Uint8Array(32).fill(1),
-      viewing: new Uint8Array(32).fill(2),
-    }
+  describe('existing record account with mismatched data length', () => {
+    it('emits delete + create + update to rebuild the account at the right size', async () => {
+      // Defensive: if the schema ever evolves (e.g., v=2 with extra fields)
+      // and a stale v=1 account is encountered, we free + recreate it instead
+      // of silently failing on a too-small write.
+      const conn = mockConnection({
+        account: fakeRecordAccount(EXPECTED_DATA_BYTES.length + 64),
+      })
 
-    await buildPublishTx(mockConnection, 'RECTOR.SOL', keys, payer)
+      const tx = await buildPublishTx(conn, 'rector.sol', KEYS, PAYER)
 
-    const callArgs = vi.mocked(createRecordInstruction).mock.calls.at(-1)!
-    expect(callArgs[1]).toBe('rector.sol')
+      expect(tx.instructions).toHaveLength(3)
+      expect(tx.instructions[0]!.data[0]).toBe(3) // delete discriminator
+      expect(tx.instructions[1]!.data[0]).toBe(0) // create discriminator
+      expect(tx.instructions[2]!.data[0]).toBe(1) // update discriminator
+    })
   })
 
-  it('encodes the record as canonical JSON with hex-encoded keys', async () => {
-    const keys = {
-      spending: new Uint8Array(32).fill(0xaa),
-      viewing: new Uint8Array(32).fill(0xbb),
-    }
+  describe('input validation', () => {
+    it('rejects non-32-byte spending key without touching the connection', async () => {
+      const conn = mockConnection({ account: null })
 
-    await buildPublishTx(mockConnection, 'rector.sol', keys, payer)
+      await expect(
+        buildPublishTx(
+          conn,
+          'rector.sol',
+          { spending: new Uint8Array(20), viewing: new Uint8Array(32) },
+          PAYER,
+        ),
+      ).rejects.toThrow(/spending key must be 32 bytes/i)
 
-    const callArgs = vi.mocked(createRecordInstruction).mock.calls.at(-1)!
-    const recordValue = callArgs[3]
-    // Canonical JSON: stable key order, no whitespace.
-    expect(recordValue).toBe(
-      `{"v":1,"spending":"${bytesToHex(keys.spending)}","viewing":"${bytesToHex(keys.viewing)}"}`,
-    )
-  })
+      expect(conn.getAccountInfo).not.toHaveBeenCalled()
+      expect(conn.getLatestBlockhash).not.toHaveBeenCalled()
+    })
 
-  it('passes the SIP-STEALTH record key and uses payer for both owner and fee payer', async () => {
-    const keys = {
-      spending: new Uint8Array(32).fill(1),
-      viewing: new Uint8Array(32).fill(2),
-    }
+    it('rejects non-32-byte viewing key without touching the connection', async () => {
+      const conn = mockConnection({ account: null })
 
-    await buildPublishTx(mockConnection, 'rector.sol', keys, payer)
+      await expect(
+        buildPublishTx(
+          conn,
+          'rector.sol',
+          { spending: new Uint8Array(32), viewing: new Uint8Array(33) },
+          PAYER,
+        ),
+      ).rejects.toThrow(/viewing key must be 32 bytes/i)
 
-    const callArgs = vi.mocked(createRecordInstruction).mock.calls.at(-1)!
-    // Args: (connection, domain, record, data, owner, payer)
-    expect(callArgs[0]).toBe(mockConnection)
-    expect(callArgs[2]).toBe('SIP-STEALTH')
-    // Owner and payer default to the same caller — self-publish flow.
-    expect((callArgs[4] as PublicKey).toBase58()).toBe(payer.toBase58())
-    expect((callArgs[5] as PublicKey).toBase58()).toBe(payer.toBase58())
-  })
-
-  it('rejects non-32-byte spending key', async () => {
-    const keys = {
-      spending: new Uint8Array(20),
-      viewing: new Uint8Array(32),
-    }
-    await expect(buildPublishTx(mockConnection, 'rector.sol', keys, payer))
-      .rejects.toThrow(/spending key must be 32 bytes/i)
-    expect(createRecordInstruction).not.toHaveBeenCalled()
-  })
-
-  it('rejects non-32-byte viewing key', async () => {
-    const keys = {
-      spending: new Uint8Array(32),
-      viewing: new Uint8Array(33),
-    }
-    await expect(buildPublishTx(mockConnection, 'rector.sol', keys, payer))
-      .rejects.toThrow(/viewing key must be 32 bytes/i)
-    expect(createRecordInstruction).not.toHaveBeenCalled()
+      expect(conn.getAccountInfo).not.toHaveBeenCalled()
+      expect(conn.getLatestBlockhash).not.toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
## Summary

`@sip-protocol/sns-stealth@0.1.0` `buildPublishTx` only emitted Bonfida's `createInstruction`, which allocates the record account but passes `undefined` as initial data. The published record was N bytes of zeros and `resolveSIPStealth` returned `NotFound('record')`.

**Confirmed on mainnet against `therector.sol`:**
- TX [`62fc8WSK…pwj`](https://solscan.io/tx/62fc8WSKtjhK5tZGhn7nccTej2akxWf5RGvH5tE1DccbyYGyTGo7VC51hfjT6yFmLxmVoxwR2Hq67Tq7YJTnpwj) succeeded (slot 419154463, 17374 CU)
- Record account [`3Vu5iLwr…NhkH`](https://solscan.io/account/3Vu5iLwrdgaU8gA3tJFY6rao9mXNnGicTVCkkXzhNhkH) holds 162 bytes of zeros
- `resolveSIPStealth('therector.sol')` returns `NotFound('record')`

`createRecordInstruction` is misleadingly named — it creates the *account*, not the *value*. Bonfida's `updateInstruction` is what writes data.

## Fix

Mirror Bonfida's own `updateRecordInstruction` flow with three on-chain paths:

| State | Instructions emitted |
|-------|----------------------|
| Account missing | `create` + `update` |
| Account exists, size matches | `update` only |
| Account exists, size differs | `delete` + `create` + `update` |

The matching-size path means RECTOR can republish on `therector.sol` over the existing empty record account — no manual cleanup required.

## Why Phase A's tests didn't catch it

Phase A had 52 tests but they all mocked `createRecordInstruction` with a noop, so they only verified arguments — never read the record back from chain. Replaced `tests/publish.test.ts` with wire-format tests that decode the resulting `Transaction` and assert on Bonfida's documented instruction discriminators (0/1/3) for all three account-state paths.

## Bundled fix

Tightened `tests/integration.test.ts` skip predicate (commit 2): the previous default `test.sipher.sol` isn't provisioned on devnet, so the test failed for anyone with the shared keypair. Now requires explicit \`SIP_TEST_DOMAIN\` env var, matching the deferred-Task-9 contract.

## Test results

\`\`\`
Test Files  6 passed | 1 skipped (7)
     Tests  55 passed | 1 skipped (56)
\`\`\`

- 9 publish wire-format tests (was 6 spy-based)
- Integration test skips cleanly with no env overrides
- Build clean (CJS 9.58 KB, ESM 7.71 KB, DTS 4.36 KB)
- Typecheck clean

## Test plan

- [x] \`pnpm --filter @sip-protocol/sns-stealth test:run\` — 55 passed, 1 skipped
- [x] \`pnpm --filter @sip-protocol/sns-stealth typecheck\` — clean
- [x] \`pnpm --filter @sip-protocol/sns-stealth build\` — clean
- [ ] After merge: \`pnpm publish\` v0.1.1 to npm
- [ ] After publish: bump downstream consumers (sip-app, sip-mobile, sipher) to \`^0.1.1\`
- [ ] After all bumps: RECTOR re-publishes on \`therector.sol\` via fixed sip-app UI; verify resolution returns the meta-address