### PR TITLE
docs: refresh ROADMAP + CLAUDE for T3 Superteam growth phase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,7 +297,7 @@ pnpm typecheck                  # Type check
 ```
 **REST Endpoints (66):** Stealth, Transfer, Commitment, Viewing Key, Multi-chain (17 chains), Private Swap, Demo, Meta, SENTINEL (8: assess, blacklist, pending, decisions, status)
 **Agent Tools (22):** deposit, send, refund, balance, scan, claim, swap, viewingKey, history, status, paymentLink, invoice, privacyScore, threatCheck, roundAmount, scheduleSend, splitSend, drip, recurring, sweep, consolidate, assessRisk
-**HERALD (X Agent):** 9 tools — autonomous mention/DM response via AgentCore + X adapter
+**HERALD (X Agent):** 9 tools — autonomous mention/DM response via AgentCore + X adapter. T3: proactive content engine added (daily approval-gated posts from a weekly calendar + GitHub-activity ingestion) — shipped to prod, dormant pending @sipprotocol X credentials + `HERALD_CONTENT_CRON_ENABLED=true`
 **SENTINEL (Security Analyst):** 14 tools (7 read + 7 action) — LLM-backed risk assessment, autonomous incident response, preflight gate on fund-moving tools, circuit breaker, SENTINEL_MODE=yolo|advisory|off
 **Command Center UI (app/):** React 19, Vite 6, Tailwind 4, Zustand — adaptive dashboard (2,079 lines, 24 files, 4 views + streaming chat sidebar)
 
@@ -581,13 +581,14 @@ interface Commitment {
 **Grant Status:**
 | Grant | Amount | Status | Date |
 |-------|--------|--------|------|
-| Superteam Indonesia | $10,000 USDC | ✅ **APPROVED** | Jan 22, 2026 |
+| Superteam Indonesia | $10,000 USDC | ✅ **APPROVED** — T1+T2 paid ($6K/$10K); T3 $4K pending | Jan 22, 2026 |
 | Solana Audit Subsidy V | Up to $50K | ⏳ Pending | Feb 7, 2026 deadline |
 | SIP Labs, Inc. | — | 📋 Planned | Feb 2026 |
 | Solana Foundation | $100K | 📋 Planned | Feb-Mar 2026 |
 
 **Superteam Deliverables:** Native Solana Privacy SDK, Jupiter DEX Integration, Production App, Developer Resources
-**Tranches:** T1 $3,000 (KYC done, payment by Jan 30) → T2 $3,000 → T3 $4,000 | Deadline: Mar 31, 2026
+**Tranches:** T1 $3,000 (paid Jan 30) ✅ → T2 $3,000 (paid May 2) ✅ → T3 $4,000 ⏳ (final — "40% upon completion") | **$6K of $10K received**
+**T3 Growth Phase (Jun 2026):** Distribution > building — operationalize HERALD (X agent), launch Discord community + 4 Superteam Earn bounties, close M18 → 24/24, dApp Store retry. Spec: `docs/superpowers/specs/2026-06-02-t3-superteam-growth-refresh-design.md`
 
 **Multi-Foundation Approach:** Chain-agnostic = loved by all = funded by all
 - Solana Foundation (same-chain privacy for SOL users)
@@ -905,5 +906,5 @@ See `contracts/sip-ethereum/DEPLOYMENT.md` for full deployment guide and gas rep
 
 ---
 
-**Last Updated:** 2026-06-01
-**Status:** M17 Complete (Mainnet Live) | M18 In Progress (20/24 done) | 7,552+ Tests + 294 Foundry | 7 Packages | 🏆 Zypherpunk Winner ($6,500, #9/93, 3 tracks) | 💰 $10K Grant Approved
+**Last Updated:** 2026-06-03
+**Status:** M17 Complete (Mainnet Live) | M18 Near-Complete (22/24 done) | T3 Growth Phase active | 7,552+ Tests + 294 Foundry | 7 Packages | 🏆 Zypherpunk Winner ($6,500, #9/93, 3 tracks) | 💰 Superteam Grant $6K/$10K paid (T3 pending)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,7 +32,7 @@
 │   • Same-chain privacy on Solana + Ethereum                                 │
 │   • Direct competitor to pool-based mixers (PrivacyCash, etc)               │
 │   • Superior tech: stealth + hidden amounts vs pool mixing                  │
-│   • Discourse forum (500+ members, self-hosted) + Twitter presence (50K imp)│
+│   • Discord community (500+ members) + Twitter presence (50K impressions)   │
 │                                                                             │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
@@ -1177,9 +1177,15 @@ const payments = await scanForPayments({
 
 ---
 
-#### M18: Ethereum Same-Chain Privacy (Solidity Contract) 🔄 Q1 2026
+#### M18: Ethereum Same-Chain Privacy (Solidity Contract) 🔄 Near-Complete (22/24)
 
 **SIP Ethereum Contract** — On-chain privacy using Solidity smart contracts.
+
+> **Status (Jun 2026):** 22 of 24 issues done. Core contracts (SIPPrivacy, PedersenVerifier,
+> ZKVerifier, StealthAddressRegistry, SIPSwapRouter, SIPRelayer) are live on **7 testnets**
+> (Sepolia, Base, OP, Arbitrum, Scroll, Linea, Mode) with 294 Foundry tests. Remaining:
+> zkSync Era (#821 — needs the `foundry-zksync` toolchain) and Blast/Mantle (#824 —
+> faucet / RPC-relay blocked). Closing these → 24/24 is a Track B item of the T3 growth phase below.
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
@@ -1275,6 +1281,44 @@ Phase 5: Long-tail   → Blast, Mantle, Mode, Taiko (completeness)
 - 3 Tier 1 L2 chains supported (Base, Arbitrum, Optimism)
 - Integration guide published
 - Gas benchmarks under 200K per shielded transfer
+
+---
+
+### T3: Superteam Growth Phase (Jun 2026) 🎯 Active
+
+With M17 shipped to mainnet and M18 at 22/24, the technical build is substantially complete.
+**T3** — the final tranche of the Superteam Indonesia grant ($4K of $10K; T1 + T2 = $6K already
+received) — shifts the mandate from *building* to *distribution and growth*. The highest-leverage
+move is to **run the distribution machinery already built**, not build new machinery.
+
+> Design spec: [`docs/superpowers/specs/2026-06-02-t3-superteam-growth-refresh-design.md`](docs/superpowers/specs/2026-06-02-t3-superteam-growth-refresh-design.md)
+
+**Two parallel tracks** (independent — they share no state):
+
+**Track A — Growth** *(RECTOR-paced)*
+- **HERALD operationalization** *(centerpiece)* — the autonomous X agent (in `sipher`) goes from
+  dormant to live: a daily approval-gated content cron driven by a weekly calendar, GitHub-activity
+  ingestion so posts reference real shipped progress, and the reactive mention/DM → reply pipeline.
+  Content engine shipped; live wiring is pending `@sipprotocol` X credentials.
+- **Discord community** — server + 8 channels, linked from the website footer, org README, and every
+  bounty listing (replaces the earlier self-hosted-forum idea).
+- **Bounties (4 listings on Superteam Earn)** — Write-a-Thread, Build-with-SDK, Technical Deep-Dive,
+  and Bug Bounty; HERALD amplifies active listings every Thursday.
+
+**Track B — Technical** *(agent-driven, concurrent)*
+- **Close M18 → 24/24** — zkSync Era (#821) + Blast/Mantle (#824).
+- **dApp Store retry** (sip-mobile) — diagnose the 4th rejection, resubmit with a reviewer walkthrough.
+- **M19 claim-privacy PoC** *(stretch)* — Pool PDA + ZK claim-proof research; moves the privacy score
+  from ~30% toward an 80%+ path (see M19 below).
+
+**Traction targets:** X followers 124 → 300+ · GitHub stars 3 → 50+ · npm ~500 → 1,000+/wk · Discord 0 → 50+.
+Success is the engine demonstrably running with metrics trending up — not necessarily every target hit.
+
+**Agent team:** SIP's build and distribution increasingly run on a dedicated agent team in the `sipher`
+repo — **SIPHER** (privacy agent + 66-endpoint REST API), **HERALD** (autonomous X distribution), and
+**SENTINEL** (LLM security analyst that gates fund-moving actions). T3 operationalizes HERALD as the
+distribution engine; the swarm grows from there (HERALD-as-Discord-bot and a standalone `sip-agents`
+repo are explicitly deferred to agent-swarm v2).
 
 ---
 
@@ -1647,7 +1691,7 @@ SIP is **chain-agnostic** — we enhance every chain, compete with none.
 
 | Milestone | Timeline | Amount | Purpose | Status |
 |-----------|----------|--------|---------|--------|
-| **Superteam Indonesia** | Jan 2026 | $10K | Community + Narrative | ✅ **APPROVED** |
+| **Superteam Indonesia** | Jan 2026 | $10K | Community + Narrative | ✅ **APPROVED** — $6K/$10K paid (T3 $4K pending) |
 | **Solana Audit Subsidy V** | Feb 2026 | Up to $50K | Security audit funding | ⏳ Pending (Feb 7) |
 | **Solana Foundation** | Feb-Mar 2026 | $100K | Solana Same-Chain Privacy | 📋 Planned |
 | **Mina Foundation** | H2 2026 | $50-100K | Proof composition (Zypherpunk relationship) | 🔲 Planned |
@@ -1702,15 +1746,15 @@ SIP is **chain-agnostic** — we enhance every chain, compete with none.
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 **Current focus areas:**
-- M18: Ethereum same-chain privacy module — Active development
-- Base L2 deployment (highest priority)
-- Superteam T1-T3 deliverables (deadline: Mar 31, 2026)
-- Solana Foundation grant application (Feb-Mar 2026)
+- T3 Superteam growth phase — operationalize HERALD, launch Discord + bounties (distribution > building)
+- Close M18 → 24/24 — zkSync Era (#821) + Blast/Mantle (#824) long-tail L2s
+- M19 claim-privacy PoC — Pool PDA + ZK claims (privacy score ~30% → 80%+)
+- Solana Foundation grant application (audit subsidy + same-chain privacy)
 - Production hardening & audit preparation
 
 ---
 
-*Last updated: March 1, 2026*
-*M16-M17 Complete | M18 In Progress (22/24 issues done) | Superteam Grant APPROVED ($10K)*
+*Last updated: June 3, 2026*
+*M16-M17 Complete | M18 Near-Complete (22/24 issues done) | T3 Superteam Growth Phase active | Superteam Grant $6K/$10K paid (T3 $4K pending)*
 *7,624+ tests | 7 packages | Full Privacy Architecture documented (M19-M20)*
 *M18: 294 Foundry tests, deployed on 7 testnets (Sepolia, Base, OP, Arbitrum, Scroll, Linea, Mode). SIPRelayer on 4 chains. GelatoRelayAdapter in SDK (23 tests). Blast/Mantle/zkSync pending.*


### PR DESCRIPTION
Workstream #7 of the T3 Superteam growth phase — the docs refresh from the approved spec ([\`docs/superpowers/specs/2026-06-02-t3-superteam-growth-refresh-design.md\`](docs/superpowers/specs/2026-06-02-t3-superteam-growth-refresh-design.md), §Cross-cutting Docs). Docs-only; no code or test impact.

## ROADMAP.md
- **New "T3: Superteam Growth Phase" section** — parallel Growth (HERALD live, Discord, 4 bounties) / Technical (close M18 → 24/24, dApp Store retry, M19 PoC) tracks, traction targets, and an **agent-team note** (SIPHER / HERALD / SENTINEL).
- **M18 marked near-complete (22/24)** — added a status note (7 testnets, 294 Foundry tests; only zkSync #821 + Blast/Mantle #824 remain).
- **Discourse forum → Discord community** (endgame targets box).
- Refreshed Superteam grant status (\$6K/\$10K paid), "current focus areas", and the footer date.

## CLAUDE.md
- Grant status: **T1 + T2 paid (\$6K/\$10K); T3 \$4K pending** (tranche table + grant row).
- **T3 growth-phase note** (HERALD operationalized, Discord, bounties) + HERALD content-engine status.
- Fixed stale footer **20/24 → 22/24** and bumped the date.

## Verified
- M18 count confirmed against issues (epic #800; only #821 + #824 open → 22/24).
- Canonical figures consistent across docs: grant \$6K/\$10K, M18 22/24, traction (X 124→300+, stars 3→50+, npm ~500→1k/wk, Discord 0→50+).
- No lingering "Discourse"; ASCII-box width preserved on the edited endgame line.

The private STRATEGY.md (bounty strategy, agent-team vision, traction targets) was refreshed separately — it lives outside the repo and is not part of this PR.