### PR TITLE
security: enable Private Vulnerability Reporting as disclosure channel (fixes #1081)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,14 +4,20 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.6.x   | :white_check_mark: |
-| < 0.6   | :x:                |
+| 0.9.x   | :white_check_mark: |
+| < 0.9   | :x:                |
 
 ## Reporting a Vulnerability
 
 **Please do NOT report security vulnerabilities through public GitHub issues.**
 
-Instead, please report them via email to: **security@sip-protocol.org**
+Use one of the following confidential channels:
+
+1. **GitHub Private Vulnerability Reporting (preferred).** Open a private report at
+   [github.com/sip-protocol/sip-protocol/security/advisories/new](https://github.com/sip-protocol/sip-protocol/security/advisories/new).
+   Private reporting is enabled on every SIP Protocol repository, so you can also file from the
+   **Security → Report a vulnerability** tab of the affected repo. This is the most reliable channel.
+2. **Email:** **security@sip-protocol.org**
 
 Include:
 - Description of the vulnerability
@@ -211,6 +217,8 @@ For users of SIP Protocol:
 - `@sip-protocol/cli`
 - `@sip-protocol/api`
 - `@sip-protocol/types`
+- `@sip-protocol/sns-stealth`
+- `@sip-protocol/react-native`
 - `sip-website`
 - `sip-app`
 - `docs-sip`
@@ -235,4 +243,4 @@ We thank the security researchers who have helped improve SIP Protocol:
 
 ---
 
-*Last updated: January 2026*
+*Last updated: June 2026*


### PR DESCRIPTION
## Summary

Resolves #1081 — an external researcher reported that the published security contact `security@sip-protocol.org` is unreachable (no MX record on `sip-protocol.org`; SMTP `4.4.1` timeouts), and GitHub Private Vulnerability Reporting was **disabled**, leaving no working confidential disclosure channel.

## Changes

- **Enabled GitHub Private Vulnerability Reporting on all 11 org repositories** (via API) — researchers can now file confidential reports from each repo's *Security → Report a vulnerability* tab.
- **SECURITY.md** now leads with PVR as the preferred confidential channel, with email as secondary.
- Refreshed stale content: supported versions `0.6.x → 0.9.x`; added `@sip-protocol/sns-stealth` + `@sip-protocol/react-native` to scope; updated the date.

## Follow-up (separate, RECTOR/DNS)

Restoring email delivery — publishing an **MX record for `sip-protocol.org`** so `security@sip-protocol.org` works again — is a separate DNS task, not blocking this fix (PVR is now the reliable channel).