### PR TITLE
fix(ci): run tests for all packages, not just @sip-protocol/sdk (fixes #1085)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,11 @@ jobs:
       - name: Lint
         run: pnpm lint
 
-      - name: Run tests with coverage
+      - name: Run SDK tests with coverage
         run: pnpm -r --filter @sip-protocol/sdk test -- --run --coverage
+
+      - name: Run tests (other packages)
+        run: pnpm -r --filter '!@sip-protocol/sdk' --if-present test -- --run
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6


### PR DESCRIPTION
Resolves #1085. The test step only ran `--filter @sip-protocol/sdk`, skipping react/cli/api/react-native/sns-stealth tests on every run. Adds a step that runs the other packages' tests (`--if-present` skips those without a test script); SDK keeps its coverage step. **Letting this PR's own CI validate that all packages pass in the runner.**