### PR TITLE
test(governance): fix flaky vote-leak assertion (hex substring → bytes)

### DIFF
--- a/packages/sdk/tests/governance/private-vote.test.ts
+++ b/packages/sdk/tests/governance/private-vote.test.ts
@@ -428,10 +428,13 @@ describe('PrivateVoting', () => {
         voter: '0xvoter123',
       })
 
-      // Verify encrypted vote has no readable information
-      expect(encryptedVote.ciphertext).not.toContain('proposal-xyz')
-      expect(encryptedVote.ciphertext).not.toContain('5000')
-      expect(encryptedVote.ciphertext).not.toContain('0xvoter123')
+      // Verify encrypted vote leaks no readable plaintext. Decode to bytes
+      // first — substring-matching the hex string false-positives when a
+      // value like "5000" coincides with hex digits in the random ciphertext.
+      const ciphertextBytes = Buffer.from(encryptedVote.ciphertext.slice(2), 'hex')
+      expect(ciphertextBytes.includes(Buffer.from('proposal-xyz'))).toBe(false)
+      expect(ciphertextBytes.includes(Buffer.from('5000'))).toBe(false)
+      expect(ciphertextBytes.includes(Buffer.from('0xvoter123'))).toBe(false)
 
       // Reveal vote
       const revealed = voting.revealVote(encryptedVote, encryptionKey)


### PR DESCRIPTION
## Summary

`tests/governance/private-vote.test.ts` had a flaky assertion that intermittently failed CI (~0.37% of runs). Pre-existing on `main`, unrelated to any feature change — it surfaced on PR #1100's CI run.

## Root cause

The end-to-end vote test verified the encrypted ciphertext leaks no plaintext via:

```js
expect(encryptedVote.ciphertext).not.toContain('5000')
```

But `ciphertext` is a **hex string** and `'5000'` is **all valid hex digits**, so the substring appears by chance in the random AEAD output. A 20,000-iteration probe measured the real rate:

```
oldHits(hex-substring) = 74 / 20000  (0.37%)
newHits(byte-level)    =  0 / 20000
positiveControlDetects = true
```

The sibling checks (`'proposal-xyz'`, `'0xvoter123'`) contain non-hex letters, so they can never false-positive — only the all-hex `'5000'` did.

## Fix

Decode the ciphertext to bytes and check for the plaintext's ASCII bytes (matches the file's existing `Buffer.from(hex)` idiom). This tests the real "no readable plaintext" property and drops the false-positive rate to ~1e-8:

```js
const ciphertextBytes = Buffer.from(encryptedVote.ciphertext.slice(2), 'hex')
expect(ciphertextBytes.includes(Buffer.from('5000'))).toBe(false)
```

## Verification

- Probe: 0 byte-level false-positives across 20k random ciphertexts; positive control still detects a genuine leak (not a no-op).
- `pnpm --filter @sip-protocol/sdk typecheck` passes.
- `private-vote.test.ts` — 56/56 pass.

Unblocks #1100's CI after rebase.
