### PR TITLE
feat(ethereum): view-only stealth scanning (#1104)

### DIFF
--- a/.changeset/evm-view-only-scan.md
+++ b/.changeset/evm-view-only-scan.md
@@ -1,0 +1,5 @@
+---
+'@sip-protocol/sdk': patch
+---
+
+Add view-only EVM stealth scanning (#1104). `checkEthereumStealthByEthAddressViewOnly` and `EthereumPrivacyAdapter.scanAnnouncementsViewOnly` detect incoming payments using the viewing private key + spending public key only — never the spending private key — restoring the compliance/delegation property on EVM (previously the only scan path, `scanAnnouncements`, required the spending private key). `EthereumScanRecipient.spendingPrivateKey` is now optional so a view-only recipient can register with just `viewingPrivateKey` + `spendingPublicKey`; the full `scanAnnouncements` (which derives claimable keys) skips recipients that lack it.

--- a/packages/sdk/src/chains/ethereum/index.ts
+++ b/packages/sdk/src/chains/ethereum/index.ts
@@ -67,6 +67,7 @@ export type {
   EthereumPrivacyAdapterState,
   EthereumScanRecipient,
   EthereumDetectedPaymentResult,
+  EthereumViewOnlyDetectionResult,
 } from './types'
 
 // ─── Stealth Addresses ────────────────────────────────────────────────────────
@@ -85,6 +86,7 @@ export {
   deriveEthereumStealthPrivateKey,
   checkEthereumStealthAddress,
   checkEthereumStealthByEthAddress,
+  checkEthereumStealthByEthAddressViewOnly,
   stealthPublicKeyToEthAddress,
   extractPublicKeys,
   createMetaAddressFromPublicKeys,

--- a/packages/sdk/src/chains/ethereum/privacy-adapter.ts
+++ b/packages/sdk/src/chains/ethereum/privacy-adapter.ts
@@ -18,6 +18,7 @@ import {
   deriveEthereumStealthPrivateKey,
   checkEthereumStealthAddress,
   checkEthereumStealthByEthAddress,
+  checkEthereumStealthByEthAddressViewOnly,
   stealthPublicKeyToEthAddress,
   type EthereumStealthMetaAddress,
   type EthereumStealthAddress,
@@ -59,6 +60,7 @@ import type {
   EthereumPrivacyAdapterState,
   EthereumScanRecipient,
   EthereumDetectedPaymentResult,
+  EthereumViewOnlyDetectionResult,
   EthereumViewingKeyExport,
   EthereumViewingKeyPair,
   EthereumPedersenCommitment,
@@ -589,6 +591,11 @@ export class EthereumPrivacyAdapter {
 
       // Check each recipient
       for (const recipient of this.scanRecipients.values()) {
+        // The full scan derives the claimable key, which needs the spending private key.
+        // View-only recipients (no spending private key) are handled by scanAnnouncementsViewOnly.
+        if (!recipient.spendingPrivateKey) {
+          continue
+        }
         // Use ETH address comparison since announcements store 20-byte addresses
         // Returns the stealth private key if match found, null otherwise
         const stealthPrivateKey = checkEthereumStealthByEthAddress(
@@ -611,6 +618,55 @@ export class EthereumPrivacyAdapter {
             },
             recipient,
             stealthPrivateKey,
+          })
+          break // Found owner, no need to check other recipients
+        }
+      }
+    }
+
+    return results
+  }
+
+  /**
+   * Scan announcements for incoming payments — VIEW-ONLY.
+   *
+   * Detects payments using each registered recipient's viewing private key + spending
+   * public key only (never the spending private key), so a compliance auditor or a
+   * delegated watcher can find incoming payments without spend authority. Results carry
+   * no derived private key — claim by deriving it separately at claim time (with both
+   * private keys).
+   *
+   * @param announcements - Announcements to scan
+   * @returns Detected payments (without private keys)
+   */
+  scanAnnouncementsViewOnly(
+    announcements: EthereumAnnouncement[]
+  ): EthereumViewOnlyDetectionResult[] {
+    const results: EthereumViewOnlyDetectionResult[] = []
+
+    for (const announcement of announcements) {
+      const stealthAddress = announcementToStealthAddress(announcement)
+
+      for (const recipient of this.scanRecipients.values()) {
+        const isMatch = checkEthereumStealthByEthAddressViewOnly(
+          announcement.stealthAddress,
+          announcement.ephemeralPublicKey,
+          announcement.viewTag,
+          recipient.spendingPublicKey,
+          recipient.viewingPrivateKey,
+        )
+
+        if (isMatch) {
+          results.push({
+            payment: {
+              stealthAddress,
+              stealthEthAddress: announcement.stealthAddress,
+              txHash: announcement.txHash!,
+              blockNumber: announcement.blockNumber!,
+              logIndex: announcement.logIndex,
+              timestamp: announcement.timestamp,
+            },
+            recipient,
           })
           break // Found owner, no need to check other recipients
         }

--- a/packages/sdk/src/chains/ethereum/stealth.ts
+++ b/packages/sdk/src/chains/ethereum/stealth.ts
@@ -460,6 +460,78 @@ export function checkEthereumStealthByEthAddress(
   }
 }
 
+/**
+ * View-only check of an Ethereum stealth announcement by ETH address.
+ *
+ * Detects whether a payment was intended for this recipient using only the viewing
+ * PRIVATE key and the spending PUBLIC key — never the spending private key (which is
+ * required to claim, not to detect). Recomputes the expected stealth public key as
+ * `A = K_spend + H(S)*G` (point arithmetic on the spending public key), converts it to an
+ * ETH address, and compares. Mirrors {@link checkEthereumStealthByEthAddress} but without
+ * the spending private key and returning a boolean rather than the derived key.
+ *
+ * @param ethAddress - The ETH address from the announcement (20 bytes)
+ * @param ephemeralPublicKey - Ephemeral public key from the announcement
+ * @param viewTag - View tag from the announcement
+ * @param spendingPublicKey - Recipient's spending public key (meta-address spendingKey)
+ * @param viewingPrivateKey - Recipient's viewing private key
+ * @returns True if the address belongs to this recipient
+ */
+export function checkEthereumStealthByEthAddressViewOnly(
+  ethAddress: HexString,
+  ephemeralPublicKey: HexString,
+  viewTag: number,
+  spendingPublicKey: HexString,
+  viewingPrivateKey: HexString,
+): boolean {
+  if (!isValidPrivateKey(viewingPrivateKey)) {
+    throw new ValidationError(
+      'must be a valid 32-byte hex string',
+      'viewingPrivateKey'
+    )
+  }
+
+  const viewingPrivBytes = hexToBytes(viewingPrivateKey.slice(2))
+  const spendingPubBytes = hexToBytes(spendingPublicKey.slice(2))
+  const ephemeralPubBytes = hexToBytes(ephemeralPublicKey.slice(2))
+
+  try {
+    // Compute shared secret: S = viewingPrivateKey * ephemeralPublicKey
+    // Canonical EIP-5564: ECDH on the viewing key (mirrors generation S = r * K_view)
+    const sharedSecretPoint = secp256k1.getSharedSecret(
+      viewingPrivBytes,
+      ephemeralPubBytes,
+    )
+    const sharedSecretHash = sha256(sharedSecretPoint)
+
+    // Quick view tag check
+    if (sharedSecretHash[0] !== viewTag) {
+      return false
+    }
+
+    // Expected stealth address: A = K_spend + hash(S)*G — point arithmetic on the spending
+    // PUBLIC key, so no spending private key is needed. Reduce hash(S) into [1, n-1] (a zero
+    // offset would be degenerate) before scaling the generator.
+    const hashScalar = BigInt('0x' + bytesToHex(sharedSecretHash)) % secp256k1.CURVE.n
+    if (hashScalar === 0n) {
+      return false
+    }
+    const spendingPubPoint = secp256k1.ProjectivePoint.fromHex(spendingPubBytes)
+    const expectedPoint = spendingPubPoint.add(
+      secp256k1.ProjectivePoint.BASE.multiply(hashScalar),
+    )
+    const expectedPubKey = expectedPoint.toRawBytes(true)
+
+    // Convert to ETH address and compare (case-insensitive)
+    const expectedPubKeyHex = ('0x' + bytesToHex(expectedPubKey)) as HexString
+    const expectedEthAddress = publicKeyToEthAddress(expectedPubKeyHex)
+
+    return expectedEthAddress.toLowerCase() === ethAddress.toLowerCase()
+  } catch {
+    return false
+  }
+}
+
 // ─── Address Conversion ─────────────────────────────────────────────────────
 
 /**

--- a/packages/sdk/src/chains/ethereum/types.ts
+++ b/packages/sdk/src/chains/ethereum/types.ts
@@ -441,8 +441,12 @@ export interface EthereumScanRecipient {
   viewingPrivateKey: HexString
   /** Spending public key */
   spendingPublicKey: HexString
-  /** Spending private key (required for scanning and key derivation) */
-  spendingPrivateKey: HexString
+  /**
+   * Spending private key — required to derive claimable keys during a full scan
+   * (`scanAnnouncements`). Optional for view-only registration: a recipient with only
+   * `viewingPrivateKey` + `spendingPublicKey` detects payments via `scanAnnouncementsViewOnly`.
+   */
+  spendingPrivateKey?: HexString
   /** Optional label */
   label?: string
 }
@@ -457,4 +461,16 @@ export interface EthereumDetectedPaymentResult {
   recipient: EthereumScanRecipient
   /** Derived stealth private key (for claiming) */
   stealthPrivateKey: HexString
+}
+
+/**
+ * View-only detected payment — carries no derived private key (detection used the
+ * spending PUBLIC key only). To claim, derive the stealth private key separately with
+ * both private keys at claim time.
+ */
+export interface EthereumViewOnlyDetectionResult {
+  /** The detected payment */
+  payment: EthereumDetectedPayment
+  /** The recipient that matched */
+  recipient: EthereumScanRecipient
 }

--- a/packages/sdk/tests/chains/ethereum/view-only-scan.test.ts
+++ b/packages/sdk/tests/chains/ethereum/view-only-scan.test.ts
@@ -1,0 +1,146 @@
+/**
+ * EVM view-only stealth scanning (#1104)
+ *
+ * Detection must work with the viewing PRIVATE key + spending PUBLIC key only — never the
+ * spending private key (which is needed to claim, not to detect). Before this, the only
+ * EVM scan path (`checkEthereumStealthByEthAddress` / `scanAnnouncements`) required the
+ * spending private key, defeating the compliance/delegation property #1099 restored.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  generateEthereumStealthMetaAddress,
+  generateEthereumStealthAddress,
+  stealthPublicKeyToEthAddress,
+  checkEthereumStealthByEthAddress,
+  checkEthereumStealthByEthAddressViewOnly,
+  createMainnetEthereumPrivacyAdapter,
+} from '../../../src/chains/ethereum'
+import type { EthereumAnnouncement } from '../../../src/chains/ethereum'
+
+function fixture() {
+  const meta = generateEthereumStealthMetaAddress()
+  const { stealthAddress } = generateEthereumStealthAddress(meta.metaAddress)
+  const stealthEthAddress = stealthPublicKeyToEthAddress(stealthAddress.address)
+  return { meta, stealthAddress, stealthEthAddress }
+}
+
+describe('checkEthereumStealthByEthAddressViewOnly (#1104)', () => {
+  it('detects a generated payment with viewing private + spending public only', () => {
+    const { meta, stealthAddress, stealthEthAddress } = fixture()
+
+    const detected = checkEthereumStealthByEthAddressViewOnly(
+      stealthEthAddress,
+      stealthAddress.ephemeralPublicKey,
+      stealthAddress.viewTag,
+      meta.metaAddress.spendingKey, // spending PUBLIC key
+      meta.viewingPrivateKey
+    )
+
+    expect(detected).toBe(true)
+  })
+
+  it('returns false for the wrong viewing key', () => {
+    const { meta, stealthAddress, stealthEthAddress } = fixture()
+    const other = generateEthereumStealthMetaAddress()
+
+    expect(
+      checkEthereumStealthByEthAddressViewOnly(
+        stealthEthAddress,
+        stealthAddress.ephemeralPublicKey,
+        stealthAddress.viewTag,
+        meta.metaAddress.spendingKey,
+        other.viewingPrivateKey
+      )
+    ).toBe(false)
+  })
+
+  it('returns false for the wrong spending public key', () => {
+    const { meta, stealthAddress, stealthEthAddress } = fixture()
+    const other = generateEthereumStealthMetaAddress()
+
+    expect(
+      checkEthereumStealthByEthAddressViewOnly(
+        stealthEthAddress,
+        stealthAddress.ephemeralPublicKey,
+        stealthAddress.viewTag,
+        other.metaAddress.spendingKey,
+        meta.viewingPrivateKey
+      )
+    ).toBe(false)
+  })
+
+  it('agrees with the spending-private-key path on the same payment', () => {
+    const { meta, stealthAddress, stealthEthAddress } = fixture()
+
+    const viaPrivate = checkEthereumStealthByEthAddress(
+      stealthEthAddress,
+      stealthAddress.ephemeralPublicKey,
+      stealthAddress.viewTag,
+      meta.spendingPrivateKey,
+      meta.viewingPrivateKey
+    )
+    const viaViewOnly = checkEthereumStealthByEthAddressViewOnly(
+      stealthEthAddress,
+      stealthAddress.ephemeralPublicKey,
+      stealthAddress.viewTag,
+      meta.metaAddress.spendingKey,
+      meta.viewingPrivateKey
+    )
+
+    expect(viaPrivate).not.toBeNull() // private path returns the derived key
+    expect(viaViewOnly).toBe(true)
+  })
+})
+
+describe('EthereumPrivacyAdapter.scanAnnouncementsViewOnly (#1104)', () => {
+  function announcementFor(stealthEthAddress: string, ephemeralPublicKey: string, viewTag: number): EthereumAnnouncement {
+    return {
+      schemeId: 1,
+      stealthAddress: stealthEthAddress as `0x${string}`,
+      caller: '0x0000000000000000000000000000000000000000' as `0x${string}`,
+      ephemeralPublicKey: ephemeralPublicKey as `0x${string}`,
+      viewTag,
+      txHash: '0x1111111111111111111111111111111111111111111111111111111111111111' as `0x${string}`,
+      blockNumber: 1,
+      logIndex: 0,
+    }
+  }
+
+  it('detects an incoming payment without the spending private key, and returns no private key', () => {
+    const { meta, stealthAddress, stealthEthAddress } = fixture()
+    const adapter = createMainnetEthereumPrivacyAdapter()
+
+    // Register a VIEW-ONLY recipient — no spending private key.
+    adapter.addScanRecipient({
+      viewingPrivateKey: meta.viewingPrivateKey,
+      spendingPublicKey: meta.metaAddress.spendingKey,
+      label: 'auditor',
+    })
+
+    const results = adapter.scanAnnouncementsViewOnly([
+      announcementFor(stealthEthAddress, stealthAddress.ephemeralPublicKey, stealthAddress.viewTag),
+    ])
+
+    expect(results).toHaveLength(1)
+    expect(results[0].payment.stealthEthAddress.toLowerCase()).toBe(stealthEthAddress.toLowerCase())
+    expect(results[0]).not.toHaveProperty('stealthPrivateKey')
+  })
+
+  it('does not detect announcements for an unrelated recipient', () => {
+    const { stealthAddress, stealthEthAddress } = fixture()
+    const other = generateEthereumStealthMetaAddress()
+    const adapter = createMainnetEthereumPrivacyAdapter()
+
+    adapter.addScanRecipient({
+      viewingPrivateKey: other.viewingPrivateKey,
+      spendingPublicKey: other.metaAddress.spendingKey,
+    })
+
+    const results = adapter.scanAnnouncementsViewOnly([
+      announcementFor(stealthEthAddress, stealthAddress.ephemeralPublicKey, stealthAddress.viewTag),
+    ])
+
+    expect(results).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Adds **view-only EVM stealth scanning** (#1104). EVM was the one chain where scanning still required the spending private key: `scanAnnouncements` derives the claimable key during the scan via `checkEthereumStealthByEthAddress`, so a holder with only viewing-private + spending-public couldn't detect payments — defeating the compliance/delegation property #1099 restored everywhere else.

## Changes
- **`checkEthereumStealthByEthAddressViewOnly(ethAddress, ephemeralPublicKey, viewTag, spendingPublicKey, viewingPrivateKey): boolean`** — recomputes `A = K_spend + H(S)·G` by point arithmetic on the spending **public** key, converts to an ETH address, compares. No spending private key; boolean result. Reduces `hash(S) mod n` + guards the zero offset, consistent with the ed25519/secp256k1 paths.
- **`EthereumPrivacyAdapter.scanAnnouncementsViewOnly(announcements)`** — uses it against registered recipients; returns `EthereumViewOnlyDetectionResult` (no derived private key — claim derives separately at claim time).
- **`EthereumScanRecipient.spendingPrivateKey` is now optional** — a view-only recipient registers with just `viewingPrivateKey` + `spendingPublicKey` (existing tests already register this way). The full `scanAnnouncements` (which derives claimable keys) now explicitly skips recipients lacking it.

## Versioning note
Changeset is **patch** per your call, but it adds public API + relaxes `spendingPrivateKey` to optional — conventionally a **minor**. Easy to bump the changeset before release if you'd prefer minor.

## Test plan
- `pnpm typecheck` ✓
- Full SDK suite ✓ — **6761 passed / 0 failed** (+6 new view-only tests: detection true/false for wrong viewing & spending keys; agreement with the private-key path; adapter view-only scan returns no private key + rejects unrelated recipients). First detection tests for the EVM scan path.

Closes #1104
Relates to #1099.