### PR TITLE
fix(ci): run changeset version via pnpm run, not the built-in

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm version
-          publish: pnpm release
+          version: pnpm run version
+          publish: pnpm run release
           title: 'chore: release packages'
           commit: 'chore: release packages'
         env:


### PR DESCRIPTION
## Problem

The `Release` workflow runs for the `@sip-protocol/sdk@0.10.1` release ([run 1](https://github.com/sip-protocol/sip-protocol/actions/runs/27109107937), [run 2](https://github.com/sip-protocol/sip-protocol/actions/runs/27109109262)) both failed at the `changesets/action` step:

> Validation Failed: `{"resource":"PullRequest","code":"custom","message":"No commits between main and changeset-release/main"}`

### Root cause

`release.yml` passed `version: pnpm version` to `changesets/action`. **`pnpm version` is a built-in command** — with no semver argument it prints the Node/pnpm version table and exits; it does **not** run the package.json `"version": "changeset version"` script. So on the version path:

1. Changesets were never applied → no version bump, no changelog diff
2. `changeset-release/main` was force-pushed identical to `main`
3. PR creation failed — "No commits between main and changeset-release/main"

The built-in shadows the lifecycle script. (`publish: pnpm release` happened to work only because `release` is **not** a built-in.)

### Why it surfaced now

Latent since changesets were wired up. `0.10.0` (#1100) was a **manual** version bump — with no changeset files present, the action skips the version path and goes straight to publish, so `pnpm version` was never exercised. #1106 and #1107 are the **first releases to ship real changeset files**, which finally ran the broken command.

## Fix

Use `pnpm run version` / `pnpm run release` so the lifecycle scripts run explicitly and the built-in can't shadow `version`.

## After merge

This push to `main` re-triggers `release.yml`. The two changeset files already sitting un-consumed on `main` (`stealth-canonical-followups`, `evm-view-only-scan`) get consumed, opening the `chore: release packages` PR that bumps `@sip-protocol/sdk` **0.10.0 → 0.10.1**. Merging *that* PR performs the npm publish.
