### PR TITLE
fix(release): SDK 0.11.0 (minor) + Prettier house-style config

### DIFF
--- a/.changeset/evm-view-only-scan.md
+++ b/.changeset/evm-view-only-scan.md
@@ -1,5 +1,5 @@
 ---
-'@sip-protocol/sdk': patch
+'@sip-protocol/sdk': minor
 ---
 
 Add view-only EVM stealth scanning (#1104). `checkEthereumStealthByEthAddressViewOnly` and `EthereumPrivacyAdapter.scanAnnouncementsViewOnly` detect incoming payments using the viewing private key + spending public key only — never the spending private key — restoring the compliance/delegation property on EVM (previously the only scan path, `scanAnnouncements`, required the spending private key). `EthereumScanRecipient.spendingPrivateKey` is now optional so a view-only recipient can register with just `viewingPrivateKey` + `spendingPublicKey`; the full `scanAnnouncements` (which derives claimable keys) skips recipients that lack it.

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "singleQuote": true
+}


### PR DESCRIPTION
## What

Addresses the review findings on Release PR #1109 **before** publishing, so the release is semantically and stylistically clean. Two atomic, root-cause fixes.

## 1. Semver — EVM view-only scanning is a *minor*, not a patch

`.changeset/evm-view-only-scan.md`: `patch` → `minor`.

#1107 adds public API (`checkEthereumStealthByEthAddressViewOnly`, `EthereumPrivacyAdapter.scanAnnouncementsViewOnly`, `EthereumViewOnlyDetectionResult`) and makes `EthereumScanRecipient.spendingPrivateKey` optional. Additive surface = **minor** under semver, so the SDK release becomes **0.10.0 → 0.11.0** (was mislabeled patch).

`pnpm changeset status` after the change:
- `@sip-protocol/sdk` → **0.11.0** (minor)
- `api`/`cli`/`react`/`react-native` → patch cascade (unchanged)
- `@sip-protocol/types` correctly **not** dragged in by the `linked` group

Trade-off: consumers pinning `^0.10.0` won't auto-receive 0.11.0 (0.x caret locks the minor) — intended, so the new API surface is signposted by the version line.

## 2. Prettier config matching house style

Adds `.prettierrc.json` = `{ "semi": false, "singleQuote": true }`.

**Root cause** of the changelog churn seen in #1109: the repo had **no Prettier config**, so `prettier` (a devDependency driving the `format` script *and* `@changesets/cli`'s CHANGELOG generation) fell back to its defaults (`semi: true`, double quotes) and rewrote a code snippet in the existing 0.10.0 changelog during versioning. The same latent bug affected `pnpm format` — it would add semicolons repo-wide, against the documented no-semicolons style.

Verified safe + effective:
- No `eslint-plugin-prettier` / `eslint-config-prettier`, eslint config doesn't reference prettier → **purely additive**, no lint/CI impact.
- `prettier --check packages/sdk/CHANGELOG.md` **passes** under the new config → main's changelog is already house-conformant, so the regenerated Release PR shows **only** the new 0.11.0 entry (no historical churn).

## After merge

`release.yml` re-runs and **updates the existing Release PR #1109 in place**: `@sip-protocol/sdk` → 0.11.0, clean changelog. Merging *that* regenerated PR performs the npm publish — still gated on your call.

> **Order matters:** merge this PR first so #1109 regenerates at 0.11.0. (Merging #1109 as-is would publish the mislabeled 0.10.1.)

Cascade dependent bumps (review finding #3) are standard `updateInternalDependencies: patch` behavior and intentionally left as-is.
