### PR TITLE
fix(sdk): export SIP_MEMO_PREFIX_V2 + SIP_MEMO_PREFIX_ANY from package entry (#1123)

### DIFF
--- a/.changeset/export-memo-prefix-constants.md
+++ b/.changeset/export-memo-prefix-constants.md
@@ -1,0 +1,5 @@
+---
+"@sip-protocol/sdk": patch
+---
+
+Export `SIP_MEMO_PREFIX_V2` (`'SIP:2:'`) and `SIP_MEMO_PREFIX_ANY` (`'SIP:'`) from the package entry. Both constants were defined in `chains/solana/constants.ts` and re-exported from the `chains/solana` sub-barrel, but were missing from the public `src/index.ts`, so ESM/TypeScript consumers could not import them by name (they resolved to `undefined` under bundlers that tolerate missing named ESM imports, and errored under `tsc`). Closes #1123.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1016,6 +1016,8 @@ export {
   SOLANA_EXPLORER_URLS,
   MEMO_PROGRAM_ID,
   SIP_MEMO_PREFIX,
+  SIP_MEMO_PREFIX_V2,
+  SIP_MEMO_PREFIX_ANY,
   getExplorerUrl as getSolanaExplorerUrl,
   getTokenMint,
   getSolanaTokenDecimals,

--- a/packages/sdk/tests/memo-prefix-exports.test.ts
+++ b/packages/sdk/tests/memo-prefix-exports.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import * as sdk from '../src'
+
+// Guards the public package entry (src/index.ts). The canonical SIP memo-prefix
+// constants are defined in chains/solana/constants.ts and re-exported from the
+// chains/solana sub-barrel, but SIP_MEMO_PREFIX_V2 / SIP_MEMO_PREFIX_ANY were
+// never re-exported from the package root — so ESM/TS consumers couldn't import
+// them (sip-protocol#1123). A namespace import keeps a missing export a clean
+// `undefined` assertion failure rather than a module-resolution error.
+describe('public SIP memo-prefix exports', () => {
+  it('re-exports SIP_MEMO_PREFIX (legacy, SIP:1)', () => {
+    expect(sdk.SIP_MEMO_PREFIX).toBe('SIP:1:')
+  })
+
+  it('re-exports SIP_MEMO_PREFIX_V2 (canonical, SIP:2)', () => {
+    expect(sdk.SIP_MEMO_PREFIX_V2).toBe('SIP:2:')
+  })
+
+  it('re-exports SIP_MEMO_PREFIX_ANY (version-agnostic prefix)', () => {
+    expect(sdk.SIP_MEMO_PREFIX_ANY).toBe('SIP:')
+  })
+})


### PR DESCRIPTION
Closes #1123.

## Problem

`SIP_MEMO_PREFIX_V2` (`'SIP:2:'`) and `SIP_MEMO_PREFIX_ANY` (`'SIP:'`) are defined in `packages/sdk/src/chains/solana/constants.ts` and re-exported from the `chains/solana` sub-barrel (`chains/solana/index.ts`), but the **public package entry** `packages/sdk/src/index.ts` re-exported only `SIP_MEMO_PREFIX`. With no `./chains/solana` deep path in `package.json#exports`, the two constants were **unreachable** for consumers:

- `tsc` → `TS2305 has no exported member`
- bundlers that tolerate missing named ESM imports (Vite/esbuild) → `undefined` at runtime

This is exactly how the gap surfaced downstream — sipher's memo-scan route imported `SIP_MEMO_PREFIX_ANY`, got `undefined`, and silently skipped every log (sipher#314 worked around it with a local constant).

## Fix

Add both names to the public re-export list in `src/index.ts`, next to `SIP_MEMO_PREFIX`. Two lines.

## Test (TDD — red first)

`packages/sdk/tests/memo-prefix-exports.test.ts` — a namespace-import guard (`import * as sdk from '../src'`) asserting all three SIP memo-prefix constants resolve from the package entry. Red before the fix (`_V2`/`_ANY` → `undefined`), green after. Namespace import keeps a missing export a clean assertion failure rather than a module-resolution error.

## Validation

- `vitest run tests/memo-prefix-exports.test.ts` → 3/3 (was 2 failing)
- `tsc --noEmit` (SDK) → clean; no duplicate-export collision (NEAR's `SIP_MEMO_PREFIX_ANY` is not separately re-exported from the entry)

## Versioning note

Changeset is **minor** — this adds importable symbols to the public/typed API surface (backward-compatible addition), consistent with the repo precedent (#1107 "adds public API → minor"). Happy to downgrade to **patch** if you'd rather treat it as an export-completeness fix. Merging will trigger the changesets release pipeline (auto-publish).