### PR TITLE
feat(sdk): gasless cash-out relayer for stealth recipients

### DIFF
--- a/.changeset/gasless-cashout-relayer.md
+++ b/.changeset/gasless-cashout-relayer.md
@@ -7,3 +7,4 @@ Add gasless cash-out relayer for stealth recipients
 - `buildGaslessCashout` / `submitGaslessCashout`: build and submit a stealth-claim transaction where a relayer pays the network fee and recovers it from the claimed amount (direct fee-payer submission, with an optional Jito bundle path for mainnet hardening).
 - `computeRelayerFee`: hybrid relayer-fee helper — `max(flatFloor, amount * bps / 10_000)` — with input validation.
 - `deriveStealthSigner` / `signEd25519WithScalar`: correct ed25519 signing for scalar-derived stealth addresses. Claiming an ed25519 stealth payment via the SDK previously produced invalid signatures because the derived scalar was signed as a key seed; stealth claims now sign and verify correctly.
+- `SolanaScanResult` (and `DetectedPayment`) now carry the announcement scheme `version`, so a scanned payment claims with the matching derivation — legacy `SIP:1` payments stay claimable.

--- a/.changeset/gasless-cashout-relayer.md
+++ b/.changeset/gasless-cashout-relayer.md
@@ -1,0 +1,9 @@
+---
+"@sip-protocol/sdk": minor
+---
+
+Add gasless cash-out relayer for stealth recipients
+
+- `buildGaslessCashout` / `submitGaslessCashout`: build and submit a stealth-claim transaction where a relayer pays the network fee and recovers it from the claimed amount (direct fee-payer submission, with an optional Jito bundle path for mainnet hardening).
+- `computeRelayerFee`: hybrid relayer-fee helper — `max(flatFloor, amount * bps / 10_000)` — with input validation.
+- `deriveStealthSigner` / `signEd25519WithScalar`: correct ed25519 signing for scalar-derived stealth addresses. Claiming an ed25519 stealth payment via the SDK previously produced invalid signatures because the derived scalar was signed as a key seed; stealth claims now sign and verify correctly.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -86,6 +86,7 @@
     "@solana/spl-token": "^0.4.14",
     "@solana/web3.js": "^1.98.4",
     "@triton-one/yellowstone-grpc": "^4.0.2",
+    "bs58": "^6.0.0",
     "langchain": "^1.4.4",
     "pino": "^10.3.1",
     "zod": "^4.4.3"

--- a/packages/sdk/src/chains/solana/gasless-cashout.ts
+++ b/packages/sdk/src/chains/solana/gasless-cashout.ts
@@ -13,6 +13,7 @@ import {
   Connection,
   PublicKey,
   Transaction,
+  Keypair,
 } from '@solana/web3.js'
 import {
   getAssociatedTokenAddress,
@@ -22,6 +23,8 @@ import {
 import type { HexString } from '@sip-protocol/types'
 import { deriveStealthSigner } from './stealth-signer'
 import { computeRelayerFee, type RelayerFeeConfig } from './relayer-fee'
+import { getExplorerUrl, type SolanaCluster } from './constants'
+import type { JitoRelayer } from '../../solana/jito-relayer'
 
 /** Parameters for building a gasless cash-out transaction. */
 export interface GaslessCashoutParams {
@@ -165,5 +168,120 @@ export async function buildGaslessCashout(
     netAmount,
     blockhash,
     lastValidBlockHeight,
+  }
+}
+
+/** Detect the Solana cluster from an RPC endpoint URL. */
+function detectCluster(endpoint: string): SolanaCluster {
+  if (endpoint.includes('devnet')) {
+    return 'devnet'
+  }
+  if (endpoint.includes('testnet')) {
+    return 'testnet'
+  }
+  if (endpoint.includes('localhost') || endpoint.includes('127.0.0.1')) {
+    return 'localnet'
+  }
+  return 'mainnet-beta'
+}
+
+/** Parameters for submitting a built gasless cash-out. */
+export interface SubmitGaslessCashoutParams {
+  /** Solana RPC connection */
+  connection: Connection
+  /** Output of buildGaslessCashout (stealth already signed) */
+  build: GaslessCashoutBuild
+  /** Relayer keypair — must equal build.transaction.feePayer */
+  relayerKeypair: Keypair
+  /** Optional Jito relayer for the bundle path (mainnet hardening). Default: direct submit. */
+  jitoRelayer?: JitoRelayer
+  /** Tip in lamports for the Jito path (ignored on the direct path) */
+  tipLamports?: number
+}
+
+/** Result of a gasless cash-out. */
+export interface GaslessCashoutResult {
+  /** Transaction signature (base58) */
+  txSignature: string
+  /** Destination that received the net amount (base58) */
+  destinationAddress: string
+  /** Net amount forwarded (base units) */
+  amount: bigint
+  /** Relayer fee charged (base units) */
+  relayerFee: bigint
+  /** Explorer URL */
+  explorerUrl: string
+  /** Whether the Jito bundle path was used */
+  viaJito: boolean
+}
+
+/**
+ * Sign as the relayer (fee-payer) and submit a gasless cash-out.
+ *
+ * Direct submission is the primary path (works on devnet + mainnet). Supplying a
+ * `jitoRelayer` routes through a Jito bundle instead (optional mainnet hardening;
+ * Jito has no devnet block engine).
+ *
+ * @throws If `relayerKeypair` is not the transaction's fee-payer
+ */
+export async function submitGaslessCashout(
+  params: SubmitGaslessCashoutParams
+): Promise<GaslessCashoutResult> {
+  const { connection, build, relayerKeypair, jitoRelayer, tipLamports } = params
+  const { transaction, netAmount, relayerFee, destinationAddress } = build
+
+  if (!transaction.feePayer || !transaction.feePayer.equals(relayerKeypair.publicKey)) {
+    throw new Error('relayerKeypair does not match the transaction fee-payer')
+  }
+
+  // Relayer adds its fee-payer signature alongside the stealth signature.
+  transaction.partialSign(relayerKeypair)
+
+  const cluster = detectCluster(connection.rpcEndpoint)
+
+  // Optional Jito path (mainnet only — Jito has no devnet block engine).
+  if (jitoRelayer) {
+    const relayed = await jitoRelayer.relayTransaction({
+      transaction,
+      tipLamports,
+      tipPayer: relayerKeypair,
+      waitForConfirmation: true,
+    })
+    return {
+      txSignature: relayed.signature,
+      destinationAddress,
+      amount: netAmount,
+      relayerFee,
+      explorerUrl: getExplorerUrl(relayed.signature, cluster),
+      viaJito: true,
+    }
+  }
+
+  // Direct path (primary): relayer is fee-payer; sendRawTransaction returns a base58 sig.
+  const txSignature = await connection.sendRawTransaction(transaction.serialize(), {
+    skipPreflight: false,
+    preflightCommitment: 'confirmed',
+  })
+  const confirmation = await connection.confirmTransaction(
+    {
+      signature: txSignature,
+      blockhash: build.blockhash,
+      lastValidBlockHeight: build.lastValidBlockHeight,
+    },
+    'confirmed'
+  )
+  if (confirmation.value.err) {
+    throw new Error(
+      `Gasless cash-out landed but failed on-chain: ${JSON.stringify(confirmation.value.err)}`
+    )
+  }
+
+  return {
+    txSignature,
+    destinationAddress,
+    amount: netAmount,
+    relayerFee,
+    explorerUrl: getExplorerUrl(txSignature, cluster),
+    viaJito: false,
   }
 }

--- a/packages/sdk/src/chains/solana/gasless-cashout.ts
+++ b/packages/sdk/src/chains/solana/gasless-cashout.ts
@@ -6,7 +6,7 @@
  * stealth address signs only the token transfers (via its raw ed25519 scalar — see
  * deriveStealthSigner). The relayer recovers its SOL cost as an SPL fee deducted from
  * the tokens being moved (fee-from-claim). Direct submission is the primary path; a
- * Jito bundle is an optional mainnet hardening layer (see submitGaslessCashout, Task 5).
+ * Jito bundle is an optional mainnet hardening layer (see submitGaslessCashout).
  */
 
 import {

--- a/packages/sdk/src/chains/solana/gasless-cashout.ts
+++ b/packages/sdk/src/chains/solana/gasless-cashout.ts
@@ -1,0 +1,169 @@
+/**
+ * Gasless cash-out for stealth recipients.
+ *
+ * A stealth address that received SPL tokens typically holds ZERO SOL, so it cannot
+ * pay a transaction fee to move those tokens out. Here a relayer is the fee-payer; the
+ * stealth address signs only the token transfers (via its raw ed25519 scalar — see
+ * deriveStealthSigner). The relayer recovers its SOL cost as an SPL fee deducted from
+ * the tokens being moved (fee-from-claim). Direct submission is the primary path; a
+ * Jito bundle is an optional mainnet hardening layer (see submitGaslessCashout, Task 5).
+ */
+
+import {
+  Connection,
+  PublicKey,
+  Transaction,
+} from '@solana/web3.js'
+import {
+  getAssociatedTokenAddress,
+  createTransferInstruction,
+  createAssociatedTokenAccountInstruction,
+} from '@solana/spl-token'
+import type { HexString } from '@sip-protocol/types'
+import { deriveStealthSigner } from './stealth-signer'
+import { computeRelayerFee, type RelayerFeeConfig } from './relayer-fee'
+
+/** Parameters for building a gasless cash-out transaction. */
+export interface GaslessCashoutParams {
+  /** Solana RPC connection */
+  connection: Connection
+  /** Stealth address holding the tokens (base58) */
+  stealthAddress: string
+  /** Ephemeral public key from the payment (base58) */
+  ephemeralPublicKey: string
+  /** Recipient's viewing private key (hex) */
+  viewingPrivateKey: HexString
+  /** Recipient's spending private key (hex) */
+  spendingPrivateKey: HexString
+  /** Final destination address (base58) */
+  destinationAddress: string
+  /** SPL token mint */
+  mint: PublicKey
+  /** Relayer public key — the transaction fee-payer (must hold SOL) */
+  relayerPublicKey: PublicKey
+  /** Relayer's token account that receives the fee (ATA for `mint`) */
+  relayerFeeAccount: PublicKey
+  /** Fee model */
+  feeConfig: RelayerFeeConfig
+  /** Announcement scheme version: '2' canonical (default) | '1' legacy */
+  version?: '1' | '2'
+}
+
+/** A stealth-signed gasless cash-out transaction, awaiting the relayer's fee-payer signature. */
+export interface GaslessCashoutBuild {
+  /** Transaction signed by the stealth address; feePayer = relayer (relayer must still sign) */
+  transaction: Transaction
+  /** Stealth address (base58) */
+  stealthAddress: string
+  /** Final destination (base58) */
+  destinationAddress: string
+  /** Gross amount in the stealth token account (base units) */
+  grossAmount: bigint
+  /** Relayer fee deducted (base units) */
+  relayerFee: bigint
+  /** Net amount forwarded to the destination (base units) */
+  netAmount: bigint
+  /** Blockhash the transaction is bound to */
+  blockhash: string
+  /** Last valid block height for confirmation */
+  lastValidBlockHeight: number
+}
+
+/**
+ * Build a gasless cash-out transaction.
+ *
+ * Derives the stealth signer from the recipient's keys, computes the fee-from-claim,
+ * assembles a two- (or three-) instruction transaction with the relayer as fee-payer,
+ * and pre-signs with the stealth scalar. The relayer must add its own signature before
+ * broadcasting.
+ *
+ * @throws If the relayer fee >= the gross claim amount (nothing left for the recipient)
+ */
+export async function buildGaslessCashout(
+  params: GaslessCashoutParams
+): Promise<GaslessCashoutBuild> {
+  const {
+    connection,
+    stealthAddress,
+    ephemeralPublicKey,
+    viewingPrivateKey,
+    spendingPrivateKey,
+    destinationAddress,
+    mint,
+    relayerPublicKey,
+    relayerFeeAccount,
+    feeConfig,
+    version = '2',
+  } = params
+
+  const stealthSigner = deriveStealthSigner({
+    stealthAddress,
+    ephemeralPublicKey,
+    viewingPrivateKey,
+    spendingPrivateKey,
+    version,
+  })
+  const stealthPubkey = stealthSigner.publicKey
+
+  const stealthATA = await getAssociatedTokenAddress(mint, stealthPubkey, true)
+  const destinationPubkey = new PublicKey(destinationAddress)
+  const destinationATA = await getAssociatedTokenAddress(mint, destinationPubkey)
+
+  // Gross balance held by the stealth ATA
+  const balanceResp = await connection.getTokenAccountBalance(stealthATA)
+  const grossAmount = BigInt(balanceResp.value.amount)
+
+  const relayerFee = computeRelayerFee(grossAmount, feeConfig)
+  if (relayerFee >= grossAmount) {
+    throw new Error(
+      `Relayer fee (${relayerFee}) equals or exceeds the claim amount (${grossAmount}); nothing left to forward`
+    )
+  }
+  const netAmount = grossAmount - relayerFee
+
+  const transaction = new Transaction()
+
+  // Create the destination ATA if missing — relayer pays rent. The flat-floor fee is
+  // intended to cover this, but it is denominated in token base units (no price oracle
+  // in v1), so SOL-rent recovery is approximate, not guaranteed.
+  const destInfo = await connection.getAccountInfo(destinationATA)
+  if (destInfo === null) {
+    transaction.add(
+      createAssociatedTokenAccountInstruction(
+        relayerPublicKey, // payer
+        destinationATA,
+        destinationPubkey,
+        mint
+      )
+    )
+  }
+
+  // Fee: stealth -> relayer fee account
+  transaction.add(
+    createTransferInstruction(stealthATA, relayerFeeAccount, stealthPubkey, relayerFee)
+  )
+  // Net: stealth -> destination
+  transaction.add(
+    createTransferInstruction(stealthATA, destinationATA, stealthPubkey, netAmount)
+  )
+
+  const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash()
+  transaction.recentBlockhash = blockhash
+  transaction.lastValidBlockHeight = lastValidBlockHeight
+  transaction.feePayer = relayerPublicKey
+
+  // Stealth signs the token transfers via its scalar; relayer (fee-payer) signs at submit time.
+  // Must be done AFTER feePayer + recentBlockhash + all instructions are set.
+  stealthSigner.signTransaction(transaction)
+
+  return {
+    transaction,
+    stealthAddress,
+    destinationAddress,
+    grossAmount,
+    relayerFee,
+    netAmount,
+    blockhash,
+    lastValidBlockHeight,
+  }
+}

--- a/packages/sdk/src/chains/solana/gasless-cashout.ts
+++ b/packages/sdk/src/chains/solana/gasless-cashout.ts
@@ -18,7 +18,8 @@ import {
 import {
   getAssociatedTokenAddress,
   createTransferInstruction,
-  createAssociatedTokenAccountInstruction,
+  createAssociatedTokenAccountIdempotentInstruction,
+  getAccount,
 } from '@solana/spl-token'
 import type { HexString } from '@sip-protocol/types'
 import { deriveStealthSigner } from './stealth-signer'
@@ -112,8 +113,33 @@ export async function buildGaslessCashout(
   const destinationPubkey = new PublicKey(destinationAddress)
   const destinationATA = await getAssociatedTokenAddress(mint, destinationPubkey)
 
+  if (destinationATA.equals(stealthATA)) {
+    throw new Error(
+      'destinationAddress resolves to the stealth token account; choose a different destination'
+    )
+  }
+
+  // Validate the relayer fee account is a token account for `mint` — otherwise the fee
+  // transfer would fail (mint mismatch) or the fee would be unrecoverable.
+  let feeAccount
+  try {
+    feeAccount = await getAccount(connection, relayerFeeAccount)
+  } catch {
+    throw new Error('relayerFeeAccount does not exist or is not a token account')
+  }
+  if (!feeAccount.mint.equals(mint)) {
+    throw new Error('relayerFeeAccount is not an associated token account for the given mint')
+  }
+
   // Gross balance held by the stealth ATA
-  const balanceResp = await connection.getTokenAccountBalance(stealthATA)
+  let balanceResp
+  try {
+    balanceResp = await connection.getTokenAccountBalance(stealthATA)
+  } catch {
+    throw new Error(
+      `Stealth token account ${stealthATA.toBase58()} for mint ${mint.toBase58()} does not exist or holds no balance; nothing to cash out`
+    )
+  }
   const grossAmount = BigInt(balanceResp.value.amount)
 
   const relayerFee = computeRelayerFee(grossAmount, feeConfig)
@@ -126,20 +152,19 @@ export async function buildGaslessCashout(
 
   const transaction = new Transaction()
 
-  // Create the destination ATA if missing — relayer pays rent. The flat-floor fee is
-  // intended to cover this, but it is denominated in token base units (no price oracle
-  // in v1), so SOL-rent recovery is approximate, not guaranteed.
-  const destInfo = await connection.getAccountInfo(destinationATA)
-  if (destInfo === null) {
-    transaction.add(
-      createAssociatedTokenAccountInstruction(
-        relayerPublicKey, // payer
-        destinationATA,
-        destinationPubkey,
-        mint
-      )
+  // Idempotently create the destination ATA — relayer pays rent. Idempotent means a
+  // no-op if it already exists, so no separate existence read is needed (one fewer RPC,
+  // and no TOCTOU gap between the read and broadcast). The flat-floor fee is intended to
+  // cover this rent, but it is denominated in token base units (no price oracle in v1),
+  // so SOL-rent recovery is approximate, not guaranteed.
+  transaction.add(
+    createAssociatedTokenAccountIdempotentInstruction(
+      relayerPublicKey, // payer (relayer pays rent)
+      destinationATA,
+      destinationPubkey,
+      mint
     )
-  }
+  )
 
   // Fee: stealth -> relayer fee account
   transaction.add(
@@ -234,8 +259,15 @@ export async function submitGaslessCashout(
     throw new Error('relayerKeypair does not match the transaction fee-payer')
   }
 
-  // Relayer adds its fee-payer signature alongside the stealth signature.
-  transaction.partialSign(relayerKeypair)
+  // Relayer adds its fee-payer signature alongside the stealth signature. Guard against
+  // re-signing when the same build is retried after a transient send failure — a second
+  // partialSign is wasteful and could surprise callers inspecting the signature set.
+  const relayerAlreadySigned = transaction.signatures.some(
+    (s) => s.publicKey.equals(relayerKeypair.publicKey) && s.signature !== null
+  )
+  if (!relayerAlreadySigned) {
+    transaction.partialSign(relayerKeypair)
+  }
 
   const cluster = detectCluster(connection.rpcEndpoint)
 
@@ -247,13 +279,25 @@ export async function submitGaslessCashout(
       tipPayer: relayerKeypair,
       waitForConfirmation: true,
     })
+    // Only a confirmed bundle means the funds actually moved. A 'submitted'/'failed'
+    // status is NOT success — surfacing it as one would silently lose the cash-out.
+    if (relayed.status !== 'confirmed') {
+      throw new Error(
+        `Gasless cash-out via Jito did not confirm (status: ${relayed.status})` +
+        (relayed.error ? `: ${relayed.error}` : '')
+      )
+    }
+    if (!relayed.signature) {
+      throw new Error('Gasless cash-out via Jito returned an empty transaction signature')
+    }
     return {
       txSignature: relayed.signature,
       destinationAddress,
       amount: netAmount,
       relayerFee,
       explorerUrl: getExplorerUrl(relayed.signature, cluster),
-      viaJito: true,
+      // Report the TRUE path: the relayer may have fallen back to direct submission.
+      viaJito: relayed.relayed,
     }
   }
 

--- a/packages/sdk/src/chains/solana/index.ts
+++ b/packages/sdk/src/chains/solana/index.ts
@@ -359,3 +359,19 @@ export {
   type VerifyProofResult,
   type Groth16Proof,
 } from './sunspot-verifier'
+
+// Gasless Cash-Out (relayer fee-payer for stealth recipients)
+export {
+  buildGaslessCashout,
+  submitGaslessCashout,
+} from './gasless-cashout'
+export type {
+  GaslessCashoutParams,
+  GaslessCashoutBuild,
+  SubmitGaslessCashoutParams,
+  GaslessCashoutResult,
+} from './gasless-cashout'
+export { computeRelayerFee } from './relayer-fee'
+export type { RelayerFeeConfig } from './relayer-fee'
+export { signEd25519WithScalar, deriveStealthSigner } from './stealth-signer'
+export type { StealthSigner, DeriveStealthSignerParams } from './stealth-signer'

--- a/packages/sdk/src/chains/solana/privacy-adapter.ts
+++ b/packages/sdk/src/chains/solana/privacy-adapter.ts
@@ -520,6 +520,7 @@ export class SolanaPrivacyAdapter {
       spendingPrivateKey: params.spendingPrivateKey,
       destinationAddress: params.destinationAddress,
       mint: new PublicKey(params.payment.mint),
+      version: params.payment.version,
     })
   }
 

--- a/packages/sdk/src/chains/solana/providers/webhook.ts
+++ b/packages/sdk/src/chains/solana/providers/webhook.ts
@@ -666,6 +666,7 @@ async function processRawTransaction(
       const payment: SolanaScanResult = {
         stealthAddress: announcement.stealthAddress || '',
         ephemeralPublicKey: announcement.ephemeralPublicKey,
+        version: announcement.version as '1' | '2',
         amount: transferInfo?.amount ?? 0n,
         mint: transferInfo?.mint ?? '',
         tokenSymbol: transferInfo?.mint ? getTokenSymbol(transferInfo.mint) : undefined,

--- a/packages/sdk/src/chains/solana/relayer-fee.ts
+++ b/packages/sdk/src/chains/solana/relayer-fee.ts
@@ -1,0 +1,36 @@
+/**
+ * Relayer fee model for gasless cash-out.
+ *
+ * The relayer fronts the SOL transaction fee on behalf of a stealth recipient
+ * and recovers its cost from the SPL tokens being cashed out (fee-from-claim).
+ * The fee is `max(flatFloor, amount * bps / 10_000)`: the floor guarantees the
+ * fixed SOL gas cost is covered even on tiny claims; bps scales on large ones.
+ * No price oracle in v1 — the floor is set in the token's base units.
+ */
+
+/** Relayer fee configuration (per token mint). */
+export interface RelayerFeeConfig {
+  /** Flat floor fee in the token's base units. Guarantees gas coverage on small claims. */
+  flatFloor: bigint
+  /** Basis points of the claim amount (1 bps = 0.01%). e.g. 10 = 0.1%. */
+  bps: number
+}
+
+/**
+ * Compute the relayer fee for a claim.
+ *
+ * @param amount - Gross amount available in the stealth token account (base units)
+ * @param config - Fee model
+ * @returns Fee in the token's base units (always >= flatFloor)
+ * @throws If `bps` is negative or non-integer, or if `amount` is negative
+ */
+export function computeRelayerFee(amount: bigint, config: RelayerFeeConfig): bigint {
+  if (!Number.isInteger(config.bps) || config.bps < 0) {
+    throw new Error('bps must be a non-negative integer')
+  }
+  if (amount < 0n) {
+    throw new Error('amount must be a non-negative bigint')
+  }
+  const bpsFee = (amount * BigInt(config.bps)) / 10_000n
+  return bpsFee > config.flatFloor ? bpsFee : config.flatFloor
+}

--- a/packages/sdk/src/chains/solana/relayer-fee.ts
+++ b/packages/sdk/src/chains/solana/relayer-fee.ts
@@ -22,7 +22,7 @@ export interface RelayerFeeConfig {
  * @param amount - Gross amount available in the stealth token account (base units)
  * @param config - Fee model
  * @returns Fee in the token's base units (always >= flatFloor)
- * @throws If `bps` is negative or non-integer, or if `amount` is negative
+ * @throws If `bps` is negative or non-integer, or if `amount` is negative, or if flatFloor is negative
  */
 export function computeRelayerFee(amount: bigint, config: RelayerFeeConfig): bigint {
   if (!Number.isInteger(config.bps) || config.bps < 0) {
@@ -30,6 +30,9 @@ export function computeRelayerFee(amount: bigint, config: RelayerFeeConfig): big
   }
   if (amount < 0n) {
     throw new Error('amount must be a non-negative bigint')
+  }
+  if (typeof config.flatFloor !== 'bigint' || config.flatFloor < 0n) {
+    throw new Error('flatFloor must be a non-negative bigint')
   }
   const bpsFee = (amount * BigInt(config.bps)) / 10_000n
   return bpsFee > config.flatFloor ? bpsFee : config.flatFloor

--- a/packages/sdk/src/chains/solana/scan.ts
+++ b/packages/sdk/src/chains/solana/scan.ts
@@ -7,7 +7,6 @@
 import {
   PublicKey,
   Transaction,
-  Keypair,
 } from '@solana/web3.js'
 import {
   getAssociatedTokenAddress,
@@ -16,8 +15,6 @@ import {
 } from '@solana/spl-token'
 import {
   checkEd25519StealthAddress,
-  deriveEd25519StealthPrivateKey,
-  deriveEd25519StealthPrivateKeyV1,
   solanaAddressToEd25519PublicKey,
 } from '../../stealth'
 import type { StealthAddress, HexString } from '@sip-protocol/types'
@@ -38,8 +35,7 @@ import {
 } from './constants'
 import { getTokenSymbol, parseTokenTransferFromBalances } from './utils'
 import type { SolanaRPCProvider } from './providers/interface'
-import { hexToBytes } from '@noble/hashes/utils'
-import { ed25519 } from '@noble/curves/ed25519'
+import { deriveStealthSigner } from './stealth-signer'
 
 /**
  * Scan for incoming stealth payments
@@ -276,54 +272,14 @@ export async function claimStealthPayment(
     )
   }
 
-  // Convert addresses to hex for SDK functions
-  const stealthAddressHex = solanaAddressToEd25519PublicKey(stealthAddress)
-  const ephemeralPubKeyHex = solanaAddressToEd25519PublicKey(ephemeralPublicKey)
-
-  // Construct stealth address object
-  const stealthAddressObj: StealthAddress = {
-    address: stealthAddressHex,
-    ephemeralPublicKey: ephemeralPubKeyHex,
-    viewTag: 0, // Not needed for derivation
-  }
-
-  // Derive stealth private key — route by announcement version:
-  // legacy SIP:1 (swapped scheme) vs canonical SIP:2 (EIP-5564).
-  const recovery = version === '1'
-    ? deriveEd25519StealthPrivateKeyV1(stealthAddressObj, spendingPrivateKey, viewingPrivateKey)
-    : deriveEd25519StealthPrivateKey(stealthAddressObj, spendingPrivateKey, viewingPrivateKey)
-
-  // Create Solana keypair from derived private key
-  // Note: ed25519 private keys in Solana are seeds, not raw scalars
-  // The SDK returns a scalar, so we need to handle this carefully
-  const stealthPrivKeyBytes = hexToBytes(recovery.privateKey.slice(2))
-
-  // Validate that the derived private key (scalar) produces the expected public key
-  // Note: SIP derives a scalar, not a seed. We use scalar multiplication to verify.
+  const stealthSigner = deriveStealthSigner({
+    stealthAddress,
+    ephemeralPublicKey,
+    viewingPrivateKey,
+    spendingPrivateKey,
+    version,
+  })
   const stealthPubkey = new PublicKey(stealthAddress)
-  const expectedPubKeyBytes = stealthPubkey.toBytes()
-
-  // Convert scalar bytes to bigint (little-endian for ed25519)
-  const scalarBigInt = bytesToBigIntLE(stealthPrivKeyBytes)
-  const ED25519_ORDER = 2n ** 252n + 27742317777372353535851937790883648493n
-  let validScalar = scalarBigInt % ED25519_ORDER
-  if (validScalar === 0n) validScalar = 1n
-
-  // Derive public key via scalar multiplication
-  const derivedPubKeyBytes = ed25519.ExtendedPoint.BASE.multiply(validScalar).toRawBytes()
-
-  if (!derivedPubKeyBytes.every((b, i) => b === expectedPubKeyBytes[i])) {
-    throw new Error(
-      'Stealth key derivation failed: derived private key does not produce expected public key. ' +
-      'This may indicate incorrect spending/viewing keys or corrupted announcement data.'
-    )
-  }
-
-  // Solana keypairs expect 64 bytes (32 byte seed + 32 byte public key)
-  // We construct this from the derived scalar (now validated)
-  const stealthKeypair = Keypair.fromSecretKey(
-    new Uint8Array([...stealthPrivKeyBytes, ...expectedPubKeyBytes])
-  )
 
   // Get token accounts
   const stealthATA = await getAssociatedTokenAddress(
@@ -360,8 +316,8 @@ export async function claimStealthPayment(
   transaction.lastValidBlockHeight = lastValidBlockHeight
   transaction.feePayer = stealthPubkey // Stealth address pays fee
 
-  // Sign with stealth keypair
-  transaction.sign(stealthKeypair)
+  // Sign with stealth scalar signer (Keypair cannot sign a raw-scalar stealth address)
+  stealthSigner.signTransaction(transaction)
 
   // Send transaction
   const txSignature = await connection.sendRawTransaction(
@@ -462,19 +418,3 @@ function detectCluster(endpoint: string): SolanaCluster {
   return 'mainnet-beta'
 }
 
-/**
- * Convert bytes to bigint in little-endian format
- *
- * Used for ed25519 scalar conversion where bytes are in little-endian order.
- *
- * @param bytes - Byte array to convert
- * @returns BigInt representation of the bytes
- * @internal
- */
-function bytesToBigIntLE(bytes: Uint8Array): bigint {
-  let result = 0n
-  for (let i = bytes.length - 1; i >= 0; i--) {
-    result = (result << 8n) | BigInt(bytes[i])
-  }
-  return result
-}

--- a/packages/sdk/src/chains/solana/scan.ts
+++ b/packages/sdk/src/chains/solana/scan.ts
@@ -197,6 +197,7 @@ export async function scanForPayments(
               results.push({
                 stealthAddress: announcement.stealthAddress || '',
                 ephemeralPublicKey: announcement.ephemeralPublicKey,
+                version: announcement.version as '1' | '2',
                 amount,
                 mint: transferInfo.mint,
                 tokenSymbol,

--- a/packages/sdk/src/chains/solana/stealth-scanner.ts
+++ b/packages/sdk/src/chains/solana/stealth-scanner.ts
@@ -116,6 +116,13 @@ export interface DetectedPayment {
   ephemeralPublicKey: string
 
   /**
+   * Announcement scheme version ('1' legacy | '2' canonical).
+   * Pass to the claim path so it routes to the matching derivation.
+   * Optional for back-compat with payments detected before version threading.
+   */
+  version?: '1' | '2'
+
+  /**
    * View tag for efficient scanning
    */
   viewTag: number
@@ -548,6 +555,7 @@ export class StealthScanner {
           return {
             stealthAddress: announcement.stealthAddress || '',
             ephemeralPublicKey: announcement.ephemeralPublicKey,
+            version: announcement.version as '1' | '2',
             viewTag: viewTagNumber,
             amount,
             mint: transferInfo.mint,

--- a/packages/sdk/src/chains/solana/stealth-signer.ts
+++ b/packages/sdk/src/chains/solana/stealth-signer.ts
@@ -1,0 +1,145 @@
+/**
+ * Stealth address signing for Solana.
+ *
+ * SIP's ed25519 stealth derivation yields a RAW SCALAR (s = s_spend + H(S) mod L),
+ * not a standard ed25519 seed. Solana's `Keypair` (tweetnacl) signs by treating the
+ * first 32 bytes as a seed (SHA-512 + clamp), so it cannot sign for a stealth address
+ * whose private key is a raw scalar. This module signs directly with the scalar using
+ * RFC 8032 Ed25519 — producing signatures any standard verifier and the Solana runtime
+ * accept — and attaches them to a transaction via `Transaction.addSignature`.
+ */
+
+import { PublicKey, Transaction } from '@solana/web3.js'
+import { ed25519 } from '@noble/curves/ed25519'
+import { sha512 } from '@noble/hashes/sha512'
+import { hexToBytes } from '@noble/hashes/utils'
+import type { StealthAddress, HexString } from '@sip-protocol/types'
+import {
+  deriveEd25519StealthPrivateKey,
+  deriveEd25519StealthPrivateKeyV1,
+  solanaAddressToEd25519PublicKey,
+} from '../../stealth'
+import { bytesToBigIntLE, bigIntToBytesLE, ED25519_ORDER } from '../../stealth/utils'
+
+/** Reduce a bigint into [0, L). */
+function modL(value: bigint): bigint {
+  const reduced = value % ED25519_ORDER
+  return reduced >= 0n ? reduced : reduced + ED25519_ORDER
+}
+
+/**
+ * Produce an RFC 8032 Ed25519 signature from a raw little-endian scalar.
+ *
+ * Unlike `Keypair`/tweetnacl signing (which expects a 32-byte seed and re-derives the
+ * scalar via SHA-512 + clamp), this signs directly with the provided scalar `a` whose
+ * public key is `A = a·G`. The per-signature nonce is derived deterministically from a
+ * hash of the scalar and the message (RFC 8032 structure): unique per message, never
+ * reused across distinct messages.
+ *
+ * @param message - Exact bytes to sign (e.g. a compiled transaction message)
+ * @param scalar - 32-byte little-endian ed25519 scalar (the stealth private key)
+ * @returns 64-byte signature (R ‖ S)
+ * @throws If the scalar reduces to zero
+ */
+export function signEd25519WithScalar(message: Uint8Array, scalar: Uint8Array): Uint8Array {
+  const a = modL(bytesToBigIntLE(scalar))
+  if (a === 0n) {
+    throw new Error('Invalid stealth scalar: reduces to zero')
+  }
+  const A = ed25519.ExtendedPoint.BASE.multiply(a).toRawBytes()
+
+  const prefix = sha512(scalar).slice(32, 64)
+  const r = modL(bytesToBigIntLE(sha512(new Uint8Array([...prefix, ...message]))))
+  if (r === 0n) {
+    throw new Error('Invalid nonce: reduces to zero')
+  }
+  const R = ed25519.ExtendedPoint.BASE.multiply(r).toRawBytes()
+
+  const k = modL(bytesToBigIntLE(sha512(new Uint8Array([...R, ...A, ...message]))))
+  const S = modL(r + k * a)
+
+  return new Uint8Array([...R, ...bigIntToBytesLE(S, 32)])
+}
+
+/** Parameters needed to derive a stealth address's signer. */
+export interface DeriveStealthSignerParams {
+  /** Stealth address (base58) */
+  stealthAddress: string
+  /** Ephemeral public key from the payment (base58) */
+  ephemeralPublicKey: string
+  /** Recipient's viewing private key (hex) */
+  viewingPrivateKey: HexString
+  /** Recipient's spending private key (hex) */
+  spendingPrivateKey: HexString
+  /** Announcement scheme version: '2' canonical (default) | '1' legacy */
+  version?: '1' | '2'
+}
+
+/** Signs transactions/messages as a stealth address using its raw ed25519 scalar. */
+export interface StealthSigner {
+  /** The stealth address this signer controls */
+  readonly publicKey: PublicKey
+  /** Sign arbitrary bytes, returning a 64-byte ed25519 signature */
+  signMessage(message: Uint8Array): Uint8Array
+  /** Attach this stealth address's signature to a transaction. Call LAST — after feePayer, recentBlockhash, and all instructions are finalized (the signature covers the serialized message at call time). */
+  signTransaction(transaction: Transaction): void
+}
+
+/**
+ * Re-derive the signer that controls a stealth address.
+ *
+ * Routes derivation by announcement version (canonical SIP:2 vs legacy SIP:1) and
+ * validates the derived scalar reproduces the on-chain stealth public key before
+ * returning a signer. The signer signs with the raw scalar (see
+ * {@link signEd25519WithScalar}); it does NOT construct a `Keypair`, which cannot sign
+ * for a scalar-derived stealth address.
+ *
+ * @throws If the derived scalar does not produce the expected stealth public key
+ */
+export function deriveStealthSigner(params: DeriveStealthSignerParams): StealthSigner {
+  const {
+    stealthAddress,
+    ephemeralPublicKey,
+    viewingPrivateKey,
+    spendingPrivateKey,
+    version = '2',
+  } = params
+
+  const stealthAddressHex = solanaAddressToEd25519PublicKey(stealthAddress)
+  const ephemeralPubKeyHex = solanaAddressToEd25519PublicKey(ephemeralPublicKey)
+
+  const stealthAddressObj: StealthAddress = {
+    address: stealthAddressHex,
+    ephemeralPublicKey: ephemeralPubKeyHex,
+    viewTag: 0,
+  }
+
+  const recovery = version === '1'
+    ? deriveEd25519StealthPrivateKeyV1(stealthAddressObj, spendingPrivateKey, viewingPrivateKey)
+    : deriveEd25519StealthPrivateKey(stealthAddressObj, spendingPrivateKey, viewingPrivateKey)
+
+  const scalar = hexToBytes(recovery.privateKey.slice(2))
+
+  const publicKey = new PublicKey(stealthAddress)
+  const expectedPubKeyBytes = publicKey.toBytes()
+  const derivedPubKeyBytes = ed25519.ExtendedPoint.BASE.multiply(modL(bytesToBigIntLE(scalar))).toRawBytes()
+
+  if (!derivedPubKeyBytes.every((b, i) => b === expectedPubKeyBytes[i])) {
+    throw new Error(
+      'Stealth key derivation failed: derived scalar does not produce expected public key. ' +
+      'This may indicate incorrect spending/viewing keys or corrupted announcement data.'
+    )
+  }
+
+  return {
+    publicKey,
+    signMessage(message: Uint8Array): Uint8Array {
+      return signEd25519WithScalar(message, scalar)
+    },
+    signTransaction(transaction: Transaction): void {
+      const message = transaction.serializeMessage()
+      const signature = signEd25519WithScalar(message, scalar)
+      transaction.addSignature(publicKey, Buffer.from(signature))
+    },
+  }
+}

--- a/packages/sdk/src/chains/solana/types.ts
+++ b/packages/sdk/src/chains/solana/types.ts
@@ -99,6 +99,8 @@ export interface SolanaScanResult {
   stealthAddress: string
   /** Ephemeral public key from the sender (base58) */
   ephemeralPublicKey: string
+  /** Announcement scheme version ('1' legacy | '2' canonical) — pass to claim */
+  version: '1' | '2'
   /** Amount received (in token's smallest unit) */
   amount: bigint
   /** Token mint address */

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1036,6 +1036,12 @@ export {
   // Helius Enhanced Transactions (Human-readable TX data)
   HeliusEnhanced,
   createHeliusEnhanced,
+  // Gasless Cash-Out (relayer fee-payer for stealth recipients)
+  buildGaslessCashout,
+  submitGaslessCashout,
+  computeRelayerFee,
+  signEd25519WithScalar,
+  deriveStealthSigner,
 } from './chains/solana'
 
 // Solana Noir Verification (Aztec/Noir bounty)
@@ -1132,6 +1138,14 @@ export type {
   SIPTransactionMetadata,
   SIPEnhancedTransaction,
   TransactionSummary,
+  // Gasless Cash-Out types (relayer fee-payer for stealth recipients)
+  GaslessCashoutParams,
+  GaslessCashoutBuild,
+  SubmitGaslessCashoutParams,
+  GaslessCashoutResult,
+  RelayerFeeConfig,
+  StealthSigner,
+  DeriveStealthSignerParams,
 } from './chains/solana'
 
 // NEAR Same-Chain Privacy (M17-NEAR)

--- a/packages/sdk/src/solana/jito-relayer.ts
+++ b/packages/sdk/src/solana/jito-relayer.ts
@@ -44,10 +44,10 @@ import {
   VersionedTransaction,
   Transaction,
   SystemProgram,
-  type Keypair,
+  Keypair,
   type TransactionInstruction,
 } from '@solana/web3.js'
-import { bytesToHex } from '@noble/hashes/utils'
+import bs58 from 'bs58'
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -156,6 +156,8 @@ export interface RelayedTransactionRequest {
   transaction: Transaction | VersionedTransaction
   /** Tip amount in lamports (paid by relayer, recovered from user) */
   tipLamports?: number
+  /** Keypair that pays the Jito tip. Required for the Jito-bundle path to land. */
+  tipPayer?: Keypair
   /** Whether to wait for confirmation */
   waitForConfirmation?: boolean
 }
@@ -233,10 +235,11 @@ export class JitoRelayerError extends Error {
  *   blockEngineUrl: 'https://ny.mainnet.block-engine.jito.wtf/api/v1',
  * })
  *
- * // Submit a signed transaction via relayer
+ * // Submit a signed transaction via the relayer (tipPayer is required for the bundle to land)
  * const result = await relayer.relayTransaction({
  *   transaction: signedTx,
  *   tipLamports: 10_000, // 0.00001 SOL tip
+ *   tipPayer: relayerKeypair,
  * })
  *
  * console.log('Transaction relayed:', result.signature)
@@ -260,6 +263,13 @@ export class JitoRelayer {
     this.debug = config.debug ?? false
     this.maxRetries = config.maxRetries ?? JITO_DEFAULTS.maxRetries
     this.submissionTimeout = config.submissionTimeout ?? JITO_DEFAULTS.submissionTimeout
+  }
+
+  // ─── Static Helpers ─────────────────────────────────────────────────────────
+
+  /** Encode a 64-byte ed25519 signature as a base58 string (Solana canonical form). */
+  static encodeSignature(sig: Uint8Array): string {
+    return bs58.encode(sig)
   }
 
   // ─── Public Methods ─────────────────────────────────────────────────────────
@@ -331,10 +341,10 @@ export class JitoRelayer {
     // Extract signatures
     const signatures = bundleTransactions.map(tx => {
       if (tx instanceof VersionedTransaction) {
-        return bytesToHex(tx.signatures[0])
-      } else {
-        return tx.signature?.toString() ?? ''
+        return JitoRelayer.encodeSignature(tx.signatures[0])
       }
+      const sig = tx.signature
+      return sig ? JitoRelayer.encodeSignature(sig) : ''
     })
 
     // Wait for confirmation if requested
@@ -373,6 +383,27 @@ export class JitoRelayer {
     this.log('Relaying transaction')
 
     try {
+      // Jito bundles require a tip to land. If a tipPayer is supplied, use the
+      // bundle path (which prepends a tip tx); otherwise fall through to the
+      // existing single-tx submission.
+      if (request.tipPayer) {
+        const bundle = await this.submitBundle({
+          transactions: [request.transaction],
+          tipLamports: request.tipLamports,
+          tipPayer: request.tipPayer,
+          waitForConfirmation: request.waitForConfirmation,
+        })
+        return {
+          signature: bundle.signatures[bundle.signatures.length - 1] ?? '',
+          bundleId: bundle.bundleId,
+          status: bundle.status === 'landed' ? 'confirmed'
+            : bundle.status === 'submitted' ? 'submitted' : 'failed',
+          slot: bundle.slot,
+          error: bundle.error,
+          relayed: true,
+        }
+      }
+
       // For single transaction relay, we need to handle it differently
       // The transaction should already be signed by the user
       // We add it to a bundle with a tip transaction
@@ -385,9 +416,10 @@ export class JitoRelayer {
       // Get signature
       let signature: string
       if (request.transaction instanceof VersionedTransaction) {
-        signature = bytesToHex(request.transaction.signatures[0])
+        signature = JitoRelayer.encodeSignature(request.transaction.signatures[0])
       } else {
-        signature = request.transaction.signature?.toString() ?? ''
+        const sig = request.transaction.signature
+        signature = sig ? JitoRelayer.encodeSignature(sig) : ''
       }
 
       // Wait for confirmation if requested

--- a/packages/sdk/src/wallet/solana/privacy-adapter.ts
+++ b/packages/sdk/src/wallet/solana/privacy-adapter.ts
@@ -23,6 +23,20 @@ import {
   checkEd25519StealthAddress,
   ed25519PublicKeyToSolanaAddress,
 } from '../../stealth'
+// Imported from the source module (not the barrel) to avoid a circular-import
+// cycle that leaves the barrel re-export undefined at call time — matching the
+// pattern in chains/solana/stealth-signer.ts and chains/ethereum/stealth.ts.
+// Using the canonical primitives here (rather than local copies) guarantees the
+// stealth address this adapter reconstructs is byte-for-byte consistent with the
+// key deriveEd25519StealthPrivateKey returns — they must share the SAME
+// bytesToBigInt (big-endian) and curve order.
+import {
+  getEd25519Scalar,
+  bytesToBigInt,
+  bytesToHex,
+  hexToBytes,
+  ED25519_ORDER,
+} from '../../stealth/utils'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -87,7 +101,12 @@ export interface ScannedPayment {
  * Result of claiming a stealth payment
  */
 export interface ClaimResult {
-  /** Derived private key for spending */
+  /**
+   * Derived spending key — a RAW ed25519 scalar (hex), NOT a 32-byte Keypair seed.
+   * Do NOT pass to `new Keypair(...)` / `Keypair.fromSecretKey(...)` — it produces
+   * INVALID signatures. Sign with `signEd25519WithScalar` (or `deriveStealthSigner`)
+   * from `@sip-protocol/sdk` instead.
+   */
   privateKey: HexString
   /** Public key (stealth address) */
   publicKey: HexString
@@ -134,7 +153,8 @@ export interface ClaimResult {
  * const payments = wallet.scanPayments([announcement1, announcement2])
  * for (const payment of payments.filter(p => p.isOwned)) {
  *   const claim = wallet.deriveClaimKey(payment.ephemeralPublicKey, payment.viewTag)
- *   // Use claim.privateKey to sign transactions
+ *   // claim.privateKey is a RAW scalar — sign via signEd25519WithScalar, NOT a Keypair:
+ *   const sig = signEd25519WithScalar(message, hexToBytes(claim.privateKey.slice(2)))
  * }
  * ```
  */
@@ -358,10 +378,13 @@ export class PrivacySolanaWalletAdapter extends SolanaWalletAdapter {
     // Compute stealth address from ephemeral key
     const ephemeralPubBytes = hexToBytes(ephemeralPublicKey.slice(2))
 
-    // Compute shared secret: S = viewing_scalar * R (canonical EIP-5564)
-    const viewingScalar = getEd25519ScalarFromPrivate(
-      hexToBytes(this.stealthKeys.viewingPrivateKey.slice(2))
-    )
+    // Compute shared secret: S = viewing_scalar * R (canonical EIP-5564).
+    // Must use the canonical ed25519 scalar (SHA-512 + little-endian +
+    // reduction mod L) so the address this reconstructs matches the key
+    // deriveEd25519StealthPrivateKey returns below.
+    const viewingScalar =
+      getEd25519Scalar(hexToBytes(this.stealthKeys.viewingPrivateKey.slice(2))) %
+      ED25519_ORDER
 
     const ephemeralPoint = ed25519.ExtendedPoint.fromHex(ephemeralPubBytes)
     const sharedSecretPoint = ephemeralPoint.multiply(viewingScalar)
@@ -476,66 +499,6 @@ export class PrivacySolanaWalletAdapter extends SolanaWalletAdapter {
       viewingPrivateKey: `0x${bytesToHex(viewingPrivateKey)}` as HexString,
     }
   }
-}
-
-// ─── Utilities ──────────────────────────────────────────────────────────────
-
-/** ed25519 curve order */
-const ED25519_ORDER = BigInt('0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed')
-
-/**
- * Convert bytes to BigInt (little-endian)
- */
-function bytesToBigInt(bytes: Uint8Array): bigint {
-  let result = 0n
-  for (let i = bytes.length - 1; i >= 0; i--) {
-    result = (result << 8n) | BigInt(bytes[i])
-  }
-  return result
-}
-
-/**
- * Convert hex string to bytes
- */
-function hexToBytes(hex: string): Uint8Array {
-  const bytes = new Uint8Array(hex.length / 2)
-  for (let i = 0; i < hex.length; i += 2) {
-    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16)
-  }
-  return bytes
-}
-
-/**
- * Convert bytes to hex string
- */
-function bytesToHex(bytes: Uint8Array): string {
-  return Array.from(bytes)
-    .map(b => b.toString(16).padStart(2, '0'))
-    .join('')
-}
-
-/**
- * Get ed25519 scalar from private key seed
- *
- * ed25519 derives the actual scalar by hashing the seed and taking
- * the lower 32 bytes with specific bit manipulations.
- */
-function getEd25519ScalarFromPrivate(seed: Uint8Array): bigint {
-  // Hash the seed to get 64 bytes
-  const h = sha256(seed)
-
-  // Take lower 32 bytes and apply ed25519 clamping
-  const scalar = new Uint8Array(32)
-  for (let i = 0; i < 32; i++) {
-    scalar[i] = h[i]
-  }
-
-  // Clamp: clear low 3 bits, clear high bit, set second-high bit
-  scalar[0] &= 248
-  scalar[31] &= 127
-  scalar[31] |= 64
-
-  return bytesToBigInt(scalar)
 }
 
 // ─── Factory ────────────────────────────────────────────────────────────────

--- a/packages/sdk/tests/chains/solana/claim.test.ts
+++ b/packages/sdk/tests/chains/solana/claim.test.ts
@@ -161,4 +161,38 @@ describe('claimStealthPayment', () => {
     // The feePayer must be the stealth address itself (not a relayer).
     expect(sentTx.feePayer?.toBase58()).toBe(s.stealthB58)
   })
+
+  // ─── (c) version is forwarded to the derivation ─────────────────────────────
+  // Regression guard for the scan->claim version-threading bug: the `version`
+  // passed to claimStealthPayment must reach deriveStealthSigner so it picks the
+  // matching derivation. We prove forwarding by claiming a CANONICAL (SIP:2)
+  // stealth address with version '1': that routes to the legacy derivation, whose
+  // scalar does NOT reproduce the canonical public key, so deriveStealthSigner
+  // throws. (With version '2' the same claim succeeds — see test (b).)
+  it("(c) forwards version to deriveStealthSigner (canonical address + version '1' -> derivation mismatch)", async () => {
+    const s = scenario()
+    const stealthPubkey = new PublicKey(s.stealthB58)
+    const tokenAccountInfo = makeTokenAccountInfo(stealthPubkey, 5_000_000n)
+
+    // Sufficient SOL + a valid token account so execution reaches the signer
+    // derivation rather than tripping the low-SOL guard.
+    const connection = {
+      rpcEndpoint: 'https://api.devnet.solana.com',
+      getBalance: async (_pk: PublicKey) => 10_000_000,
+      getAccountInfo: async (_address: PublicKey) => tokenAccountInfo,
+    } as unknown as Connection
+
+    await expect(
+      claimStealthPayment({
+        connection,
+        stealthAddress: s.stealthB58,
+        ephemeralPublicKey: s.ephemeralB58,
+        viewingPrivateKey: s.recipient.viewingPrivateKey,
+        spendingPrivateKey: s.recipient.spendingPrivateKey,
+        destinationAddress: 'So11111111111111111111111111111111111111112',
+        mint: USDC_MINT,
+        version: '1', // wrong scheme for a canonical address — must route to V1 derivation
+      })
+    ).rejects.toThrow('Stealth key derivation failed')
+  })
 })

--- a/packages/sdk/tests/chains/solana/claim.test.ts
+++ b/packages/sdk/tests/chains/solana/claim.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for claimStealthPayment (packages/sdk/src/chains/solana/scan.ts).
+ *
+ * Two tests:
+ *   (a) Low-SOL guard — rejects before any token-account access.
+ *   (b) Happy path — proves the stealth scalar signer produces a fully-valid
+ *       transaction; this is the regression guard for the headline bug where
+ *       Keypair could not sign a scalar-derived stealth address.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { PublicKey, Transaction, type Connection } from '@solana/web3.js'
+import { AccountLayout, TOKEN_PROGRAM_ID } from '@solana/spl-token'
+import type { ChainId } from '@sip-protocol/types'
+import {
+  generateEd25519StealthMetaAddress,
+  generateEd25519StealthAddress,
+  ed25519PublicKeyToSolanaAddress,
+} from '../../../src/stealth'
+import { claimStealthPayment } from '../../../src/chains/solana/scan'
+
+const USDC_MINT = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')
+
+/**
+ * Build a real stealth scenario using canonical SIP:2 derivation — the same
+ * helper pattern used in gasless-cashout.test.ts.
+ */
+function scenario() {
+  const recipient = generateEd25519StealthMetaAddress('solana' as ChainId)
+  const { stealthAddress } = generateEd25519StealthAddress(recipient.metaAddress)
+  return {
+    recipient,
+    stealthB58: ed25519PublicKeyToSolanaAddress(stealthAddress.address),
+    ephemeralB58: ed25519PublicKeyToSolanaAddress(stealthAddress.ephemeralPublicKey),
+  }
+}
+
+/**
+ * Encode a minimal but valid 165-byte SPL token account buffer.
+ *
+ * `getAccount` from @solana/spl-token calls `connection.getAccountInfo(ata)`
+ * and then calls `unpackAccount(address, info, TOKEN_PROGRAM_ID)`.
+ * `unpackAccount` validates:
+ *   - info !== null
+ *   - info.owner.equals(TOKEN_PROGRAM_ID)   ← the *account program* owner
+ *   - info.data.length >= ACCOUNT_SIZE (165)
+ *
+ * The owner field encoded *inside* the layout is the ATA's token owner
+ * (stealthPubkey) — returned as data, not checked by unpackAccount itself.
+ */
+function makeTokenAccountInfo(stealthPubkey: PublicKey, amount: bigint) {
+  const data = Buffer.alloc(AccountLayout.span)
+  AccountLayout.encode(
+    {
+      mint: USDC_MINT,
+      owner: stealthPubkey,
+      amount,
+      delegateOption: 0,
+      delegate: PublicKey.default,
+      state: 1, // AccountState.Initialized
+      isNativeOption: 0,
+      isNative: 0n,
+      delegatedAmount: 0n,
+      closeAuthorityOption: 0,
+      closeAuthority: PublicKey.default,
+    },
+    data,
+    0
+  )
+  return {
+    data,
+    owner: TOKEN_PROGRAM_ID, // the *program* that owns this account — must match TOKEN_PROGRAM_ID
+    executable: false,
+    lamports: 2039280,
+    rentEpoch: 0,
+  }
+}
+
+// ─── (a) Low-SOL guard ───────────────────────────────────────────────────────
+
+describe('claimStealthPayment', () => {
+  it('(a) rejects with Insufficient SOL when balance < 5000 lamports', async () => {
+    const s = scenario()
+    const stealthPubkey = new PublicKey(s.stealthB58)
+
+    const connection = {
+      rpcEndpoint: 'https://api.devnet.solana.com',
+      getBalance: async (_pk: PublicKey) => 100, // well below the 5000-lamport minimum
+    } as unknown as Connection
+
+    await expect(
+      claimStealthPayment({
+        connection,
+        stealthAddress: s.stealthB58,
+        ephemeralPublicKey: s.ephemeralB58,
+        viewingPrivateKey: s.recipient.viewingPrivateKey,
+        spendingPrivateKey: s.recipient.spendingPrivateKey,
+        destinationAddress: stealthPubkey.toBase58(), // destination can be anything valid
+        mint: USDC_MINT,
+      })
+    ).rejects.toThrow('Insufficient SOL')
+  })
+
+  // ─── (b) Happy path — scalar signer regression guard ─────────────────────
+
+  it('(b) resolves with correct amount + a fully-verifiable transaction (scalar-signer regression)', async () => {
+    const s = scenario()
+    const stealthPubkey = new PublicKey(s.stealthB58)
+    const tokenAccountInfo = makeTokenAccountInfo(stealthPubkey, 5_000_000n)
+
+    // Capture the raw bytes that claimStealthPayment sends to the network.
+    let capturedRaw: Uint8Array | null = null
+    const fakeSignature = '4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi1v9eHNzaRZ2d5kH3J4b9mzSJ'
+
+    const connection = {
+      rpcEndpoint: 'https://api.devnet.solana.com',
+      // SOL balance check — must be >= 5000 lamports
+      getBalance: async (_pk: PublicKey) => 10_000_000,
+      // spl-token's getAccount() calls connection.getAccountInfo internally
+      getAccountInfo: async (_address: PublicKey) => tokenAccountInfo,
+      getLatestBlockhash: async () => ({
+        blockhash: '11111111111111111111111111111111',
+        lastValidBlockHeight: 100,
+      }),
+      sendRawTransaction: async (raw: Uint8Array) => {
+        capturedRaw = raw
+        return fakeSignature
+      },
+      confirmTransaction: async () => ({ value: { err: null } }),
+    } as unknown as Connection
+
+    // Any valid Solana address works as the destination.
+    const destination = 'So11111111111111111111111111111111111111112'
+
+    const result = await claimStealthPayment({
+      connection,
+      stealthAddress: s.stealthB58,
+      ephemeralPublicKey: s.ephemeralB58,
+      viewingPrivateKey: s.recipient.viewingPrivateKey,
+      spendingPrivateKey: s.recipient.spendingPrivateKey,
+      destinationAddress: destination,
+      mint: USDC_MINT,
+      version: '2',
+    })
+
+    // ── Functional assertions ──────────────────────────────────────────────
+    expect(result.amount).toBe(5_000_000n)
+    expect(result.txSignature).toMatch(/^[1-9A-HJ-NP-Za-km-z]+$/) // base58
+
+    // ── Scalar-signer regression guard ────────────────────────────────────
+    // On origin/main before the scalar-signer fix, Keypair could not sign a
+    // stealth address whose private key is a raw scalar; transaction.serialize()
+    // would have thrown or produced an invalid signature.
+    //
+    // We prove the produced tx is fully valid: every required signature is
+    // present and cryptographically correct for the serialized message.
+    expect(capturedRaw).not.toBeNull()
+    const sentTx = Transaction.from(capturedRaw!)
+    expect(sentTx.verifySignatures(true)).toBe(true)
+
+    // The feePayer must be the stealth address itself (not a relayer).
+    expect(sentTx.feePayer?.toBase58()).toBe(s.stealthB58)
+  })
+})

--- a/packages/sdk/tests/chains/solana/gasless-cashout.test.ts
+++ b/packages/sdk/tests/chains/solana/gasless-cashout.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import { Keypair, PublicKey, type Connection } from '@solana/web3.js'
+import { TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID } from '@solana/spl-token'
+import type { ChainId } from '@sip-protocol/types'
+import {
+  generateEd25519StealthMetaAddress,
+  generateEd25519StealthAddress,
+  ed25519PublicKeyToSolanaAddress,
+} from '../../../src/stealth'
+import { buildGaslessCashout } from '../../../src/chains/solana/gasless-cashout'
+
+const USDC_MINT = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')
+
+function scenario() {
+  const recipient = generateEd25519StealthMetaAddress('solana' as ChainId)
+  const { stealthAddress } = generateEd25519StealthAddress(recipient.metaAddress)
+  return {
+    recipient,
+    stealthB58: ed25519PublicKeyToSolanaAddress(stealthAddress.address),
+    ephemeralB58: ed25519PublicKeyToSolanaAddress(stealthAddress.ephemeralPublicKey),
+  }
+}
+
+/** Mock connection: stealth ATA holds `gross`; dest ATA exists unless destMissing. */
+function mockConn(gross: bigint, destMissing = false): Connection {
+  return {
+    rpcEndpoint: 'https://api.devnet.solana.com',
+    getLatestBlockhash: async () => ({
+      blockhash: '11111111111111111111111111111111',
+      lastValidBlockHeight: 100,
+    }),
+    getTokenAccountBalance: async () => ({
+      value: { amount: gross.toString(), decimals: 6, uiAmount: 0, uiAmountString: '0' },
+    }),
+    getAccountInfo: async () => (destMissing ? null : ({ lamports: 1 } as unknown as object)),
+  } as unknown as Connection
+}
+
+describe('buildGaslessCashout', () => {
+  const relayer = Keypair.generate()
+  const relayerFeeAccount = Keypair.generate().publicKey
+  const destination = Keypair.generate().publicKey
+
+  it('builds a stealth-signed tx with feePayer = relayer and net = gross - fee', async () => {
+    const s = scenario()
+    const build = await buildGaslessCashout({
+      connection: mockConn(1_000_000_000n), // 1000 USDC
+      stealthAddress: s.stealthB58,
+      ephemeralPublicKey: s.ephemeralB58,
+      viewingPrivateKey: s.recipient.viewingPrivateKey,
+      spendingPrivateKey: s.recipient.spendingPrivateKey,
+      destinationAddress: destination.toBase58(),
+      mint: USDC_MINT,
+      relayerPublicKey: relayer.publicKey,
+      relayerFeeAccount,
+      feeConfig: { flatFloor: 10_000n, bps: 10 },
+      version: '2',
+    })
+
+    expect(build.grossAmount).toBe(1_000_000_000n)
+    expect(build.relayerFee).toBe(1_000_000n) // 1000 USDC * 10bps
+    expect(build.netAmount).toBe(999_000_000n)
+    expect(build.destinationAddress).toBe(destination.toBase58())
+    expect(build.transaction.feePayer?.toBase58()).toBe(relayer.publicKey.toBase58())
+
+    // Relayer slot still empty (filled at submit); stealth slot signed + valid.
+    const relayerSig = build.transaction.signatures.find(x => x.publicKey.equals(relayer.publicKey))
+    expect(relayerSig?.signature).toBeNull()
+    const stealthSig = build.transaction.signatures.find(x => x.publicKey.equals(new PublicKey(s.stealthB58)))
+    expect(stealthSig?.signature).not.toBeNull()
+    expect(build.transaction.verifySignatures(false)).toBe(true) // present sigs valid; relayer allowed missing
+
+    // Two SPL transfers (fee + net); no create-ATA since dest exists.
+    expect(build.transaction.instructions.length).toBe(2)
+    // Both instructions are SPL token transfers (fee + net)
+    expect(build.transaction.instructions.every(i => i.programId.equals(TOKEN_PROGRAM_ID))).toBe(true)
+  })
+
+  it('adds a create-ATA instruction (relayer as payer) when the dest ATA is missing', async () => {
+    const s = scenario()
+    const build = await buildGaslessCashout({
+      connection: mockConn(1_000_000_000n, true),
+      stealthAddress: s.stealthB58,
+      ephemeralPublicKey: s.ephemeralB58,
+      viewingPrivateKey: s.recipient.viewingPrivateKey,
+      spendingPrivateKey: s.recipient.spendingPrivateKey,
+      destinationAddress: destination.toBase58(),
+      mint: USDC_MINT,
+      relayerPublicKey: relayer.publicKey,
+      relayerFeeAccount,
+      feeConfig: { flatFloor: 10_000n, bps: 10 },
+    })
+    expect(build.transaction.instructions.length).toBe(3) // create-ATA + fee + net
+    expect(build.transaction.instructions[0].programId.equals(ASSOCIATED_TOKEN_PROGRAM_ID)).toBe(true)
+    expect(build.transaction.instructions[1].programId.equals(TOKEN_PROGRAM_ID)).toBe(true)
+    expect(build.transaction.instructions[2].programId.equals(TOKEN_PROGRAM_ID)).toBe(true)
+  })
+
+  it('throws when the fee would consume the entire claim', async () => {
+    const s = scenario()
+    await expect(buildGaslessCashout({
+      connection: mockConn(5_000n), // gross < floor
+      stealthAddress: s.stealthB58,
+      ephemeralPublicKey: s.ephemeralB58,
+      viewingPrivateKey: s.recipient.viewingPrivateKey,
+      spendingPrivateKey: s.recipient.spendingPrivateKey,
+      destinationAddress: destination.toBase58(),
+      mint: USDC_MINT,
+      relayerPublicKey: relayer.publicKey,
+      relayerFeeAccount,
+      feeConfig: { flatFloor: 10_000n, bps: 10 },
+    })).rejects.toThrow('exceeds the claim amount')
+  })
+})

--- a/packages/sdk/tests/chains/solana/gasless-cashout.test.ts
+++ b/packages/sdk/tests/chains/solana/gasless-cashout.test.ts
@@ -146,7 +146,14 @@ describe('submitGaslessCashout', () => {
     } as unknown as Connection
 
     const build = await buildFor(relayer)
+
+    // Before submit: stealth has signed but relayer hasn't — verifySignatures(true) requires ALL.
+    expect(build.transaction.verifySignatures(true)).toBe(false)
+
     const result = await submitGaslessCashout({ connection, build, relayerKeypair: relayer })
+
+    // After submit: partialSign(relayer) mutates build.transaction — both signatures now present.
+    expect(build.transaction.verifySignatures(true)).toBe(true)
 
     expect(result.viaJito).toBe(false)
     expect(result.txSignature).toMatch(/^[1-9A-HJ-NP-Za-km-z]+$/) // base58

--- a/packages/sdk/tests/chains/solana/gasless-cashout.test.ts
+++ b/packages/sdk/tests/chains/solana/gasless-cashout.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { Keypair, PublicKey, type Connection } from '@solana/web3.js'
-import { TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID } from '@solana/spl-token'
+import { Keypair, PublicKey, type Connection, type AccountInfo } from '@solana/web3.js'
+import {
+  TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  AccountLayout,
+  ACCOUNT_SIZE,
+  AccountState,
+} from '@solana/spl-token'
 import type { ChainId } from '@sip-protocol/types'
 import {
   generateEd25519StealthMetaAddress,
@@ -22,18 +28,68 @@ function scenario() {
   }
 }
 
-/** Mock connection: stealth ATA holds `gross`; dest ATA exists unless destMissing. */
-function mockConn(gross: bigint, destMissing = false): Connection {
+/** Encode a valid, initialized SPL token-account buffer so `getAccount` decodes it. */
+function encodeTokenAccountInfo(mint: PublicKey, owner: PublicKey): AccountInfo<Buffer> {
+  const data = Buffer.alloc(ACCOUNT_SIZE)
+  AccountLayout.encode(
+    {
+      mint,
+      owner,
+      amount: 0n,
+      delegateOption: 0,
+      delegate: PublicKey.default,
+      state: AccountState.Initialized,
+      isNativeOption: 0,
+      isNative: 0n,
+      delegatedAmount: 0n,
+      closeAuthorityOption: 0,
+      closeAuthority: PublicKey.default,
+    },
+    data
+  )
+  return {
+    lamports: 2_039_280,
+    owner: TOKEN_PROGRAM_ID,
+    executable: false,
+    rentEpoch: 0,
+    data,
+  }
+}
+
+interface MockConnOptions {
+  /** Gross balance reported for the stealth token account */
+  gross: bigint
+  /** Make getTokenAccountBalance reject (stealth ATA missing) */
+  balanceThrows?: boolean
+  /** Mint to report on the relayerFeeAccount (default: USDC_MINT) */
+  feeAccountMint?: PublicKey
+  /** Owner to report on the relayerFeeAccount token account (default: a fresh key) */
+  feeAccountOwner?: PublicKey
+}
+
+/**
+ * Mock connection. The stealth ATA reports `gross`. `getAccountInfo` returns a valid
+ * SPL token-account for the relayer fee account so `getAccount` decodes it (mint =
+ * feeAccountMint, default USDC_MINT). The dest ATA no longer needs a gate read.
+ */
+function mockConn(opts: MockConnOptions): Connection {
+  const feeMint = opts.feeAccountMint ?? USDC_MINT
+  const feeOwner = opts.feeAccountOwner ?? Keypair.generate().publicKey
   return {
     rpcEndpoint: 'https://api.devnet.solana.com',
     getLatestBlockhash: async () => ({
       blockhash: '11111111111111111111111111111111',
       lastValidBlockHeight: 100,
     }),
-    getTokenAccountBalance: async () => ({
-      value: { amount: gross.toString(), decimals: 6, uiAmount: 0, uiAmountString: '0' },
-    }),
-    getAccountInfo: async () => (destMissing ? null : ({ lamports: 1 } as unknown as object)),
+    getTokenAccountBalance: async () => {
+      if (opts.balanceThrows) {
+        throw new Error('could not find account')
+      }
+      return {
+        value: { amount: opts.gross.toString(), decimals: 6, uiAmount: 0, uiAmountString: '0' },
+      }
+    },
+    getAccountInfo: async () => encodeTokenAccountInfo(feeMint, feeOwner),
   } as unknown as Connection
 }
 
@@ -42,10 +98,8 @@ describe('buildGaslessCashout', () => {
   const relayerFeeAccount = Keypair.generate().publicKey
   const destination = Keypair.generate().publicKey
 
-  it('builds a stealth-signed tx with feePayer = relayer and net = gross - fee', async () => {
-    const s = scenario()
-    const build = await buildGaslessCashout({
-      connection: mockConn(1_000_000_000n), // 1000 USDC
+  function baseParams(s: ReturnType<typeof scenario>) {
+    return {
       stealthAddress: s.stealthB58,
       ephemeralPublicKey: s.ephemeralB58,
       viewingPrivateKey: s.recipient.viewingPrivateKey,
@@ -55,6 +109,14 @@ describe('buildGaslessCashout', () => {
       relayerPublicKey: relayer.publicKey,
       relayerFeeAccount,
       feeConfig: { flatFloor: 10_000n, bps: 10 },
+    }
+  }
+
+  it('builds a stealth-signed tx with feePayer = relayer and net = gross - fee', async () => {
+    const s = scenario()
+    const build = await buildGaslessCashout({
+      connection: mockConn({ gross: 1_000_000_000n }), // 1000 USDC
+      ...baseParams(s),
       version: '2',
     })
 
@@ -71,46 +133,86 @@ describe('buildGaslessCashout', () => {
     expect(stealthSig?.signature).not.toBeNull()
     expect(build.transaction.verifySignatures(false)).toBe(true) // present sigs valid; relayer allowed missing
 
-    // Two SPL transfers (fee + net); no create-ATA since dest exists.
-    expect(build.transaction.instructions.length).toBe(2)
-    // Both instructions are SPL token transfers (fee + net)
-    expect(build.transaction.instructions.every(i => i.programId.equals(TOKEN_PROGRAM_ID))).toBe(true)
-  })
-
-  it('adds a create-ATA instruction (relayer as payer) when the dest ATA is missing', async () => {
-    const s = scenario()
-    const build = await buildGaslessCashout({
-      connection: mockConn(1_000_000_000n, true),
-      stealthAddress: s.stealthB58,
-      ephemeralPublicKey: s.ephemeralB58,
-      viewingPrivateKey: s.recipient.viewingPrivateKey,
-      spendingPrivateKey: s.recipient.spendingPrivateKey,
-      destinationAddress: destination.toBase58(),
-      mint: USDC_MINT,
-      relayerPublicKey: relayer.publicKey,
-      relayerFeeAccount,
-      feeConfig: { flatFloor: 10_000n, bps: 10 },
-    })
-    expect(build.transaction.instructions.length).toBe(3) // create-ATA + fee + net
+    // create-ATA (idempotent) + fee transfer + net transfer.
+    expect(build.transaction.instructions.length).toBe(3)
     expect(build.transaction.instructions[0].programId.equals(ASSOCIATED_TOKEN_PROGRAM_ID)).toBe(true)
     expect(build.transaction.instructions[1].programId.equals(TOKEN_PROGRAM_ID)).toBe(true)
     expect(build.transaction.instructions[2].programId.equals(TOKEN_PROGRAM_ID)).toBe(true)
   })
 
+  it('always includes the idempotent create-ATA instruction for the destination (no separate gate read)', async () => {
+    const s = scenario()
+    let getAccountInfoCalls = 0
+    const conn = mockConn({ gross: 1_000_000_000n })
+    const wrapped = {
+      ...conn,
+      getAccountInfo: async (...args: unknown[]) => {
+        getAccountInfoCalls++
+        return (conn.getAccountInfo as unknown as (...a: unknown[]) => Promise<unknown>)(...args)
+      },
+    } as unknown as Connection
+
+    const build = await buildGaslessCashout({
+      connection: wrapped,
+      ...baseParams(s),
+    })
+
+    // create-ATA + fee + net, with the create-ATA being idempotent.
+    expect(build.transaction.instructions.length).toBe(3)
+    expect(build.transaction.instructions[0].programId.equals(ASSOCIATED_TOKEN_PROGRAM_ID)).toBe(true)
+    // getAccountInfo is consumed only by getAccount (fee-account validation), NOT a dest gate.
+    expect(getAccountInfoCalls).toBe(1)
+  })
+
   it('throws when the fee would consume the entire claim', async () => {
     const s = scenario()
     await expect(buildGaslessCashout({
-      connection: mockConn(5_000n), // gross < floor
-      stealthAddress: s.stealthB58,
-      ephemeralPublicKey: s.ephemeralB58,
-      viewingPrivateKey: s.recipient.viewingPrivateKey,
-      spendingPrivateKey: s.recipient.spendingPrivateKey,
-      destinationAddress: destination.toBase58(),
-      mint: USDC_MINT,
-      relayerPublicKey: relayer.publicKey,
-      relayerFeeAccount,
-      feeConfig: { flatFloor: 10_000n, bps: 10 },
+      connection: mockConn({ gross: 5_000n }), // gross < floor
+      ...baseParams(s),
     })).rejects.toThrow('exceeds the claim amount')
+  })
+
+  // 2a — B5: clear error when the stealth ATA is missing / holds no balance
+  it('throws a clear error when the stealth token account does not exist', async () => {
+    const s = scenario()
+    await expect(buildGaslessCashout({
+      connection: mockConn({ gross: 0n, balanceThrows: true }),
+      ...baseParams(s),
+    })).rejects.toThrow(/does not exist or holds no balance/)
+  })
+
+  // 2b — B1: reject destination == stealth
+  it('rejects when the destination resolves to the stealth token account', async () => {
+    const s = scenario()
+    await expect(buildGaslessCashout({
+      connection: mockConn({ gross: 1_000_000_000n }),
+      ...baseParams(s),
+      destinationAddress: s.stealthB58, // same owner -> same ATA
+    })).rejects.toThrow(/stealth token account/)
+  })
+
+  // 2c — B4: relayerFeeAccount must belong to `mint`
+  it('rejects a relayerFeeAccount whose on-chain mint differs from the given mint', async () => {
+    const s = scenario()
+    const otherMint = new PublicKey('So11111111111111111111111111111111111111112') // wSOL
+    await expect(buildGaslessCashout({
+      connection: mockConn({ gross: 1_000_000_000n, feeAccountMint: otherMint }),
+      ...baseParams(s),
+    })).rejects.toThrow(/not an associated token account for the given mint/)
+  })
+
+  it('rejects when the relayerFeeAccount is not a token account at all', async () => {
+    const s = scenario()
+    const conn = mockConn({ gross: 1_000_000_000n })
+    // getAccount throws when getAccountInfo returns null (no account).
+    const wrapped = {
+      ...conn,
+      getAccountInfo: async () => null,
+    } as unknown as Connection
+    await expect(buildGaslessCashout({
+      connection: wrapped,
+      ...baseParams(s),
+    })).rejects.toThrow(/relayerFeeAccount does not exist or is not a token account/)
   })
 })
 
@@ -120,7 +222,7 @@ describe('submitGaslessCashout', () => {
   async function buildFor(relayer: Keypair) {
     const s = scenario()
     return buildGaslessCashout({
-      connection: mockConn(1_000_000_000n),
+      connection: mockConn({ gross: 1_000_000_000n }),
       stealthAddress: s.stealthB58,
       ephemeralPublicKey: s.ephemeralB58,
       viewingPrivateKey: s.recipient.viewingPrivateKey,
@@ -188,7 +290,50 @@ describe('submitGaslessCashout', () => {
     ).rejects.toThrow('failed on-chain')
   })
 
-  it('Jito path: routes through the relayer when jitoRelayer is provided', async () => {
+  // 2e — B3: idempotent relayer signing on retry (no duplicate relayer signature)
+  it('does not re-sign as the relayer when retried with the same build', async () => {
+    const relayer = Keypair.generate()
+    const build = await buildFor(relayer)
+
+    // Spy on partialSign — it must run exactly once across the failed attempt + retry.
+    const realPartialSign = build.transaction.partialSign.bind(build.transaction)
+    let partialSignCalls = 0
+    build.transaction.partialSign = ((...signers: Parameters<typeof realPartialSign>) => {
+      partialSignCalls++
+      return realPartialSign(...signers)
+    }) as typeof build.transaction.partialSign
+
+    let attempts = 0
+    const connection = {
+      rpcEndpoint: 'https://api.devnet.solana.com',
+      sendRawTransaction: async () => {
+        attempts++
+        if (attempts === 1) {
+          throw new Error('Transaction simulation failed: blockhash not found')
+        }
+        return '5wHu1qwD4kT3zr8nF2sZ9q7vXpYbN6cM1aE4dR7tG9hJ2kL3mP8qS5vT6wX9yZ1aB2cD3eF4gH5iJ6kL7mN8oP9qR'
+      },
+      confirmTransaction: async () => ({ value: { err: null } }),
+    } as unknown as Connection
+
+    // First submit fails on a transient send error.
+    await expect(
+      submitGaslessCashout({ connection, build, relayerKeypair: relayer })
+    ).rejects.toThrow('blockhash not found')
+
+    const sigCountAfterFirst = build.transaction.signatures.filter(s => s.signature !== null).length
+
+    // Retry the SAME build — must succeed without re-signing as the relayer.
+    const result = await submitGaslessCashout({ connection, build, relayerKeypair: relayer })
+    expect(result.viaJito).toBe(false)
+
+    const sigCountAfterRetry = build.transaction.signatures.filter(s => s.signature !== null).length
+    expect(sigCountAfterRetry).toBe(sigCountAfterFirst)
+    // The relayer signed exactly once — the retry detected the existing signature and skipped.
+    expect(partialSignCalls).toBe(1)
+  })
+
+  it('Jito path: routes through the relayer when jitoRelayer confirms', async () => {
     const relayer = Keypair.generate()
     const build = await buildFor(relayer)
     const connection = { rpcEndpoint: 'https://api.mainnet-beta.solana.com' } as unknown as Connection
@@ -196,7 +341,7 @@ describe('submitGaslessCashout', () => {
       relayTransaction: async () => ({
         signature: 'JitoSig1111111111111111111111111111111111111',
         bundleId: 'bundle-1',
-        status: 'submitted',
+        status: 'confirmed',
         relayed: true,
       }),
     } as unknown as JitoRelayer
@@ -205,5 +350,60 @@ describe('submitGaslessCashout', () => {
     expect(result.viaJito).toBe(true)
     expect(result.txSignature).toBe('JitoSig1111111111111111111111111111111111111')
     expect(result.amount).toBe(build.netAmount)
+  })
+
+  // 2f — J1: a non-confirmed Jito status must reject (not be reported as success)
+  it('Jito path: rejects when the bundle does not confirm', async () => {
+    const relayer = Keypair.generate()
+    const build = await buildFor(relayer)
+    const connection = { rpcEndpoint: 'https://api.mainnet-beta.solana.com' } as unknown as Connection
+    const jitoRelayer = {
+      relayTransaction: async () => ({
+        signature: 'x',
+        status: 'failed',
+        error: 'bundle expired',
+        relayed: true,
+      }),
+    } as unknown as JitoRelayer
+
+    await expect(
+      submitGaslessCashout({ connection, build, relayerKeypair: relayer, jitoRelayer })
+    ).rejects.toThrow(/did not confirm/)
+  })
+
+  // 2f — J2: confirmed but empty signature must reject
+  it('Jito path: rejects when the confirmed result has an empty signature', async () => {
+    const relayer = Keypair.generate()
+    const build = await buildFor(relayer)
+    const connection = { rpcEndpoint: 'https://api.mainnet-beta.solana.com' } as unknown as Connection
+    const jitoRelayer = {
+      relayTransaction: async () => ({
+        signature: '',
+        status: 'confirmed',
+        relayed: true,
+      }),
+    } as unknown as JitoRelayer
+
+    await expect(
+      submitGaslessCashout({ connection, build, relayerKeypair: relayer, jitoRelayer })
+    ).rejects.toThrow(/empty transaction signature/)
+  })
+
+  // 2f — J5: report the TRUE relay path (relayed=false -> viaJito=false)
+  it('Jito path: reports viaJito = false when the relayer fell back to direct submission', async () => {
+    const relayer = Keypair.generate()
+    const build = await buildFor(relayer)
+    const connection = { rpcEndpoint: 'https://api.mainnet-beta.solana.com' } as unknown as Connection
+    const jitoRelayer = {
+      relayTransaction: async () => ({
+        signature: 'sig123',
+        status: 'confirmed',
+        relayed: false,
+      }),
+    } as unknown as JitoRelayer
+
+    const result = await submitGaslessCashout({ connection, build, relayerKeypair: relayer, jitoRelayer })
+    expect(result.viaJito).toBe(false)
+    expect(result.txSignature).toBe('sig123')
   })
 })

--- a/packages/sdk/tests/chains/solana/gasless-cashout.test.ts
+++ b/packages/sdk/tests/chains/solana/gasless-cashout.test.ts
@@ -7,7 +7,8 @@ import {
   generateEd25519StealthAddress,
   ed25519PublicKeyToSolanaAddress,
 } from '../../../src/stealth'
-import { buildGaslessCashout } from '../../../src/chains/solana/gasless-cashout'
+import { buildGaslessCashout, submitGaslessCashout } from '../../../src/chains/solana/gasless-cashout'
+import type { JitoRelayer } from '../../../src/solana/jito-relayer'
 
 const USDC_MINT = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')
 
@@ -110,5 +111,92 @@ describe('buildGaslessCashout', () => {
       relayerFeeAccount,
       feeConfig: { flatFloor: 10_000n, bps: 10 },
     })).rejects.toThrow('exceeds the claim amount')
+  })
+})
+
+describe('submitGaslessCashout', () => {
+  const relayerFeeAccount = Keypair.generate().publicKey
+
+  async function buildFor(relayer: Keypair) {
+    const s = scenario()
+    return buildGaslessCashout({
+      connection: mockConn(1_000_000_000n),
+      stealthAddress: s.stealthB58,
+      ephemeralPublicKey: s.ephemeralB58,
+      viewingPrivateKey: s.recipient.viewingPrivateKey,
+      spendingPrivateKey: s.recipient.spendingPrivateKey,
+      destinationAddress: Keypair.generate().publicKey.toBase58(),
+      mint: USDC_MINT,
+      relayerPublicKey: relayer.publicKey,
+      relayerFeeAccount,
+      feeConfig: { flatFloor: 10_000n, bps: 10 },
+    })
+  }
+
+  it('direct path: relayer co-signs as fee-payer, sends, returns the base58 signature', async () => {
+    const relayer = Keypair.generate()
+    let sentRaw: Uint8Array | null = null
+    const connection = {
+      rpcEndpoint: 'https://api.devnet.solana.com',
+      sendRawTransaction: async (raw: Uint8Array) => {
+        sentRaw = raw
+        return '5wHu1qwD4kT3zr8nF2sZ9q7vXpYbN6cM1aE4dR7tG9hJ2kL3mP8qS5vT6wX9yZ1aB2cD3eF4gH5iJ6kL7mN8oP9qR'
+      },
+      confirmTransaction: async () => ({ value: { err: null } }),
+    } as unknown as Connection
+
+    const build = await buildFor(relayer)
+    const result = await submitGaslessCashout({ connection, build, relayerKeypair: relayer })
+
+    expect(result.viaJito).toBe(false)
+    expect(result.txSignature).toMatch(/^[1-9A-HJ-NP-Za-km-z]+$/) // base58
+    expect(result.amount).toBe(build.netAmount)
+    expect(result.relayerFee).toBe(build.relayerFee)
+    expect(result.destinationAddress).toBe(build.destinationAddress)
+    expect(sentRaw).not.toBeNull() // a fully-signed tx was serialized + sent
+  })
+
+  it('rejects if the relayer keypair does not match the build fee-payer', async () => {
+    const relayer = Keypair.generate()
+    const wrong = Keypair.generate()
+    const build = await buildFor(relayer)
+    const connection = { rpcEndpoint: 'x' } as unknown as Connection
+    await expect(
+      submitGaslessCashout({ connection, build, relayerKeypair: wrong })
+    ).rejects.toThrow('does not match')
+  })
+
+  it('throws if the transaction lands but fails on-chain', async () => {
+    const relayer = Keypair.generate()
+    const connection = {
+      rpcEndpoint: 'https://api.devnet.solana.com',
+      sendRawTransaction: async () =>
+        '5wHu1qwD4kT3zr8nF2sZ9q7vXpYbN6cM1aE4dR7tG9hJ2kL3mP8qS5vT6wX9yZ1aB2cD3eF4gH5iJ6kL7mN8oP9qR',
+      confirmTransaction: async () => ({ value: { err: { InstructionError: [1, 'Custom'] } } }),
+    } as unknown as Connection
+
+    const build = await buildFor(relayer)
+    await expect(
+      submitGaslessCashout({ connection, build, relayerKeypair: relayer })
+    ).rejects.toThrow('failed on-chain')
+  })
+
+  it('Jito path: routes through the relayer when jitoRelayer is provided', async () => {
+    const relayer = Keypair.generate()
+    const build = await buildFor(relayer)
+    const connection = { rpcEndpoint: 'https://api.mainnet-beta.solana.com' } as unknown as Connection
+    const jitoRelayer = {
+      relayTransaction: async () => ({
+        signature: 'JitoSig1111111111111111111111111111111111111',
+        bundleId: 'bundle-1',
+        status: 'submitted',
+        relayed: true,
+      }),
+    } as unknown as JitoRelayer
+
+    const result = await submitGaslessCashout({ connection, build, relayerKeypair: relayer, jitoRelayer })
+    expect(result.viaJito).toBe(true)
+    expect(result.txSignature).toBe('JitoSig1111111111111111111111111111111111111')
+    expect(result.amount).toBe(build.netAmount)
   })
 })

--- a/packages/sdk/tests/chains/solana/gasless-exports.test.ts
+++ b/packages/sdk/tests/chains/solana/gasless-exports.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import * as sdk from '../../../src/index'
+
+describe('gasless cash-out public exports', () => {
+  it('exposes the gasless cash-out surface from the package root', () => {
+    expect(typeof sdk.buildGaslessCashout).toBe('function')
+    expect(typeof sdk.submitGaslessCashout).toBe('function')
+    expect(typeof sdk.computeRelayerFee).toBe('function')
+    expect(typeof sdk.deriveStealthSigner).toBe('function')
+    expect(typeof sdk.signEd25519WithScalar).toBe('function')
+  })
+})

--- a/packages/sdk/tests/chains/solana/relayer-fee.test.ts
+++ b/packages/sdk/tests/chains/solana/relayer-fee.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { computeRelayerFee, type RelayerFeeConfig } from '../../../src/chains/solana/relayer-fee'
+
+describe('computeRelayerFee', () => {
+  const cfg: RelayerFeeConfig = { flatFloor: 10_000n, bps: 10 } // 0.01 USDC floor, 0.1%
+
+  it('uses the flat floor when bps fee is smaller (small claim)', () => {
+    // 1 USDC * 10bps = 1000 < 10_000 floor
+    expect(computeRelayerFee(1_000_000n, cfg)).toBe(10_000n)
+  })
+
+  it('uses the bps fee when it exceeds the floor (large claim)', () => {
+    // 1000 USDC * 10bps = 1_000_000 > 10_000 floor
+    expect(computeRelayerFee(1_000_000_000n, cfg)).toBe(1_000_000n)
+  })
+
+  it('returns the floor exactly at the crossover', () => {
+    // floor 10_000 == amount*10/10000 => amount = 10_000_000
+    expect(computeRelayerFee(10_000_000n, cfg)).toBe(10_000n)
+  })
+
+  it('returns the floor for a zero-amount claim', () => {
+    expect(computeRelayerFee(0n, cfg)).toBe(10_000n)
+  })
+
+  it('supports a zero floor (pure bps)', () => {
+    expect(computeRelayerFee(2_000_000n, { flatFloor: 0n, bps: 25 })).toBe(5_000n)
+  })
+
+  it('throws on negative bps', () => {
+    expect(() => computeRelayerFee(1n, { flatFloor: 0n, bps: -1 })).toThrow('bps must be')
+  })
+
+  it('throws on fractional bps', () => {
+    expect(() => computeRelayerFee(1n, { flatFloor: 0n, bps: 1.7 })).toThrow('bps must be')
+  })
+
+  it('throws on a negative amount', () => {
+    expect(() => computeRelayerFee(-1n, cfg)).toThrow('amount must be')
+  })
+
+  it('switches to the bps fee just past the crossover', () => {
+    // floor=10_000; bps fee overtakes the floor once amount*10/10_000 > 10_000,
+    // i.e. amount >= 10_001_000 (integer division floors). 10_001_000*10/10_000 = 10_001.
+    expect(computeRelayerFee(10_001_000n, cfg)).toBe(10_001n)
+  })
+})

--- a/packages/sdk/tests/chains/solana/relayer-fee.test.ts
+++ b/packages/sdk/tests/chains/solana/relayer-fee.test.ts
@@ -39,6 +39,16 @@ describe('computeRelayerFee', () => {
     expect(() => computeRelayerFee(-1n, cfg)).toThrow('amount must be')
   })
 
+  it('rejects a negative flatFloor', () => {
+    expect(() => computeRelayerFee(1_000n, { flatFloor: -1n, bps: 0 })).toThrow(
+      'flatFloor must be a non-negative bigint'
+    )
+  })
+
+  it('accepts a zero flatFloor', () => {
+    expect(computeRelayerFee(1_000n, { flatFloor: 0n, bps: 10 })).toBe(1n)
+  })
+
   it('switches to the bps fee just past the crossover', () => {
     // floor=10_000; bps fee overtakes the floor once amount*10/10_000 > 10_000,
     // i.e. amount >= 10_001_000 (integer division floors). 10_001_000*10/10_000 = 10_001.

--- a/packages/sdk/tests/chains/solana/scan-e2e.test.ts
+++ b/packages/sdk/tests/chains/solana/scan-e2e.test.ts
@@ -143,6 +143,32 @@ describe('scanForPayments end-to-end (view-only, canonical SIP:2)', () => {
     expect(payment.txSignature).toBe(TEST_SIGNATURE)
     expect(payment.slot).toBe(TEST_SLOT)
     expect(payment.timestamp).toBe(TEST_BLOCK_TIME)
+    // The result carries the announcement scheme version so the claim path can
+    // route to the matching derivation. A canonical memo reports '2'.
+    expect(payment.version).toBe('2')
+  })
+
+  it('carries version "1" for a legacy SIP:1 announcement so claim can route correctly', async () => {
+    // The announcement version label is independent of the cryptographic content:
+    // a canonical stealth address wrapped in a SIP:1-prefixed memo is still
+    // detectable via the same view-only check, and the scan result must surface
+    // the parsed '1' so claimStealthPayment can pick the legacy derivation.
+    const s = buildScenario()
+    const legacyMemo = `SIP:1:${s.ephemeralB58}:${s.stealthAddress.viewTag
+      .toString(16)
+      .padStart(2, '0')}:${s.stealthAddressB58}`
+    expect(parseAnnouncement(legacyMemo)?.version).toBe('1')
+
+    const connection = createMockConnection(legacyMemo, s.preTokenBalances, s.postTokenBalances)
+
+    const results = await scanForPayments({
+      connection,
+      viewingPrivateKey: s.recipient.viewingPrivateKey,
+      spendingPublicKey: s.recipient.metaAddress.spendingKey,
+    })
+
+    expect(results).toHaveLength(1)
+    expect(results[0].version).toBe('1')
   })
 
   it('returns no results for a DIFFERENT (wrong) viewing private key', async () => {

--- a/packages/sdk/tests/chains/solana/stealth-signer.test.ts
+++ b/packages/sdk/tests/chains/solana/stealth-signer.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest'
+import { Transaction, SystemProgram } from '@solana/web3.js'
+import { ed25519 } from '@noble/curves/ed25519'
+import { hexToBytes, bytesToHex, randomBytes } from '@noble/hashes/utils'
+import { sha256 } from '@noble/hashes/sha256'
+import type { ChainId, StealthAddress, HexString } from '@sip-protocol/types'
+import { bytesToBigIntLE, bytesToBigInt, bigIntToBytesLE, ED25519_ORDER, getEd25519Scalar } from '../../../src/stealth/utils'
+import {
+  generateEd25519StealthMetaAddress,
+  generateEd25519StealthAddress,
+  ed25519PublicKeyToSolanaAddress,
+} from '../../../src/stealth'
+import { signEd25519WithScalar, deriveStealthSigner } from '../../../src/chains/solana/stealth-signer'
+
+/**
+ * Generate a SIP:1 (legacy, pre-canonical-flip) ed25519 stealth address.
+ *
+ * Legacy scheme (swapped ECDH):
+ *   S = s_spend * R  (ECDH on the SPENDING key)
+ *   P_stealth = P_view + H(S)*G
+ *   p_stealth = s_view + H(S) mod L
+ */
+function generateLegacyV1StealthAddress(
+  spendingPrivateKey: HexString,
+  viewingPrivateKey: HexString,
+): StealthAddress {
+  const spendingPrivBytes = hexToBytes(spendingPrivateKey.slice(2))
+  const viewingPrivBytes = hexToBytes(viewingPrivateKey.slice(2))
+
+  // Generate ephemeral keypair
+  const ephemeralSeed = randomBytes(32)
+  const ephemeralPublicKey = ed25519.getPublicKey(ephemeralSeed)
+  const rawEphemeralScalar = getEd25519Scalar(ephemeralSeed)
+  const ephemeralScalar = rawEphemeralScalar % ED25519_ORDER
+
+  // S = ephemeral_scalar * P_spend  (legacy: ECDH on the spending key)
+  const spendingPubBytes = ed25519.getPublicKey(spendingPrivBytes)
+  const spendingPubPoint = ed25519.ExtendedPoint.fromHex(spendingPubBytes)
+  const sharedSecretPoint = spendingPubPoint.multiply(ephemeralScalar)
+  const sharedSecretHash = sha256(sharedSecretPoint.toRawBytes())
+
+  // P_stealth = P_view + H(S)*G
+  const viewingPubBytes = ed25519.getPublicKey(viewingPrivBytes)
+  const viewingPoint = ed25519.ExtendedPoint.fromHex(viewingPubBytes)
+  const hashScalar = bytesToBigInt(sharedSecretHash) % ED25519_ORDER
+  const hashTimesG = ed25519.ExtendedPoint.BASE.multiply(hashScalar)
+  const stealthPoint = viewingPoint.add(hashTimesG)
+
+  return {
+    address: `0x${bytesToHex(stealthPoint.toRawBytes())}` as HexString,
+    ephemeralPublicKey: `0x${bytesToHex(ephemeralPublicKey)}` as HexString,
+    viewTag: sharedSecretHash[0],
+  }
+}
+
+function pubFromScalar(scalar: Uint8Array): Uint8Array {
+  let a = bytesToBigIntLE(scalar) % ED25519_ORDER
+  if (a < 0n) a += ED25519_ORDER
+  return ed25519.ExtendedPoint.BASE.multiply(a).toRawBytes()
+}
+
+describe('signEd25519WithScalar', () => {
+  it('produces a signature that verifies against the scalar public key', () => {
+    const scalar = hexToBytes('0a'.repeat(32))
+    const msg = new Uint8Array([1, 2, 3, 4, 5])
+    const sig = signEd25519WithScalar(msg, scalar)
+    expect(sig.length).toBe(64)
+    expect(ed25519.verify(sig, msg, pubFromScalar(scalar))).toBe(true)
+  })
+
+  it('does not verify against a tampered message', () => {
+    const scalar = hexToBytes('0a'.repeat(32))
+    const sig = signEd25519WithScalar(new Uint8Array([1, 2, 3]), scalar)
+    expect(ed25519.verify(sig, new Uint8Array([1, 2, 4]), pubFromScalar(scalar))).toBe(false)
+  })
+
+  it('throws on a zero scalar', () => {
+    expect(() => signEd25519WithScalar(new Uint8Array([1]), new Uint8Array(32))).toThrow('reduces to zero')
+  })
+})
+
+describe('deriveStealthSigner', () => {
+  it('derives a signer whose publicKey matches the canonical (SIP:2) stealth address', () => {
+    const recipient = generateEd25519StealthMetaAddress('solana' as ChainId)
+    const { stealthAddress } = generateEd25519StealthAddress(recipient.metaAddress)
+    const stealthB58 = ed25519PublicKeyToSolanaAddress(stealthAddress.address)
+    const ephemeralB58 = ed25519PublicKeyToSolanaAddress(stealthAddress.ephemeralPublicKey)
+
+    const signer = deriveStealthSigner({
+      stealthAddress: stealthB58,
+      ephemeralPublicKey: ephemeralB58,
+      viewingPrivateKey: recipient.viewingPrivateKey,
+      spendingPrivateKey: recipient.spendingPrivateKey,
+      version: '2',
+    })
+
+    expect(signer.publicKey.toBase58()).toBe(stealthB58)
+  })
+
+  it('signs a transaction so verifySignatures() passes (a Keypair could NOT sign this)', () => {
+    const recipient = generateEd25519StealthMetaAddress('solana' as ChainId)
+    const { stealthAddress } = generateEd25519StealthAddress(recipient.metaAddress)
+    const stealthB58 = ed25519PublicKeyToSolanaAddress(stealthAddress.address)
+    const ephemeralB58 = ed25519PublicKeyToSolanaAddress(stealthAddress.ephemeralPublicKey)
+
+    const signer = deriveStealthSigner({
+      stealthAddress: stealthB58,
+      ephemeralPublicKey: ephemeralB58,
+      viewingPrivateKey: recipient.viewingPrivateKey,
+      spendingPrivateKey: recipient.spendingPrivateKey,
+    })
+
+    const tx = new Transaction()
+    tx.add(SystemProgram.transfer({ fromPubkey: signer.publicKey, toPubkey: signer.publicKey, lamports: 1 }))
+    tx.recentBlockhash = '11111111111111111111111111111111'
+    tx.feePayer = signer.publicKey
+    signer.signTransaction(tx)
+
+    expect(tx.verifySignatures()).toBe(true)
+  })
+
+  it('signMessage produces a signature that verifies against the stealth pubkey', () => {
+    const recipient = generateEd25519StealthMetaAddress('solana' as ChainId)
+    const { stealthAddress } = generateEd25519StealthAddress(recipient.metaAddress)
+    const stealthB58 = ed25519PublicKeyToSolanaAddress(stealthAddress.address)
+    const ephemeralB58 = ed25519PublicKeyToSolanaAddress(stealthAddress.ephemeralPublicKey)
+    const signer = deriveStealthSigner({
+      stealthAddress: stealthB58,
+      ephemeralPublicKey: ephemeralB58,
+      viewingPrivateKey: recipient.viewingPrivateKey,
+      spendingPrivateKey: recipient.spendingPrivateKey,
+    })
+    const message = new Uint8Array([10, 20, 30, 40])
+    const sig = signer.signMessage(message)
+    expect(ed25519.verify(sig, message, signer.publicKey.toBytes())).toBe(true)
+  })
+
+  it('version "1" (SIP:1 legacy): derives signer, publicKey matches, signTransaction passes', () => {
+    const recipient = generateEd25519StealthMetaAddress('solana' as ChainId)
+    const stealthAddress = generateLegacyV1StealthAddress(
+      recipient.spendingPrivateKey,
+      recipient.viewingPrivateKey,
+    )
+    const stealthB58 = ed25519PublicKeyToSolanaAddress(stealthAddress.address)
+    const ephemeralB58 = ed25519PublicKeyToSolanaAddress(stealthAddress.ephemeralPublicKey)
+
+    const signer = deriveStealthSigner({
+      stealthAddress: stealthB58,
+      ephemeralPublicKey: ephemeralB58,
+      viewingPrivateKey: recipient.viewingPrivateKey,
+      spendingPrivateKey: recipient.spendingPrivateKey,
+      version: '1',
+    })
+
+    expect(signer.publicKey.toBase58()).toBe(stealthB58)
+
+    const tx = new Transaction()
+    tx.add(SystemProgram.transfer({ fromPubkey: signer.publicKey, toPubkey: signer.publicKey, lamports: 1 }))
+    tx.recentBlockhash = '11111111111111111111111111111111'
+    tx.feePayer = signer.publicKey
+    signer.signTransaction(tx)
+
+    expect(tx.verifySignatures()).toBe(true)
+  })
+
+  it('throws on mismatched keys (wrong spending key cannot derive the address)', () => {
+    const recipient = generateEd25519StealthMetaAddress('solana' as ChainId)
+    const other = generateEd25519StealthMetaAddress('solana' as ChainId)
+    const { stealthAddress } = generateEd25519StealthAddress(recipient.metaAddress)
+    const stealthB58 = ed25519PublicKeyToSolanaAddress(stealthAddress.address)
+    const ephemeralB58 = ed25519PublicKeyToSolanaAddress(stealthAddress.ephemeralPublicKey)
+
+    expect(() =>
+      deriveStealthSigner({
+        stealthAddress: stealthB58,
+        ephemeralPublicKey: ephemeralB58,
+        viewingPrivateKey: recipient.viewingPrivateKey,
+        spendingPrivateKey: other.spendingPrivateKey,
+      })
+    ).toThrow('Stealth key derivation failed')
+  })
+})

--- a/packages/sdk/tests/chains/solana/stealth-signer.test.ts
+++ b/packages/sdk/tests/chains/solana/stealth-signer.test.ts
@@ -68,6 +68,20 @@ describe('signEd25519WithScalar', () => {
     expect(ed25519.verify(sig, msg, pubFromScalar(scalar))).toBe(true)
   })
 
+  it('is deterministic per message but derives a distinct nonce per message (no nonce reuse)', () => {
+    const scalar = hexToBytes('0a'.repeat(32))
+    const msg1 = new Uint8Array([1, 2, 3])
+    const msg2 = new Uint8Array([1, 2, 4])
+    const sigA = signEd25519WithScalar(msg1, scalar)
+    const sigB = signEd25519WithScalar(msg1, scalar)
+    const sigC = signEd25519WithScalar(msg2, scalar)
+    // Deterministic: same (scalar, message) -> identical signature (safe retries).
+    expect(bytesToHex(sigA)).toBe(bytesToHex(sigB))
+    // Distinct messages -> distinct nonce R (first 32 bytes). Equal R across different
+    // messages would leak the scalar (catastrophic ed25519 nonce reuse).
+    expect(bytesToHex(sigC.slice(0, 32))).not.toBe(bytesToHex(sigA.slice(0, 32)))
+  })
+
   it('does not verify against a tampered message', () => {
     const scalar = hexToBytes('0a'.repeat(32))
     const sig = signEd25519WithScalar(new Uint8Array([1, 2, 3]), scalar)

--- a/packages/sdk/tests/solana/jito-relayer.test.ts
+++ b/packages/sdk/tests/solana/jito-relayer.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { Keypair, Transaction, SystemProgram } from '@solana/web3.js'
+import bs58 from 'bs58'
+import {
+  JitoRelayer,
+  createJitoRelayer,
+  JITO_TIP_ACCOUNTS,
+} from '../../src/solana/jito-relayer'
+
+// Helper: build a signed legacy transfer tx for bundle tests.
+function buildSignedTransferTx(payer: Keypair): Transaction {
+  const tx = new Transaction()
+  tx.add(SystemProgram.transfer({
+    fromPubkey: payer.publicKey,
+    toPubkey: payer.publicKey,
+    lamports: 1,
+  }))
+  tx.recentBlockhash = '11111111111111111111111111111111'
+  tx.feePayer = payer.publicKey
+  tx.sign(payer)
+  return tx
+}
+
+describe('JitoRelayer', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  describe('constructor + helpers', () => {
+    it('applies defaults', () => {
+      const r = createJitoRelayer()
+      expect(r).toBeInstanceOf(JitoRelayer)
+    })
+
+    it('getRandomTipAccount returns a known tip account', () => {
+      const r = createJitoRelayer()
+      const acct = r.getRandomTipAccount().toBase58()
+      expect(JITO_TIP_ACCOUNTS as readonly string[]).toContain(acct)
+    })
+  })
+
+  describe('isAvailable', () => {
+    it('returns true on healthy block engine', async () => {
+      vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true }) as Response))
+      const r = createJitoRelayer()
+      expect(await r.isAvailable()).toBe(true)
+    })
+
+    it('returns false on network error', async () => {
+      vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('down') }))
+      const r = createJitoRelayer()
+      expect(await r.isAvailable()).toBe(false)
+    })
+  })
+
+  describe('encodeSignature', () => {
+    it('encodes a 64-byte signature as base58 (not hex)', () => {
+      const sig = new Uint8Array(64).fill(7)
+      const out = JitoRelayer.encodeSignature(sig)
+      expect(out).toBe(bs58.encode(sig))
+      // a hex encoding of 64 bytes would be 128 chars all in [0-9a-f]; base58 includes uppercase
+      expect(out).not.toMatch(/^[0-9a-f]+$/)
+    })
+  })
+
+  describe('submitBundle', () => {
+    it('submits a tip + user tx and reports a base58 bundle result', async () => {
+      const fetchMock = vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ result: 'bundle-123' }),
+      }) as unknown as Response)
+      vi.stubGlobal('fetch', fetchMock)
+
+      const tipPayer = Keypair.generate()
+      const r = new JitoRelayer({
+        blockEngineUrl: 'https://x.test/api/v1',
+        rpcUrl: 'https://api.mainnet-beta.solana.com',
+      })
+      // @ts-expect-error override private connection for the test
+      r.connection = {
+        getLatestBlockhash: async () => ({
+          blockhash: '11111111111111111111111111111111',
+          lastValidBlockHeight: 100,
+        }),
+      }
+
+      const userTx = buildSignedTransferTx(tipPayer)
+      const res = await r.submitBundle({ transactions: [userTx], tipPayer })
+
+      expect(res.bundleId).toBe('bundle-123')
+      expect(res.status).toBe('submitted')
+      expect(fetchMock).toHaveBeenCalled()
+    })
+  })
+
+  describe('relayTransaction', () => {
+    it('routes through submitBundle when tipPayer is provided', async () => {
+      const fetchMock = vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ result: 'bundle-xyz' }),
+      }) as unknown as Response)
+      vi.stubGlobal('fetch', fetchMock)
+
+      const tipPayer = Keypair.generate()
+      const r = new JitoRelayer({ blockEngineUrl: 'https://x.test/api/v1' })
+      // @ts-expect-error override private connection for the test
+      r.connection = {
+        getLatestBlockhash: async () => ({
+          blockhash: '11111111111111111111111111111111',
+          lastValidBlockHeight: 100,
+        }),
+      }
+
+      const userTx = buildSignedTransferTx(tipPayer)
+      const result = await r.relayTransaction({ transaction: userTx, tipPayer })
+
+      expect(result.relayed).toBe(true)
+      expect(result.bundleId).toBe('bundle-xyz')
+      expect(result.status).toBe('submitted')
+      // user tx is the LAST entry in the bundle; signature must be base58
+      expect(result.signature).toMatch(/^[1-9A-HJ-NP-Za-km-z]+$/)
+      expect(fetchMock).toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/sdk/tests/wallet/solana/privacy-adapter-claim-key.test.ts
+++ b/packages/sdk/tests/wallet/solana/privacy-adapter-claim-key.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Privacy Solana wallet adapter — deriveClaimKey signing-path guard.
+ *
+ * `PrivacySolanaWalletAdapter.deriveClaimKey` returns `ClaimResult.privateKey`
+ * as a RAW ed25519 scalar (little-endian), NOT a 32-byte Keypair seed. Building
+ * a `Keypair` from it (`new Keypair(...)` / `Keypair.fromSecretKey(...)`)
+ * produces INVALID signatures. The sanctioned path is `signEd25519WithScalar`.
+ *
+ * This file uses REAL crypto (no module mock) so the derived scalar genuinely
+ * round-trips: a signature made with the scalar must verify against the
+ * stealth public key the same call returns. It locks in the correct signing
+ * path and guards against a regression that re-introduces the seed footgun.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { ed25519 } from '@noble/curves/ed25519'
+import { hexToBytes } from '@noble/hashes/utils'
+import type { HexString, StealthMetaAddress } from '@sip-protocol/types'
+import { PrivacySolanaWalletAdapter } from '../../../src/wallet/solana/privacy-adapter'
+import { signEd25519WithScalar } from '../../../src/chains/solana/stealth-signer'
+import { generateEd25519StealthAddress } from '../../../src/stealth'
+
+// Minimal mock Solana provider (the adapter requires a connected provider to
+// construct, but deriveClaimKey itself only needs the imported stealth keys).
+const createMockProvider = () => ({
+  isConnected: true,
+  publicKey: {
+    toBase58: () => 'DemoWallet111111111111111111111111111111111',
+    toBytes: () => new Uint8Array(32),
+    toString: () => 'DemoWallet111111111111111111111111111111111',
+  },
+  connect: vi.fn().mockResolvedValue({
+    publicKey: { toBase58: () => 'DemoWallet111111111111111111111111111111111' },
+  }),
+  disconnect: vi.fn().mockResolvedValue(undefined),
+  signMessage: vi.fn(),
+  signTransaction: vi.fn(),
+  signAndSendTransaction: vi.fn(),
+  signAllTransactions: vi.fn(),
+  on: vi.fn(),
+  off: vi.fn(),
+})
+
+/**
+ * Build an adapter holding a real ed25519 stealth meta-address, plus a real
+ * ephemeral public key + view tag derived for that meta-address (so the address
+ * deriveClaimKey reconstructs is internally consistent with the keys).
+ */
+function buildAdapterWithRealKeys() {
+  // Real 32-byte ed25519 seeds for spending + viewing.
+  const spendingSeed = ed25519.utils.randomPrivateKey()
+  const viewingSeed = ed25519.utils.randomPrivateKey()
+
+  const spendingPublicKey = ed25519.getPublicKey(spendingSeed)
+  const viewingPublicKey = ed25519.getPublicKey(viewingSeed)
+
+  const toHex = (b: Uint8Array): HexString =>
+    `0x${Array.from(b).map((x) => x.toString(16).padStart(2, '0')).join('')}` as HexString
+
+  const metaAddress: StealthMetaAddress = {
+    chain: 'solana',
+    spendingKey: toHex(spendingPublicKey),
+    viewingKey: toHex(viewingPublicKey),
+  }
+
+  const adapter = new PrivacySolanaWalletAdapter({
+    provider: createMockProvider(),
+    metaAddress,
+    spendingPrivateKey: toHex(spendingSeed),
+    viewingPrivateKey: toHex(viewingSeed),
+  })
+
+  // Generate a real stealth announcement (ephemeral key + view tag) FOR this
+  // meta-address using the canonical generator.
+  const { stealthAddress } = generateEd25519StealthAddress(metaAddress)
+
+  return {
+    adapter,
+    ephemeralPublicKey: stealthAddress.ephemeralPublicKey,
+    viewTag: stealthAddress.viewTag,
+  }
+}
+
+describe('PrivacySolanaWalletAdapter.deriveClaimKey signing path', () => {
+  it('deriveClaimKey scalar signs correctly via signEd25519WithScalar (not a Keypair seed)', () => {
+    const { adapter, ephemeralPublicKey, viewTag } = buildAdapterWithRealKeys()
+
+    const claim = adapter.deriveClaimKey(ephemeralPublicKey, viewTag)
+
+    const msg = new TextEncoder().encode('hello sip')
+    const sig = signEd25519WithScalar(msg, hexToBytes(claim.privateKey.slice(2)))
+    const pub = hexToBytes(claim.publicKey.slice(2))
+
+    expect(ed25519.verify(sig, msg, pub)).toBe(true)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,13 +328,13 @@ importers:
         version: 6.0.48
       '@langchain/core':
         specifier: ^0.3.30
-        version: 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+        version: 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@langchain/openai':
         specifier: ^0.4.2
-        version: 0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+        version: 0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@magicblock-labs/ephemeral-rollups-sdk':
         specifier: ^0.15.0
-        version: 0.15.0(bufferutil@4.1.0)(encoding@0.1.13)(utf-8-validate@6.0.6)
+        version: 0.15.0(bufferutil@4.1.0)(encoding@0.1.13)(utf-8-validate@5.0.10)
       '@noble/ciphers':
         specifier: ^2.2.0
         version: 2.2.0
@@ -352,7 +352,7 @@ importers:
         version: 1.0.0-beta.22
       '@radr/shadowwire':
         specifier: ^1.1.15
-        version: 1.1.15(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@6.0.6)
+        version: 1.1.15(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@5.0.10)
       '@scure/base':
         specifier: ^2.2.0
         version: 2.2.0
@@ -367,28 +367,31 @@ importers:
         version: 0.2.2
       '@solana-program/compute-budget':
         specifier: ^0.15.0
-        version: 0.15.0(@solana/kit@5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+        version: 0.15.0(@solana/kit@5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10))
       '@solana-program/system':
         specifier: ^0.12.2
-        version: 0.12.2(@solana/kit@5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+        version: 0.12.2(@solana/kit@5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10))
       '@solana/compat':
         specifier: ^5.4.0
         version: 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/kit':
         specifier: ^5.4.0
-        version: 5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+        version: 5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10)
       '@solana/spl-token':
         specifier: ^0.4.14
-        version: 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+        version: 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10)
       '@solana/web3.js':
         specifier: ^1.98.4
-        version: 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@6.0.6)
+        version: 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@5.0.10)
       '@triton-one/yellowstone-grpc':
         specifier: ^4.0.2
         version: 4.0.2
+      bs58:
+        specifier: ^6.0.0
+        version: 6.0.0
       langchain:
         specifier: ^1.4.4
-        version: 1.4.4(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod-to-json-schema@3.25.1(zod@4.4.3))
+        version: 1.4.4(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@4.4.3))
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -5925,14 +5928,14 @@ snapshots:
 
   '@jup-ag/api@6.0.48': {}
 
-  '@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.7.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      langsmith: 0.7.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -5946,14 +5949,14 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph-checkpoint@1.0.4(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+  '@langchain/langgraph-checkpoint@1.0.4(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)))':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       uuid: 14.0.0
 
-  '@langchain/langgraph-sdk@1.9.13(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@langchain/langgraph-sdk@1.9.13(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@langchain/protocol': 0.0.16
       '@types/json-schema': 7.0.15
       p-queue: 9.3.0
@@ -5963,11 +5966,11 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@langchain/langgraph@1.3.4(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)':
+  '@langchain/langgraph@1.3.4(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      '@langchain/langgraph-checkpoint': 1.0.4(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
-      '@langchain/langgraph-sdk': 1.9.13(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@langchain/langgraph-checkpoint': 1.0.4(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
+      '@langchain/langgraph-sdk': 1.9.13(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@langchain/protocol': 0.0.16
       '@standard-schema/spec': 1.1.0
       uuid: 14.0.0
@@ -5980,11 +5983,11 @@ snapshots:
       - svelte
       - vue
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       js-tiktoken: 1.0.21
-      openai: 4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)
+      openai: 4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
@@ -6018,12 +6021,12 @@ snapshots:
 
   '@ledgerhq/logs@6.17.0': {}
 
-  '@magicblock-labs/ephemeral-rollups-sdk@0.15.0(bufferutil@4.1.0)(encoding@0.1.13)(utf-8-validate@6.0.6)':
+  '@magicblock-labs/ephemeral-rollups-sdk@0.15.0(bufferutil@4.1.0)(encoding@0.1.13)(utf-8-validate@5.0.10)':
     dependencies:
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@phala/dcap-qvl': 0.3.9(encoding@0.1.13)
-      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
       bs58: 6.0.0
       rpc-websockets: 9.3.9
       tweetnacl: 1.0.3
@@ -6215,9 +6218,9 @@ snapshots:
 
   '@protobufjs/utf8@1.1.1': {}
 
-  '@radr/shadowwire@1.1.15(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+  '@radr/shadowwire@1.1.15(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@5.0.10)
       bs58: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -6453,13 +6456,13 @@ snapshots:
 
   '@sip-protocol/types@0.2.2': {}
 
-  '@solana-program/compute-budget@0.15.0(@solana/kit@5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+  '@solana-program/compute-budget@0.15.0(@solana/kit@5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10))':
     dependencies:
-      '@solana/kit': 5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/kit': 5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10)
 
-  '@solana-program/system@0.12.2(@solana/kit@5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+  '@solana-program/system@0.12.2(@solana/kit@5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10))':
     dependencies:
-      '@solana/kit': 5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/kit': 5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10)
 
   '@solana/accounts@5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
@@ -6496,20 +6499,6 @@ snapshots:
     dependencies:
       '@solana/buffer-layout': 4.0.1
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@5.0.10)
-      bigint-buffer: bigint-buffer-fixed@1.1.6
-      bignumber.js: 9.3.1
-    transitivePeerDependencies:
-      - bluebird
-      - bufferutil
-      - encoding
-      - supports-color
-      - typescript
-      - utf-8-validate
-
-  '@solana/buffer-layout-utils@0.2.0(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@6.0.6)':
-    dependencies:
-      '@solana/buffer-layout': 4.0.1
-      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@6.0.6)
       bigint-buffer: bigint-buffer-fixed@1.1.6
       bignumber.js: 9.3.1
     transitivePeerDependencies:
@@ -6740,7 +6729,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit@5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+  '@solana/kit@5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/accounts': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/addresses': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
@@ -6757,11 +6746,11 @@ snapshots:
       '@solana/rpc-api': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-parsed-types': 5.4.0(typescript@6.0.3)
       '@solana/rpc-spec-types': 5.4.0(typescript@6.0.3)
-      '@solana/rpc-subscriptions': 5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/rpc-subscriptions': 5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10)
       '@solana/rpc-types': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/signers': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/sysvars': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/transaction-confirmation': 5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/transaction-confirmation': 5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10)
       '@solana/transaction-messages': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/transactions': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
@@ -6882,13 +6871,13 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-channel-websocket@5.4.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+  '@solana/rpc-subscriptions-channel-websocket@5.4.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/errors': 5.4.0(typescript@6.0.3)
       '@solana/functional': 5.4.0(typescript@6.0.3)
       '@solana/rpc-subscriptions-spec': 5.4.0(typescript@6.0.3)
       '@solana/subscribable': 5.4.0(typescript@6.0.3)
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -6904,7 +6893,7 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/rpc-subscriptions@5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+  '@solana/rpc-subscriptions@5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/errors': 5.4.0(typescript@6.0.3)
       '@solana/fast-stable-stringify': 5.4.0(typescript@6.0.3)
@@ -6912,7 +6901,7 @@ snapshots:
       '@solana/promises': 5.4.0(typescript@6.0.3)
       '@solana/rpc-spec-types': 5.4.0(typescript@6.0.3)
       '@solana/rpc-subscriptions-api': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/rpc-subscriptions-channel-websocket': 5.4.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/rpc-subscriptions-channel-websocket': 5.4.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@5.0.10)
       '@solana/rpc-subscriptions-spec': 5.4.0(typescript@6.0.3)
       '@solana/rpc-transformers': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-types': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
@@ -7006,26 +6995,10 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@solana/spl-token-group@0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
-    dependencies:
-      '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@6.0.6)
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - typescript
-
   '@solana/spl-token-metadata@0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - typescript
-
-  '@solana/spl-token-metadata@0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
-    dependencies:
-      '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
@@ -7037,23 +7010,6 @@ snapshots:
       '@solana/spl-token-group': 0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@5.0.10)
-      buffer: 6.0.3
-    transitivePeerDependencies:
-      - bluebird
-      - bufferutil
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - supports-color
-      - typescript
-      - utf-8-validate
-
-  '@solana/spl-token@0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
-    dependencies:
-      '@solana/buffer-layout': 4.0.1
-      '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@6.0.6)
-      '@solana/spl-token-group': 0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@6.0.6)
       buffer: 6.0.3
     transitivePeerDependencies:
       - bluebird
@@ -7102,7 +7058,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-confirmation@5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+  '@solana/transaction-confirmation@5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/addresses': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-strings': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
@@ -7110,7 +7066,7 @@ snapshots:
       '@solana/keys': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/promises': 5.4.0(typescript@6.0.3)
       '@solana/rpc': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/rpc-subscriptions': 5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/rpc-subscriptions': 5.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10)
       '@solana/rpc-types': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/transaction-messages': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/transactions': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
@@ -7156,7 +7112,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@noble/curves': 1.9.7
@@ -7169,7 +7125,7 @@ snapshots:
       bs58: 4.0.1
       buffer: 6.0.3
       fast-stable-stringify: 1.0.0
-      jayson: 4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      jayson: 4.3.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       node-fetch: 2.7.0(encoding@0.1.13)
       rpc-websockets: 9.3.2
       superstruct: 2.0.2
@@ -7193,29 +7149,6 @@ snapshots:
       buffer: 6.0.3
       fast-stable-stringify: 1.0.0
       jayson: 4.3.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      node-fetch: 2.7.0(encoding@0.1.13)
-      rpc-websockets: 9.3.2
-      superstruct: 2.0.2
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
-
-  '@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@6.0.6)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      '@noble/curves': 1.9.7
-      '@noble/hashes': 1.8.0
-      '@solana/buffer-layout': 4.0.1
-      '@solana/codecs-numbers': 2.3.0(typescript@6.0.3)
-      agentkeepalive: 4.6.0
-      bn.js: 5.2.3
-      borsh: 0.7.0
-      bs58: 4.0.1
-      buffer: 6.0.3
-      fast-stable-stringify: 1.0.0
-      jayson: 4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       node-fetch: 2.7.0(encoding@0.1.13)
       rpc-websockets: 9.3.2
       superstruct: 2.0.2
@@ -7630,7 +7563,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@6.4.3(@types/node@25.9.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@6.4.3(@types/node@25.9.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -8919,10 +8852,6 @@ snapshots:
     dependencies:
       ws: 7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
-  isomorphic-ws@4.0.1(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
-    dependencies:
-      ws: 7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-report@3.0.1:
@@ -8950,24 +8879,6 @@ snapshots:
       stream-json: 1.9.1
       uuid: 8.3.2
       ws: 7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  jayson@4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    dependencies:
-      '@types/connect': 3.4.38
-      '@types/node': 12.20.55
-      '@types/ws': 7.4.7
-      commander: 2.20.3
-      delay: 5.0.0
-      es6-promisify: 5.0.0
-      eyes: 0.1.8
-      isomorphic-ws: 4.0.1(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      json-stringify-safe: 5.0.1
-      stream-json: 1.9.1
-      uuid: 8.3.2
-      ws: 7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -9119,12 +9030,12 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  langchain@1.4.4(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod-to-json-schema@3.25.1(zod@4.4.3)):
+  langchain@1.4.4(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@4.4.3)):
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      '@langchain/langgraph': 1.3.4(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)
-      '@langchain/langgraph-checkpoint': 1.0.4(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
-      langsmith: 0.7.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@langchain/langgraph': 1.3.4(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)
+      '@langchain/langgraph-checkpoint': 1.0.4(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
+      langsmith: 0.7.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       zod: 4.4.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -9138,14 +9049,14 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  langsmith@0.7.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+  langsmith@0.7.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
     dependencies:
       p-queue: 6.6.2
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
-      openai: 4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3)
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      openai: 4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3)
+      ws: 7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
   leven@3.1.0: {}
 
@@ -9694,7 +9605,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76):
+  openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -9704,12 +9615,12 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0(encoding@0.1.13)
     optionalDependencies:
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
 
-  openai@4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3):
+  openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -9719,7 +9630,7 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0(encoding@0.1.13)
     optionalDependencies:
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod: 4.4.3
     transitivePeerDependencies:
       - encoding
@@ -10935,11 +10846,6 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 5.0.10
-
-  ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 6.0.6
 
   ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     optionalDependencies:


### PR DESCRIPTION
## Summary

Lets a stealth-address recipient cash out received SPL tokens **without holding any SOL**. A relayer is the transaction fee-payer; the stealth address signs only the token transfers; the relayer recovers its SOL cost as an SPL fee deducted from the moved tokens (fee-from-claim) — the Solana analogue of the EVM Gelato deposit-mode relayer.

Refs #1134.

## ⚠️ Also fixes a pre-existing critical bug — Fixes #1139

While building this, we found that **ed25519 stealth addresses were unspendable via the SDK**: the derived key is a raw scalar, but a Solana `Keypair`/tweetnacl signs by treating the first 32 bytes as a *seed*, so signatures never verified. `claimStealthPayment` was broken and no test caught it. Fixed with a from-scratch RFC 8032 sign-with-scalar primitive. See #1139 for the full root-cause + proof.

## What's included

- **`computeRelayerFee`** — hybrid fee `max(flatFloor, amount·bps/10_000)` (floor guarantees gas coverage on small claims, bps scales on large ones; no oracle in v1). Validates inputs (non-integer/negative bps, negative amount).
- **`signEd25519WithScalar` + `deriveStealthSigner`** (`stealth-signer.ts`) — RFC 8032 signing from a raw scalar; a `StealthSigner` that attaches signatures via `Transaction.addSignature`. Replaces the `Keypair` abstraction for stealth addresses.
- **`buildGaslessCashout`** — builds the stealth-signed tx: `feePayer = relayer`, optional dest-ATA creation (relayer pays rent), fee transfer + net transfer; throws if the fee would consume the whole claim.
- **`submitGaslessCashout`** — relayer co-signs as fee-payer and submits. **Direct submission is the primary path** (works devnet + mainnet); a **Jito bundle is optional** mainnet hardening. Checks on-chain confirmation `err`.
- **JitoRelayer hardening** — base58 signatures (was hex), tip-correctness fix (single-tx bundles now carry a tip via the `tipPayer` route), first-ever relayer tests.
- Public exports wired through the `@sip-protocol/sdk` barrel.

## Design decisions (locked)

1. Relayer-as-fee-payer single tx is the primary path; Jito bundle is opt-in.
2. Fee model: hybrid `max(flatFloor, bps)`, caller-supplied config — no fee hardcoded in the SDK.
3. `claimStealthPayment` (the self-funded claim) is unchanged in behavior except its signing is now correct.

## Testing

- Full SDK suite green: **6,804 passed / 0 failed**. `pnpm typecheck` clean (9 packages).
- New coverage: fee model (9), stealth signer incl. SIP:1 legacy + sign/verify + tamper + zero-scalar (8), JitoRelayer base58 + tip routing (7), gasless build + submit + on-chain-failure (8), `claimStealthPayment` end-to-end signing regression guard, package-export smoke test.
- Crypto independently audited (noble + tweetnacl + hand-rolled verifier) and fund-safety reviewed (relayer-fee-account and destination are strictly caller-controlled; tamper breaks the signature).

## Caveats

- **Jito path is mock-tested only** (mocked `fetch`) — Jito has no devnet block engine, so it's validated on mainnet later. The direct path is the devnet-testable one.
- This branch also carries one unrelated docs commit (`docs(claude): mark VPS->Vercel migration…`) that landed on the branch during development.

## Follow-ups (out of scope)

- Verify whether the on-chain `claim_transfer` / mobile claim flow share the scalar-vs-seed assumption (#1139).
- `detectCluster` is duplicated across Solana modules — consolidate in a later cleanup.