### PR TITLE
fix(sdk): harden Solana gasless cash-out (Jito windows, Token-2022, cleanup)

### DIFF
--- a/.changeset/solana-cashout-hardening.md
+++ b/.changeset/solana-cashout-hardening.md
@@ -1,0 +1,11 @@
+---
+"@sip-protocol/sdk": minor
+---
+
+Harden Solana gasless cash-out (closes #1141, #1142).
+
+**Jito relayer (#1141):** the Jito bundle path now binds the prepended tip transaction and the confirmation window to the cash-out transaction's own blockhash. Previously a freshly fetched blockhash was used for the tip and for confirmation while the cash-out transaction kept its own, so an expired cash-out blockhash could never land in the atomic bundle and confirmation was judged against the wrong window. `directSubmit` now confirms against the sent transaction's own blockhash. A tip-less `relayTransaction` call now fails loudly (and falls back to direct submission) instead of reporting a never-included bundle as `submitted`.
+
+**Token-2022 (#1142):** `buildGaslessCashout`, `claimStealthPayment`, and `getStealthBalance` accept an optional `tokenProgramId` (defaults to the classic SPL Token program), so Token-2022 mints derive the correct associated-token account and target the correct token program. Existing classic-mint callers are unaffected.
+
+**Cleanup (#1142):** `signEd25519WithScalar` accepts an optional precomputed public key to skip a redundant scalar multiplication per signature; the duplicated Solana `detectCluster` helper is consolidated into one constants module; the independent RPC reads in `buildGaslessCashout` now run concurrently; and the direct `bs58` dependency is dropped in favour of the in-repo base58 encoder.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -86,7 +86,6 @@
     "@solana/spl-token": "^0.4.14",
     "@solana/web3.js": "^1.98.4",
     "@triton-one/yellowstone-grpc": "^4.0.2",
-    "bs58": "^6.0.0",
     "langchain": "^1.4.4",
     "pino": "^10.3.1",
     "zod": "^4.4.3"

--- a/packages/sdk/src/chains/solana/constants.ts
+++ b/packages/sdk/src/chains/solana/constants.ts
@@ -132,6 +132,29 @@ export const HELIUS_API_KEY_MIN_LENGTH = 8
 export const WEBHOOK_MAX_BATCH_SIZE = 100
 
 /**
+ * Detect the Solana cluster from an RPC endpoint URL.
+ *
+ * Inspects the endpoint hostname for well-known cluster markers. Anything that
+ * does not match devnet/testnet/localnet is treated as mainnet-beta, so custom
+ * mainnet RPC providers (Helius, QuickNode, Triton, …) resolve correctly.
+ *
+ * @param endpoint - RPC endpoint URL (e.g. `connection.rpcEndpoint`)
+ * @returns Detected cluster name
+ */
+export function detectCluster(endpoint: string): SolanaCluster {
+  if (endpoint.includes('devnet')) {
+    return 'devnet'
+  }
+  if (endpoint.includes('testnet')) {
+    return 'testnet'
+  }
+  if (endpoint.includes('localhost') || endpoint.includes('127.0.0.1')) {
+    return 'localnet'
+  }
+  return 'mainnet-beta'
+}
+
+/**
  * Get explorer URL for a transaction
  */
 export function getExplorerUrl(

--- a/packages/sdk/src/chains/solana/gasless-cashout.ts
+++ b/packages/sdk/src/chains/solana/gasless-cashout.ts
@@ -24,7 +24,7 @@ import {
 import type { HexString } from '@sip-protocol/types'
 import { deriveStealthSigner } from './stealth-signer'
 import { computeRelayerFee, type RelayerFeeConfig } from './relayer-fee'
-import { getExplorerUrl, type SolanaCluster } from './constants'
+import { detectCluster, getExplorerUrl } from './constants'
 import type { JitoRelayer } from '../../solana/jito-relayer'
 
 /** Parameters for building a gasless cash-out transaction. */
@@ -194,20 +194,6 @@ export async function buildGaslessCashout(
     blockhash,
     lastValidBlockHeight,
   }
-}
-
-/** Detect the Solana cluster from an RPC endpoint URL. */
-function detectCluster(endpoint: string): SolanaCluster {
-  if (endpoint.includes('devnet')) {
-    return 'devnet'
-  }
-  if (endpoint.includes('testnet')) {
-    return 'testnet'
-  }
-  if (endpoint.includes('localhost') || endpoint.includes('127.0.0.1')) {
-    return 'localnet'
-  }
-  return 'mainnet-beta'
 }
 
 /** Parameters for submitting a built gasless cash-out. */

--- a/packages/sdk/src/chains/solana/gasless-cashout.ts
+++ b/packages/sdk/src/chains/solana/gasless-cashout.ts
@@ -132,28 +132,40 @@ export async function buildGaslessCashout(
     )
   }
 
-  // Validate the relayer fee account is a token account for `mint` — otherwise the fee
-  // transfer would fail (mint mismatch) or the fee would be unrecoverable.
-  let feeAccount
-  try {
-    feeAccount = await getAccount(connection, relayerFeeAccount, undefined, tokenProgramId)
-  } catch {
+  // The three RPC reads below are independent — fire them concurrently and then
+  // validate the settled results in a FIXED order so failures stay deterministic
+  // (Promise.all would surface whichever rejects first, which is nondeterministic).
+  const [feeAccountSettled, balanceSettled, blockhashSettled] = await Promise.allSettled([
+    // Validate the relayer fee account is a token account for `mint` — otherwise the fee
+    // transfer would fail (mint mismatch) or the fee would be unrecoverable.
+    getAccount(connection, relayerFeeAccount, undefined, tokenProgramId),
+    // Gross balance held by the stealth ATA.
+    connection.getTokenAccountBalance(stealthATA),
+    connection.getLatestBlockhash(),
+  ])
+
+  // 1. Relayer fee account: existence first, then mint match.
+  if (feeAccountSettled.status === 'rejected') {
     throw new Error('relayerFeeAccount does not exist or is not a token account')
   }
-  if (!feeAccount.mint.equals(mint)) {
+  if (!feeAccountSettled.value.mint.equals(mint)) {
     throw new Error('relayerFeeAccount is not an associated token account for the given mint')
   }
 
-  // Gross balance held by the stealth ATA
-  let balanceResp
-  try {
-    balanceResp = await connection.getTokenAccountBalance(stealthATA)
-  } catch {
+  // 2. Stealth ATA balance.
+  if (balanceSettled.status === 'rejected') {
     throw new Error(
       `Stealth token account ${stealthATA.toBase58()} for mint ${mint.toBase58()} does not exist or holds no balance; nothing to cash out`
     )
   }
-  const grossAmount = BigInt(balanceResp.value.amount)
+  const grossAmount = BigInt(balanceSettled.value.value.amount)
+
+  // 3. Recent blockhash — bound below after the fee guard so we never sign a tx with
+  // a stale/absent blockhash; surface a clear error instead of an unhandled rejection.
+  if (blockhashSettled.status === 'rejected') {
+    throw new Error('Failed to fetch a recent blockhash for the cash-out transaction')
+  }
+  const { blockhash, lastValidBlockHeight } = blockhashSettled.value
 
   const relayerFee = computeRelayerFee(grossAmount, feeConfig)
   if (relayerFee >= grossAmount) {
@@ -189,7 +201,7 @@ export async function buildGaslessCashout(
     createTransferInstruction(stealthATA, destinationATA, stealthPubkey, netAmount, [], tokenProgramId)
   )
 
-  const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash()
+  // Blockhash was fetched concurrently above and validated before this point.
   transaction.recentBlockhash = blockhash
   transaction.lastValidBlockHeight = lastValidBlockHeight
   transaction.feePayer = relayerPublicKey

--- a/packages/sdk/src/chains/solana/gasless-cashout.ts
+++ b/packages/sdk/src/chains/solana/gasless-cashout.ts
@@ -160,8 +160,8 @@ export async function buildGaslessCashout(
   }
   const grossAmount = BigInt(balanceSettled.value.value.amount)
 
-  // 3. Recent blockhash — bound below after the fee guard so we never sign a tx with
-  // a stale/absent blockhash; surface a clear error instead of an unhandled rejection.
+  // 3. Recent blockhash — validated after the fee/balance guards so a transient blockhash
+  // RPC failure surfaces a clear error rather than an unhandled rejection.
   if (blockhashSettled.status === 'rejected') {
     throw new Error('Failed to fetch a recent blockhash for the cash-out transaction')
   }
@@ -194,11 +194,25 @@ export async function buildGaslessCashout(
 
   // Fee: stealth -> relayer fee account
   transaction.add(
-    createTransferInstruction(stealthATA, relayerFeeAccount, stealthPubkey, relayerFee, [], tokenProgramId)
+    createTransferInstruction(
+      stealthATA,
+      relayerFeeAccount,
+      stealthPubkey,
+      relayerFee,
+      [], // multiSigners
+      tokenProgramId
+    )
   )
   // Net: stealth -> destination
   transaction.add(
-    createTransferInstruction(stealthATA, destinationATA, stealthPubkey, netAmount, [], tokenProgramId)
+    createTransferInstruction(
+      stealthATA,
+      destinationATA,
+      stealthPubkey,
+      netAmount,
+      [], // multiSigners
+      tokenProgramId
+    )
   )
 
   // Blockhash was fetched concurrently above and validated before this point.

--- a/packages/sdk/src/chains/solana/gasless-cashout.ts
+++ b/packages/sdk/src/chains/solana/gasless-cashout.ts
@@ -20,6 +20,7 @@ import {
   createTransferInstruction,
   createAssociatedTokenAccountIdempotentInstruction,
   getAccount,
+  TOKEN_PROGRAM_ID,
 } from '@solana/spl-token'
 import type { HexString } from '@sip-protocol/types'
 import { deriveStealthSigner } from './stealth-signer'
@@ -51,6 +52,12 @@ export interface GaslessCashoutParams {
   feeConfig: RelayerFeeConfig
   /** Announcement scheme version: '2' canonical (default) | '1' legacy */
   version?: '1' | '2'
+  /**
+   * SPL token program owning the mint — defaults to the classic Token program;
+   * pass TOKEN_2022_PROGRAM_ID for Token-2022 mints. A wrong program id derives the
+   * wrong ATA and targets the wrong program (on-chain failure).
+   */
+  tokenProgramId?: PublicKey
 }
 
 /** A stealth-signed gasless cash-out transaction, awaiting the relayer's fee-payer signature. */
@@ -99,6 +106,7 @@ export async function buildGaslessCashout(
     feeConfig,
     version = '2',
   } = params
+  const tokenProgramId = params.tokenProgramId ?? TOKEN_PROGRAM_ID
 
   const stealthSigner = deriveStealthSigner({
     stealthAddress,
@@ -109,9 +117,14 @@ export async function buildGaslessCashout(
   })
   const stealthPubkey = stealthSigner.publicKey
 
-  const stealthATA = await getAssociatedTokenAddress(mint, stealthPubkey, true)
+  const stealthATA = await getAssociatedTokenAddress(mint, stealthPubkey, true, tokenProgramId)
   const destinationPubkey = new PublicKey(destinationAddress)
-  const destinationATA = await getAssociatedTokenAddress(mint, destinationPubkey)
+  const destinationATA = await getAssociatedTokenAddress(
+    mint,
+    destinationPubkey,
+    false,
+    tokenProgramId
+  )
 
   if (destinationATA.equals(stealthATA)) {
     throw new Error(
@@ -123,7 +136,7 @@ export async function buildGaslessCashout(
   // transfer would fail (mint mismatch) or the fee would be unrecoverable.
   let feeAccount
   try {
-    feeAccount = await getAccount(connection, relayerFeeAccount)
+    feeAccount = await getAccount(connection, relayerFeeAccount, undefined, tokenProgramId)
   } catch {
     throw new Error('relayerFeeAccount does not exist or is not a token account')
   }
@@ -162,17 +175,18 @@ export async function buildGaslessCashout(
       relayerPublicKey, // payer (relayer pays rent)
       destinationATA,
       destinationPubkey,
-      mint
+      mint,
+      tokenProgramId
     )
   )
 
   // Fee: stealth -> relayer fee account
   transaction.add(
-    createTransferInstruction(stealthATA, relayerFeeAccount, stealthPubkey, relayerFee)
+    createTransferInstruction(stealthATA, relayerFeeAccount, stealthPubkey, relayerFee, [], tokenProgramId)
   )
   // Net: stealth -> destination
   transaction.add(
-    createTransferInstruction(stealthATA, destinationATA, stealthPubkey, netAmount)
+    createTransferInstruction(stealthATA, destinationATA, stealthPubkey, netAmount, [], tokenProgramId)
   )
 
   const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash()

--- a/packages/sdk/src/chains/solana/scan.ts
+++ b/packages/sdk/src/chains/solana/scan.ts
@@ -12,6 +12,7 @@ import {
   getAssociatedTokenAddress,
   createTransferInstruction,
   getAccount,
+  TOKEN_PROGRAM_ID,
 } from '@solana/spl-token'
 import {
   checkEd25519StealthAddress,
@@ -261,6 +262,7 @@ export async function claimStealthPayment(
     mint,
     version = '2',
   } = params
+  const tokenProgramId = params.tokenProgramId ?? TOKEN_PROGRAM_ID
 
   // M7 FIX: Check SOL balance for fees before attempting claim
   const stealthPubkeyForBalance = new PublicKey(stealthAddress)
@@ -286,17 +288,20 @@ export async function claimStealthPayment(
   const stealthATA = await getAssociatedTokenAddress(
     mint,
     stealthPubkey,
-    true
+    true,
+    tokenProgramId
   )
 
   const destinationPubkey = new PublicKey(destinationAddress)
   const destinationATA = await getAssociatedTokenAddress(
     mint,
-    destinationPubkey
+    destinationPubkey,
+    false,
+    tokenProgramId
   )
 
   // Get balance
-  const stealthAccount = await getAccount(connection, stealthATA)
+  const stealthAccount = await getAccount(connection, stealthATA, undefined, tokenProgramId)
   const amount = stealthAccount.amount
 
   // Build transfer transaction
@@ -307,7 +312,9 @@ export async function claimStealthPayment(
       stealthATA,
       destinationATA,
       stealthPubkey,
-      amount
+      amount,
+      [],
+      tokenProgramId
     )
   )
 
@@ -357,6 +364,8 @@ export async function claimStealthPayment(
  * @param stealthAddress - Stealth address to check (base58)
  * @param mint - SPL token mint address
  * @param provider - Optional RPC provider for efficient queries
+ * @param tokenProgramId - SPL token program owning the mint (default: classic Token
+ *   program; pass TOKEN_2022_PROGRAM_ID for Token-2022 mints)
  * @returns Token balance in smallest unit
  *
  * @example
@@ -373,7 +382,8 @@ export async function getStealthBalance(
   connection: SolanaScanParams['connection'],
   stealthAddress: string,
   mint: PublicKey,
-  provider?: SolanaRPCProvider
+  provider?: SolanaRPCProvider,
+  tokenProgramId: PublicKey = TOKEN_PROGRAM_ID
 ): Promise<bigint> {
   // Use provider if available for efficient queries
   if (provider) {
@@ -387,8 +397,8 @@ export async function getStealthBalance(
   // Standard RPC fallback
   try {
     const stealthPubkey = new PublicKey(stealthAddress)
-    const ata = await getAssociatedTokenAddress(mint, stealthPubkey, true)
-    const account = await getAccount(connection, ata)
+    const ata = await getAssociatedTokenAddress(mint, stealthPubkey, true, tokenProgramId)
+    const account = await getAccount(connection, ata, undefined, tokenProgramId)
     return account.amount
   } catch {
     return 0n

--- a/packages/sdk/src/chains/solana/scan.ts
+++ b/packages/sdk/src/chains/solana/scan.ts
@@ -28,10 +28,10 @@ import { parseAnnouncement } from './types'
 import {
   SIP_MEMO_PREFIX_ANY,
   MEMO_PROGRAM_ID,
+  detectCluster,
   getExplorerUrl,
   DEFAULT_SCAN_LIMIT,
   VIEW_TAG_MAX,
-  type SolanaCluster,
 } from './constants'
 import { getTokenSymbol, parseTokenTransferFromBalances } from './utils'
 import type { SolanaRPCProvider } from './providers/interface'
@@ -396,26 +396,4 @@ export async function getStealthBalance(
 }
 
 // Token transfer parsing and symbol lookup moved to ./utils.ts (L3 fix)
-
-/**
- * Detect Solana cluster from RPC endpoint URL
- *
- * Parses the endpoint URL to determine which Solana cluster it connects to.
- *
- * @param endpoint - RPC endpoint URL
- * @returns Detected cluster name
- * @internal
- */
-function detectCluster(endpoint: string): SolanaCluster {
-  if (endpoint.includes('devnet')) {
-    return 'devnet'
-  }
-  if (endpoint.includes('testnet')) {
-    return 'testnet'
-  }
-  if (endpoint.includes('localhost') || endpoint.includes('127.0.0.1')) {
-    return 'localnet'
-  }
-  return 'mainnet-beta'
-}
 

--- a/packages/sdk/src/chains/solana/sol-transfer.ts
+++ b/packages/sdk/src/chains/solana/sol-transfer.ts
@@ -25,6 +25,7 @@ import type { StealthMetaAddress } from '@sip-protocol/types'
 import { createAnnouncementMemo } from './types'
 import {
   MEMO_PROGRAM_ID,
+  detectCluster,
   getExplorerUrl,
   ESTIMATED_TX_FEE_LAMPORTS,
   type SolanaCluster,
@@ -721,12 +722,3 @@ export async function getSOLBalance(
   }
 }
 
-/**
- * Detect Solana cluster from RPC endpoint
- */
-function detectCluster(endpoint: string): SolanaCluster {
-  if (endpoint.includes('devnet')) return 'devnet'
-  if (endpoint.includes('testnet')) return 'testnet'
-  if (endpoint.includes('localhost') || endpoint.includes('127.0.0.1')) return 'localnet'
-  return 'mainnet-beta'
-}

--- a/packages/sdk/src/chains/solana/spl-transfer.ts
+++ b/packages/sdk/src/chains/solana/spl-transfer.ts
@@ -35,6 +35,7 @@ import type { StealthMetaAddress } from '@sip-protocol/types'
 import { createAnnouncementMemo } from './types'
 import {
   MEMO_PROGRAM_ID,
+  detectCluster,
   getExplorerUrl,
   ESTIMATED_TX_FEE_LAMPORTS,
   type SolanaCluster,
@@ -875,12 +876,3 @@ export function parseTokenAmount(input: string, decimals: number): bigint {
   return BigInt(raw)
 }
 
-/**
- * Detect Solana cluster from RPC endpoint
- */
-function detectCluster(endpoint: string): SolanaCluster {
-  if (endpoint.includes('devnet')) return 'devnet'
-  if (endpoint.includes('testnet')) return 'testnet'
-  if (endpoint.includes('localhost') || endpoint.includes('127.0.0.1')) return 'localnet'
-  return 'mainnet-beta'
-}

--- a/packages/sdk/src/chains/solana/stealth-signer.ts
+++ b/packages/sdk/src/chains/solana/stealth-signer.ts
@@ -38,15 +38,29 @@ function modL(value: bigint): bigint {
  *
  * @param message - Exact bytes to sign (e.g. a compiled transaction message)
  * @param scalar - 32-byte little-endian ed25519 scalar (the stealth private key)
+ * @param publicKeyBytes - Optional 32-byte compressed public key `A = a·G`. When supplied,
+ *   it is used directly as `A` to skip one scalar multiplication per signature — a pure
+ *   performance shortcut for callers that already hold the public key (e.g.
+ *   {@link deriveStealthSigner}, which proves `A` equals the stealth address before signing).
+ *   It is NOT a second independent input: it MUST equal `a·G`. Supplying a wrong value does
+ *   not raise an error — it silently produces an invalid signature (`A` feeds the challenge
+ *   `k = H(R‖A‖message)`). When omitted, `A` is computed from `a`. Must be exactly 32 bytes.
  * @returns 64-byte signature (R ‖ S)
- * @throws If the scalar reduces to zero
+ * @throws If the scalar reduces to zero, or if `publicKeyBytes` is supplied but not 32 bytes
  */
-export function signEd25519WithScalar(message: Uint8Array, scalar: Uint8Array): Uint8Array {
+export function signEd25519WithScalar(
+  message: Uint8Array,
+  scalar: Uint8Array,
+  publicKeyBytes?: Uint8Array,
+): Uint8Array {
+  if (publicKeyBytes !== undefined && publicKeyBytes.length !== 32) {
+    throw new Error('publicKeyBytes must be 32 bytes')
+  }
   const a = modL(bytesToBigIntLE(scalar))
   if (a === 0n) {
     throw new Error('Invalid stealth scalar: reduces to zero')
   }
-  const A = ed25519.ExtendedPoint.BASE.multiply(a).toRawBytes()
+  const A = publicKeyBytes ?? ed25519.ExtendedPoint.BASE.multiply(a).toRawBytes()
 
   const prefix = sha512(scalar).slice(32, 64)
   const r = modL(bytesToBigIntLE(sha512(new Uint8Array([...prefix, ...message]))))
@@ -134,11 +148,11 @@ export function deriveStealthSigner(params: DeriveStealthSignerParams): StealthS
   return {
     publicKey,
     signMessage(message: Uint8Array): Uint8Array {
-      return signEd25519WithScalar(message, scalar)
+      return signEd25519WithScalar(message, scalar, derivedPubKeyBytes)
     },
     signTransaction(transaction: Transaction): void {
       const message = transaction.serializeMessage()
-      const signature = signEd25519WithScalar(message, scalar)
+      const signature = signEd25519WithScalar(message, scalar, derivedPubKeyBytes)
       transaction.addSignature(publicKey, Buffer.from(signature))
     },
   }

--- a/packages/sdk/src/chains/solana/stealth-signer.ts
+++ b/packages/sdk/src/chains/solana/stealth-signer.ts
@@ -54,7 +54,7 @@ export function signEd25519WithScalar(
   publicKeyBytes?: Uint8Array,
 ): Uint8Array {
   if (publicKeyBytes !== undefined && publicKeyBytes.length !== 32) {
-    throw new Error('publicKeyBytes must be 32 bytes')
+    throw new Error(`publicKeyBytes must be 32 bytes, got ${publicKeyBytes.length}`)
   }
   const a = modL(bytesToBigIntLE(scalar))
   if (a === 0n) {
@@ -96,8 +96,8 @@ export interface StealthSigner {
   /**
    * Sign arbitrary bytes with the stealth scalar, returning a 64-byte ed25519 signature.
    *
-   * This is a deliberate symmetric primitive (mirrors {@link signTransaction}'s non-transaction
-   * counterpart): it lets the controller of a stealth address produce an off-chain proof of
+   * This is the raw-bytes sibling of {@link signTransaction}: it lets the controller of a
+   * stealth address produce an off-chain proof of
    * control — e.g. authenticating to an off-chain service or attesting ownership — without
    * moving funds. The signature verifies against {@link publicKey} with any standard ed25519
    * verifier. Use {@link signTransaction} for on-chain Solana transactions.

--- a/packages/sdk/src/chains/solana/stealth-signer.ts
+++ b/packages/sdk/src/chains/solana/stealth-signer.ts
@@ -93,7 +93,15 @@ export interface DeriveStealthSignerParams {
 export interface StealthSigner {
   /** The stealth address this signer controls */
   readonly publicKey: PublicKey
-  /** Sign arbitrary bytes, returning a 64-byte ed25519 signature */
+  /**
+   * Sign arbitrary bytes with the stealth scalar, returning a 64-byte ed25519 signature.
+   *
+   * This is a deliberate symmetric primitive (mirrors {@link signTransaction}'s non-transaction
+   * counterpart): it lets the controller of a stealth address produce an off-chain proof of
+   * control — e.g. authenticating to an off-chain service or attesting ownership — without
+   * moving funds. The signature verifies against {@link publicKey} with any standard ed25519
+   * verifier. Use {@link signTransaction} for on-chain Solana transactions.
+   */
   signMessage(message: Uint8Array): Uint8Array
   /** Attach this stealth address's signature to a transaction. Call LAST — after feePayer, recentBlockhash, and all instructions are finalized (the signature covers the serialized message at call time). */
   signTransaction(transaction: Transaction): void

--- a/packages/sdk/src/chains/solana/transfer.ts
+++ b/packages/sdk/src/chains/solana/transfer.ts
@@ -31,9 +31,9 @@ import type {
 import { createAnnouncementMemo } from './types'
 import {
   MEMO_PROGRAM_ID,
+  detectCluster,
   getExplorerUrl,
   ESTIMATED_TX_FEE_LAMPORTS,
-  type SolanaCluster,
 } from './constants'
 import { bytesToHex } from '@noble/hashes/utils'
 
@@ -316,20 +316,4 @@ export async function hasTokenAccount(
   } catch {
     return false
   }
-}
-
-/**
- * Detect Solana cluster from RPC endpoint
- */
-function detectCluster(endpoint: string): SolanaCluster {
-  if (endpoint.includes('devnet')) {
-    return 'devnet'
-  }
-  if (endpoint.includes('testnet')) {
-    return 'testnet'
-  }
-  if (endpoint.includes('localhost') || endpoint.includes('127.0.0.1')) {
-    return 'localnet'
-  }
-  return 'mainnet-beta'
 }

--- a/packages/sdk/src/chains/solana/types.ts
+++ b/packages/sdk/src/chains/solana/types.ts
@@ -155,6 +155,12 @@ export interface SolanaClaimParams {
    * Pass the `version` returned by {@link parseAnnouncement}.
    */
   version?: '1' | '2'
+  /**
+   * SPL token program owning the mint — defaults to the classic Token program;
+   * pass TOKEN_2022_PROGRAM_ID for Token-2022 mints. A wrong program id derives the
+   * wrong ATA and targets the wrong program (on-chain failure).
+   */
+  tokenProgramId?: PublicKey
 }
 
 /**

--- a/packages/sdk/src/solana/jito-relayer.ts
+++ b/packages/sdk/src/solana/jito-relayer.ts
@@ -299,8 +299,14 @@ export class JitoRelayer {
     // Create tip instruction
     const tipInstruction = this.createTipInstruction(request.tipPayer.publicKey, tipLamports)
 
-    // Get recent blockhash
-    const { blockhash, lastValidBlockHeight } = await this.connection.getLatestBlockhash()
+    // The relayer cannot re-sign the user (cash-out) transaction — it lacks the
+    // signing key. So the prepended tip tx and the confirmation window must ADOPT
+    // the user tx's blockhash window; a fresh blockhash would orphan the bundle
+    // (the user tx could be expired yet the tip tx still look valid). Fall back to
+    // a fresh blockhash only when the user tx carries no window (e.g. versioned tx).
+    const ctx = this.extractBlockhashContext(request.transactions[0])
+    const { blockhash, lastValidBlockHeight } =
+      ctx ?? (await this.connection.getLatestBlockhash())
 
     // Add tip to the first transaction or create a standalone tip tx
     const bundleTransactions = await this.prepareBundleTransactions(
@@ -485,6 +491,27 @@ export class JitoRelayer {
   // ─── Private Methods ────────────────────────────────────────────────────────
 
   /**
+   * Extract a legacy transaction's blockhash window so the tip tx and the
+   * confirmation window can be reconciled against the SAME window the user tx is
+   * signed for. Returns `null` for versioned transactions, or when either field
+   * is missing — callers then fall back to a freshly fetched blockhash.
+   */
+  private extractBlockhashContext(
+    tx: Transaction | VersionedTransaction
+  ): { blockhash: string; lastValidBlockHeight: number } | null {
+    if (tx instanceof VersionedTransaction) {
+      return null
+    }
+    const lastValidBlockHeight = (
+      tx as Transaction & { lastValidBlockHeight?: number }
+    ).lastValidBlockHeight
+    if (tx.recentBlockhash && typeof lastValidBlockHeight === 'number') {
+      return { blockhash: tx.recentBlockhash, lastValidBlockHeight }
+    }
+    return null
+  }
+
+  /**
    * Create tip instruction
    */
   private createTipInstruction(
@@ -657,7 +684,12 @@ export class JitoRelayer {
     )
 
     if (waitForConfirmation) {
-      const { blockhash, lastValidBlockHeight } = await this.connection.getLatestBlockhash()
+      // Confirm against the SENT tx's own blockhash window — a freshly fetched
+      // blockhash could report a different (later) window and misjudge expiry.
+      // Fall back to a fresh blockhash only for versioned txs that carry no window.
+      const ctx = this.extractBlockhashContext(transaction)
+      const { blockhash, lastValidBlockHeight } =
+        ctx ?? (await this.connection.getLatestBlockhash())
       const confirmation = await this.connection.confirmTransaction({
         signature,
         blockhash,

--- a/packages/sdk/src/solana/jito-relayer.ts
+++ b/packages/sdk/src/solana/jito-relayer.ts
@@ -472,9 +472,7 @@ export class JitoRelayer {
     if (tx instanceof VersionedTransaction) {
       return null
     }
-    const lastValidBlockHeight = (
-      tx as Transaction & { lastValidBlockHeight?: number }
-    ).lastValidBlockHeight
+    const lastValidBlockHeight = tx.lastValidBlockHeight
     if (tx.recentBlockhash && typeof lastValidBlockHeight === 'number') {
       return { blockhash: tx.recentBlockhash, lastValidBlockHeight }
     }

--- a/packages/sdk/src/solana/jito-relayer.ts
+++ b/packages/sdk/src/solana/jito-relayer.ts
@@ -389,9 +389,9 @@ export class JitoRelayer {
     this.log('Relaying transaction')
 
     try {
-      // Jito bundles require a tip to land. If a tipPayer is supplied, use the
-      // bundle path (which prepends a tip tx); otherwise fall through to the
-      // existing single-tx submission.
+      // Jito bundles require a tip to land. A tipPayer is therefore mandatory for
+      // the bundle path (which prepends a tip tx). Without one we fail loud below
+      // and let the catch fall back to honest direct submission.
       if (request.tipPayer) {
         const bundle = await this.submitBundle({
           transactions: [request.transaction],
@@ -410,45 +410,15 @@ export class JitoRelayer {
         }
       }
 
-      // For single transaction relay, we need to handle it differently
-      // The transaction should already be signed by the user
-      // We add it to a bundle with a tip transaction
-
-      const serializedTx = Buffer.from(request.transaction.serialize()).toString('base64')
-
-      // Submit as single-tx bundle
-      const bundleId = await this.sendBundle([serializedTx])
-
-      // Get signature
-      let signature: string
-      if (request.transaction instanceof VersionedTransaction) {
-        signature = JitoRelayer.encodeSignature(request.transaction.signatures[0])
-      } else {
-        const sig = request.transaction.signature
-        signature = sig ? JitoRelayer.encodeSignature(sig) : ''
-      }
-
-      // Wait for confirmation if requested
-      if (request.waitForConfirmation) {
-        const { lastValidBlockHeight } = await this.connection.getLatestBlockhash()
-        const status = await this.waitForBundleConfirmation(bundleId, lastValidBlockHeight)
-
-        return {
-          signature,
-          bundleId,
-          status: status.status === 'Landed' ? 'confirmed' : 'failed',
-          slot: status.landedSlot,
-          error: status.error,
-          relayed: true,
-        }
-      }
-
-      return {
-        signature,
-        bundleId,
-        status: 'submitted',
-        relayed: true,
-      }
+      // No tipPayer → there is no way to land a Jito bundle. A tip-less bundle is
+      // never included by the block engine, so reporting it as 'submitted' would
+      // be a silent lie. Fail loud here; the catch below falls back to honest
+      // direct submission (relayed:false).
+      throw new JitoRelayerError(
+        JitoRelayerErrorCode.INSUFFICIENT_TIP,
+        'Jito bundle relay requires a tipPayer; tip-less bundles are never included ' +
+          'by the block engine. Provide a tipPayer or submit directly.'
+      )
     } catch (error) {
       // Fallback to direct submission
       this.log('Relayer failed, falling back to direct submission:', error)

--- a/packages/sdk/src/solana/jito-relayer.ts
+++ b/packages/sdk/src/solana/jito-relayer.ts
@@ -47,7 +47,7 @@ import {
   Keypair,
   type TransactionInstruction,
 } from '@solana/web3.js'
-import bs58 from 'bs58'
+import { bytesToBase58 } from '../stealth/utils'
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -269,7 +269,7 @@ export class JitoRelayer {
 
   /** Encode a 64-byte ed25519 signature as a base58 string (Solana canonical form). */
   static encodeSignature(sig: Uint8Array): string {
-    return bs58.encode(sig)
+    return bytesToBase58(sig)
   }
 
   // ─── Public Methods ─────────────────────────────────────────────────────────

--- a/packages/sdk/tests/chains/solana/claim.test.ts
+++ b/packages/sdk/tests/chains/solana/claim.test.ts
@@ -10,14 +10,19 @@
 
 import { describe, it, expect } from 'vitest'
 import { PublicKey, Transaction, type Connection } from '@solana/web3.js'
-import { AccountLayout, TOKEN_PROGRAM_ID } from '@solana/spl-token'
+import {
+  AccountLayout,
+  TOKEN_PROGRAM_ID,
+  TOKEN_2022_PROGRAM_ID,
+  getAssociatedTokenAddressSync,
+} from '@solana/spl-token'
 import type { ChainId } from '@sip-protocol/types'
 import {
   generateEd25519StealthMetaAddress,
   generateEd25519StealthAddress,
   ed25519PublicKeyToSolanaAddress,
 } from '../../../src/stealth'
-import { claimStealthPayment } from '../../../src/chains/solana/scan'
+import { claimStealthPayment, getStealthBalance } from '../../../src/chains/solana/scan'
 
 const USDC_MINT = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')
 
@@ -48,7 +53,11 @@ function scenario() {
  * The owner field encoded *inside* the layout is the ATA's token owner
  * (stealthPubkey) — returned as data, not checked by unpackAccount itself.
  */
-function makeTokenAccountInfo(stealthPubkey: PublicKey, amount: bigint) {
+function makeTokenAccountInfo(
+  stealthPubkey: PublicKey,
+  amount: bigint,
+  tokenProgramId: PublicKey = TOKEN_PROGRAM_ID
+) {
   const data = Buffer.alloc(AccountLayout.span)
   AccountLayout.encode(
     {
@@ -69,7 +78,7 @@ function makeTokenAccountInfo(stealthPubkey: PublicKey, amount: bigint) {
   )
   return {
     data,
-    owner: TOKEN_PROGRAM_ID, // the *program* that owns this account — must match TOKEN_PROGRAM_ID
+    owner: tokenProgramId, // the *program* that owns this account — must match the unpack programId
     executable: false,
     lamports: 2039280,
     rentEpoch: 0,
@@ -194,5 +203,165 @@ describe('claimStealthPayment', () => {
         version: '1', // wrong scheme for a canonical address — must route to V1 derivation
       })
     ).rejects.toThrow('Stealth key derivation failed')
+  })
+
+  // ─── (d) S1: Token-2022 mint support ────────────────────────────────────────
+  it('(d) derives the Token-2022 ATA and targets the Token-2022 program when tokenProgramId is set', async () => {
+    const s = scenario()
+    const stealthPubkey = new PublicKey(s.stealthB58)
+    // Token account is owned by the Token-2022 program; getAccount must unpack with it.
+    const tokenAccountInfo = makeTokenAccountInfo(stealthPubkey, 5_000_000n, TOKEN_2022_PROGRAM_ID)
+
+    let capturedRaw: Uint8Array | null = null
+    const connection = {
+      rpcEndpoint: 'https://api.devnet.solana.com',
+      getBalance: async (_pk: PublicKey) => 10_000_000,
+      getAccountInfo: async (_address: PublicKey) => tokenAccountInfo,
+      getLatestBlockhash: async () => ({
+        blockhash: '11111111111111111111111111111111',
+        lastValidBlockHeight: 100,
+      }),
+      sendRawTransaction: async (raw: Uint8Array) => {
+        capturedRaw = raw
+        return '4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi1v9eHNzaRZ2d5kH3J4b9mzSJ'
+      },
+      confirmTransaction: async () => ({ value: { err: null } }),
+    } as unknown as Connection
+
+    const result = await claimStealthPayment({
+      connection,
+      stealthAddress: s.stealthB58,
+      ephemeralPublicKey: s.ephemeralB58,
+      viewingPrivateKey: s.recipient.viewingPrivateKey,
+      spendingPrivateKey: s.recipient.spendingPrivateKey,
+      destinationAddress: 'So11111111111111111111111111111111111111112',
+      mint: USDC_MINT,
+      version: '2',
+      tokenProgramId: TOKEN_2022_PROGRAM_ID,
+    })
+
+    expect(result.amount).toBe(5_000_000n)
+
+    // The transfer instruction must target the Token-2022 program, and its source
+    // account (keys[0]) must be the Token-2022-derived ATA (≠ classic ATA).
+    expect(capturedRaw).not.toBeNull()
+    const sentTx = Transaction.from(capturedRaw!)
+    const transferIx = sentTx.instructions.find((ix) =>
+      ix.programId.equals(TOKEN_2022_PROGRAM_ID)
+    )
+    expect(transferIx).toBeDefined()
+    expect(
+      sentTx.instructions.some((ix) => ix.programId.equals(TOKEN_PROGRAM_ID))
+    ).toBe(false)
+
+    const expected2022ATA = getAssociatedTokenAddressSync(
+      USDC_MINT,
+      stealthPubkey,
+      true,
+      TOKEN_2022_PROGRAM_ID
+    )
+    const classicATA = getAssociatedTokenAddressSync(USDC_MINT, stealthPubkey, true, TOKEN_PROGRAM_ID)
+    expect(transferIx!.keys[0].pubkey.equals(expected2022ATA)).toBe(true)
+    expect(transferIx!.keys[0].pubkey.equals(classicATA)).toBe(false)
+  })
+
+  // ─── (e) S1 regression: default stays classic ───────────────────────────────
+  it('(e) defaults to the classic token program when tokenProgramId is omitted', async () => {
+    const s = scenario()
+    const stealthPubkey = new PublicKey(s.stealthB58)
+    const tokenAccountInfo = makeTokenAccountInfo(stealthPubkey, 5_000_000n)
+
+    let capturedRaw: Uint8Array | null = null
+    const connection = {
+      rpcEndpoint: 'https://api.devnet.solana.com',
+      getBalance: async (_pk: PublicKey) => 10_000_000,
+      getAccountInfo: async (_address: PublicKey) => tokenAccountInfo,
+      getLatestBlockhash: async () => ({
+        blockhash: '11111111111111111111111111111111',
+        lastValidBlockHeight: 100,
+      }),
+      sendRawTransaction: async (raw: Uint8Array) => {
+        capturedRaw = raw
+        return '4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi1v9eHNzaRZ2d5kH3J4b9mzSJ'
+      },
+      confirmTransaction: async () => ({ value: { err: null } }),
+    } as unknown as Connection
+
+    await claimStealthPayment({
+      connection,
+      stealthAddress: s.stealthB58,
+      ephemeralPublicKey: s.ephemeralB58,
+      viewingPrivateKey: s.recipient.viewingPrivateKey,
+      spendingPrivateKey: s.recipient.spendingPrivateKey,
+      destinationAddress: 'So11111111111111111111111111111111111111112',
+      mint: USDC_MINT,
+      version: '2',
+    })
+
+    const sentTx = Transaction.from(capturedRaw!)
+    const transferIx = sentTx.instructions.find((ix) => ix.programId.equals(TOKEN_PROGRAM_ID))
+    expect(transferIx).toBeDefined()
+    const classicATA = getAssociatedTokenAddressSync(USDC_MINT, stealthPubkey, true, TOKEN_PROGRAM_ID)
+    expect(transferIx!.keys[0].pubkey.equals(classicATA)).toBe(true)
+  })
+})
+
+// ─── getStealthBalance — Token-2022 support ───────────────────────────────────
+
+describe('getStealthBalance', () => {
+  it('reads the Token-2022 ATA when tokenProgramId is provided', async () => {
+    const s = scenario()
+    const stealthPubkey = new PublicKey(s.stealthB58)
+    const expected2022ATA = getAssociatedTokenAddressSync(
+      USDC_MINT,
+      stealthPubkey,
+      true,
+      TOKEN_2022_PROGRAM_ID
+    )
+    const tokenAccountInfo = makeTokenAccountInfo(stealthPubkey, 7_000_000n, TOKEN_2022_PROGRAM_ID)
+
+    // Only return the account when queried at the Token-2022 ATA; anything else
+    // (e.g. the classic ATA) returns null so getAccount would throw → balance 0n.
+    let queriedAddress: PublicKey | null = null
+    const connection = {
+      rpcEndpoint: 'https://api.devnet.solana.com',
+      getAccountInfo: async (address: PublicKey) => {
+        queriedAddress = address
+        return address.equals(expected2022ATA) ? tokenAccountInfo : null
+      },
+    } as unknown as Connection
+
+    const balance = await getStealthBalance(
+      connection,
+      s.stealthB58,
+      USDC_MINT,
+      undefined,
+      TOKEN_2022_PROGRAM_ID
+    )
+
+    expect(balance).toBe(7_000_000n)
+    expect(queriedAddress).not.toBeNull()
+    expect((queriedAddress as unknown as PublicKey).equals(expected2022ATA)).toBe(true)
+  })
+
+  it('defaults to the classic ATA when tokenProgramId is omitted', async () => {
+    const s = scenario()
+    const stealthPubkey = new PublicKey(s.stealthB58)
+    const classicATA = getAssociatedTokenAddressSync(USDC_MINT, stealthPubkey, true, TOKEN_PROGRAM_ID)
+    const tokenAccountInfo = makeTokenAccountInfo(stealthPubkey, 3_000_000n)
+
+    let queriedAddress: PublicKey | null = null
+    const connection = {
+      rpcEndpoint: 'https://api.devnet.solana.com',
+      getAccountInfo: async (address: PublicKey) => {
+        queriedAddress = address
+        return address.equals(classicATA) ? tokenAccountInfo : null
+      },
+    } as unknown as Connection
+
+    const balance = await getStealthBalance(connection, s.stealthB58, USDC_MINT)
+
+    expect(balance).toBe(3_000_000n)
+    expect((queriedAddress as unknown as PublicKey).equals(classicATA)).toBe(true)
   })
 })

--- a/packages/sdk/tests/chains/solana/constants.test.ts
+++ b/packages/sdk/tests/chains/solana/constants.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Solana Constants Tests
+ *
+ * Focused coverage for the shared helpers consolidated into constants.ts.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { detectCluster, getExplorerUrl } from '../../../src/chains/solana/constants'
+
+describe('detectCluster', () => {
+  it('maps a devnet URL to devnet', () => {
+    expect(detectCluster('https://api.devnet.solana.com')).toBe('devnet')
+  })
+
+  it('maps a testnet URL to testnet', () => {
+    expect(detectCluster('https://api.testnet.solana.com')).toBe('testnet')
+  })
+
+  it('maps a localhost URL to localnet', () => {
+    expect(detectCluster('http://localhost:8899')).toBe('localnet')
+  })
+
+  it('maps a 127.0.0.1 URL to localnet', () => {
+    expect(detectCluster('http://127.0.0.1:8899')).toBe('localnet')
+  })
+
+  it('defaults a mainnet (or unrecognized) URL to mainnet-beta', () => {
+    expect(detectCluster('https://api.mainnet-beta.solana.com')).toBe('mainnet-beta')
+  })
+
+  it('defaults an unknown host to mainnet-beta', () => {
+    expect(detectCluster('https://my-rpc.example.com')).toBe('mainnet-beta')
+  })
+
+  it('feeds the detected cluster into getExplorerUrl (devnet adds the cluster query)', () => {
+    const cluster = detectCluster('https://api.devnet.solana.com')
+    expect(getExplorerUrl('abc123', cluster)).toContain('cluster=devnet')
+  })
+})

--- a/packages/sdk/tests/chains/solana/gasless-cashout.test.ts
+++ b/packages/sdk/tests/chains/solana/gasless-cashout.test.ts
@@ -234,6 +234,47 @@ describe('buildGaslessCashout', () => {
     })).rejects.toThrow(/relayerFeeAccount does not exist or is not a token account/)
   })
 
+  // D4 — deterministic precedence: when the fee account AND the stealth balance both
+  // fail, the fee-account error must win (validation order is fixed, not first-to-reject).
+  it('reports the fee-account error first even when the stealth balance also fails', async () => {
+    const s = scenario()
+    const conn = mockConn({ gross: 0n, balanceThrows: true })
+    const wrapped = {
+      ...conn,
+      getAccountInfo: async () => null, // fee account missing too
+    } as unknown as Connection
+    await expect(buildGaslessCashout({
+      connection: wrapped,
+      ...baseParams(s),
+    })).rejects.toThrow(/relayerFeeAccount does not exist or is not a token account/)
+  })
+
+  // D4 — a wrong-mint fee account still wins over a failing stealth balance.
+  it('reports the fee-account mint mismatch before the stealth-balance failure', async () => {
+    const s = scenario()
+    const otherMint = new PublicKey('So11111111111111111111111111111111111111112')
+    await expect(buildGaslessCashout({
+      connection: mockConn({ gross: 0n, balanceThrows: true, feeAccountMint: otherMint }),
+      ...baseParams(s),
+    })).rejects.toThrow(/not an associated token account for the given mint/)
+  })
+
+  // D4 — a blockhash fetch failure surfaces a clear error (not an unhandled rejection).
+  it('throws a clear error when the recent blockhash cannot be fetched', async () => {
+    const s = scenario()
+    const conn = mockConn({ gross: 1_000_000_000n })
+    const wrapped = {
+      ...conn,
+      getLatestBlockhash: async () => {
+        throw new Error('429 Too Many Requests')
+      },
+    } as unknown as Connection
+    await expect(buildGaslessCashout({
+      connection: wrapped,
+      ...baseParams(s),
+    })).rejects.toThrow(/blockhash/i)
+  })
+
   // S1 — Token-2022 support: program id must flow into ATA derivation + instructions
   it('derives Token-2022 ATAs and targets the Token-2022 program when tokenProgramId is set', async () => {
     const s = scenario()

--- a/packages/sdk/tests/chains/solana/gasless-cashout.test.ts
+++ b/packages/sdk/tests/chains/solana/gasless-cashout.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from 'vitest'
 import { Keypair, PublicKey, type Connection, type AccountInfo } from '@solana/web3.js'
 import {
   TOKEN_PROGRAM_ID,
+  TOKEN_2022_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID,
   AccountLayout,
   ACCOUNT_SIZE,
   AccountState,
+  getAssociatedTokenAddressSync,
 } from '@solana/spl-token'
 import type { ChainId } from '@sip-protocol/types'
 import {
@@ -28,8 +30,19 @@ function scenario() {
   }
 }
 
-/** Encode a valid, initialized SPL token-account buffer so `getAccount` decodes it. */
-function encodeTokenAccountInfo(mint: PublicKey, owner: PublicKey): AccountInfo<Buffer> {
+/**
+ * Encode a valid, initialized SPL token-account buffer so `getAccount` decodes it.
+ *
+ * @param mint - mint the account holds
+ * @param owner - wallet owner stored inside the account data
+ * @param tokenProgramId - program that OWNS the account (must match the programId
+ *   `getAccount` unpacks with, else unpackAccount throws TokenInvalidAccountOwnerError)
+ */
+function encodeTokenAccountInfo(
+  mint: PublicKey,
+  owner: PublicKey,
+  tokenProgramId: PublicKey = TOKEN_PROGRAM_ID
+): AccountInfo<Buffer> {
   const data = Buffer.alloc(ACCOUNT_SIZE)
   AccountLayout.encode(
     {
@@ -49,7 +62,7 @@ function encodeTokenAccountInfo(mint: PublicKey, owner: PublicKey): AccountInfo<
   )
   return {
     lamports: 2_039_280,
-    owner: TOKEN_PROGRAM_ID,
+    owner: tokenProgramId,
     executable: false,
     rentEpoch: 0,
     data,
@@ -65,6 +78,11 @@ interface MockConnOptions {
   feeAccountMint?: PublicKey
   /** Owner to report on the relayerFeeAccount token account (default: a fresh key) */
   feeAccountOwner?: PublicKey
+  /**
+   * Token program that owns the relayerFeeAccount (default: classic TOKEN_PROGRAM_ID).
+   * Must match the `tokenProgramId` passed to buildGaslessCashout so `getAccount` unpacks.
+   */
+  feeAccountProgram?: PublicKey
 }
 
 /**
@@ -75,6 +93,7 @@ interface MockConnOptions {
 function mockConn(opts: MockConnOptions): Connection {
   const feeMint = opts.feeAccountMint ?? USDC_MINT
   const feeOwner = opts.feeAccountOwner ?? Keypair.generate().publicKey
+  const feeProgram = opts.feeAccountProgram ?? TOKEN_PROGRAM_ID
   return {
     rpcEndpoint: 'https://api.devnet.solana.com',
     getLatestBlockhash: async () => ({
@@ -89,7 +108,7 @@ function mockConn(opts: MockConnOptions): Connection {
         value: { amount: opts.gross.toString(), decimals: 6, uiAmount: 0, uiAmountString: '0' },
       }
     },
-    getAccountInfo: async () => encodeTokenAccountInfo(feeMint, feeOwner),
+    getAccountInfo: async () => encodeTokenAccountInfo(feeMint, feeOwner, feeProgram),
   } as unknown as Connection
 }
 
@@ -213,6 +232,70 @@ describe('buildGaslessCashout', () => {
       connection: wrapped,
       ...baseParams(s),
     })).rejects.toThrow(/relayerFeeAccount does not exist or is not a token account/)
+  })
+
+  // S1 — Token-2022 support: program id must flow into ATA derivation + instructions
+  it('derives Token-2022 ATAs and targets the Token-2022 program when tokenProgramId is set', async () => {
+    const s = scenario()
+    const build = await buildGaslessCashout({
+      connection: mockConn({
+        gross: 1_000_000_000n,
+        feeAccountProgram: TOKEN_2022_PROGRAM_ID, // fee account owned by Token-2022
+      }),
+      ...baseParams(s),
+      tokenProgramId: TOKEN_2022_PROGRAM_ID,
+    })
+
+    // The two transfer instructions (fee + net) must target the Token-2022 program.
+    const transfers = build.transaction.instructions.filter((ix) =>
+      ix.programId.equals(TOKEN_2022_PROGRAM_ID)
+    )
+    expect(transfers.length).toBe(2)
+    // No classic-program transfer leaked in.
+    expect(
+      build.transaction.instructions.some((ix) => ix.programId.equals(TOKEN_PROGRAM_ID))
+    ).toBe(false)
+    // The idempotent create-ATA still routes through the associated-token program,
+    // but is told to create a Token-2022 account (program id is a passed key/arg).
+    expect(
+      build.transaction.instructions[0].programId.equals(ASSOCIATED_TOKEN_PROGRAM_ID)
+    ).toBe(true)
+
+    // The source account (stealth ATA, keys[0]) must be the Token-2022-derived ATA,
+    // which differs from the classic-program ATA for the same mint+owner.
+    const feeTransfer = build.transaction.instructions[1]
+    const stealthATA_2022 = feeTransfer.keys[0].pubkey
+    const stealthPubkey = new PublicKey(s.stealthB58)
+    const classicATA = getAssociatedTokenAddressSync(USDC_MINT, stealthPubkey, true, TOKEN_PROGRAM_ID)
+    const expected2022ATA = getAssociatedTokenAddressSync(
+      USDC_MINT,
+      stealthPubkey,
+      true,
+      TOKEN_2022_PROGRAM_ID
+    )
+    expect(stealthATA_2022.equals(expected2022ATA)).toBe(true)
+    expect(stealthATA_2022.equals(classicATA)).toBe(false)
+  })
+
+  // S1 regression: default (no tokenProgramId) stays classic — derivation + instructions
+  it('defaults to the classic token program and ATA when tokenProgramId is omitted', async () => {
+    const s = scenario()
+    const build = await buildGaslessCashout({
+      connection: mockConn({ gross: 1_000_000_000n }),
+      ...baseParams(s),
+    })
+
+    const transfers = build.transaction.instructions.filter((ix) =>
+      ix.programId.equals(TOKEN_PROGRAM_ID)
+    )
+    expect(transfers.length).toBe(2)
+    expect(
+      build.transaction.instructions.some((ix) => ix.programId.equals(TOKEN_2022_PROGRAM_ID))
+    ).toBe(false)
+
+    const stealthPubkey = new PublicKey(s.stealthB58)
+    const classicATA = getAssociatedTokenAddressSync(USDC_MINT, stealthPubkey, true, TOKEN_PROGRAM_ID)
+    expect(build.transaction.instructions[1].keys[0].pubkey.equals(classicATA)).toBe(true)
   })
 })
 

--- a/packages/sdk/tests/chains/solana/stealth-signer.test.ts
+++ b/packages/sdk/tests/chains/solana/stealth-signer.test.ts
@@ -91,6 +91,35 @@ describe('signEd25519WithScalar', () => {
   it('throws on a zero scalar', () => {
     expect(() => signEd25519WithScalar(new Uint8Array([1]), new Uint8Array(32))).toThrow('reduces to zero')
   })
+
+  it('with a supplied (correct) public key produces a byte-identical signature to the 2-arg form', () => {
+    const scalar = hexToBytes('0a'.repeat(32))
+    const msg = new Uint8Array([1, 2, 3, 4, 5])
+    const A = pubFromScalar(scalar)
+    const sigDefault = signEd25519WithScalar(msg, scalar)
+    const sigSupplied = signEd25519WithScalar(msg, scalar, A)
+    // The third arg is a pure performance shortcut: with the correct A, R/k/S are
+    // unchanged, so the output MUST be byte-for-byte identical.
+    expect(bytesToHex(sigSupplied)).toBe(bytesToHex(sigDefault))
+  })
+
+  it('consumes the supplied public key: a WRONG A yields a signature that fails verification', () => {
+    const scalar = hexToBytes('0a'.repeat(32))
+    const msg = new Uint8Array([9, 8, 7])
+    // A valid-but-wrong 32-byte point (public key of a different scalar).
+    const wrongA = pubFromScalar(hexToBytes('0b'.repeat(32)))
+    const sig = signEd25519WithScalar(msg, scalar, wrongA)
+    // The param is genuinely fed into the k = H(R‖A‖msg) hash, so a wrong A corrupts S
+    // and the signature cannot verify against the real public key.
+    expect(ed25519.verify(sig, msg, pubFromScalar(scalar))).toBe(false)
+  })
+
+  it('throws when the supplied public key is not exactly 32 bytes', () => {
+    const scalar = hexToBytes('0a'.repeat(32))
+    const msg = new Uint8Array([1, 2, 3])
+    expect(() => signEd25519WithScalar(msg, scalar, new Uint8Array(31))).toThrow('publicKeyBytes must be 32 bytes')
+    expect(() => signEd25519WithScalar(msg, scalar, new Uint8Array(33))).toThrow('publicKeyBytes must be 32 bytes')
+  })
 })
 
 describe('deriveStealthSigner', () => {

--- a/packages/sdk/tests/solana/jito-relayer.test.ts
+++ b/packages/sdk/tests/solana/jito-relayer.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { Keypair, Transaction, SystemProgram } from '@solana/web3.js'
-import bs58 from 'bs58'
 import {
   JitoRelayer,
   createJitoRelayer,
   JITO_TIP_ACCOUNTS,
 } from '../../src/solana/jito-relayer'
+
+// Base58 of a 64-byte signature filled with 0x07 — captured from the historical
+// bs58.encode output so the in-repo encoder is proven byte-identical to it.
+const SIG_ALL_SEVENS_BASE58 =
+  '99eUso3aSbE9tqGSTXzo3TLfKb9RkMTURrHKQ1K7Zh3BbeqPevr5E1iCbpTjqHuTFLtfxTTD5ekfVuZFzQyEQf8'
 
 // Helper: build a signed legacy transfer tx for bundle tests.
 function buildSignedTransferTx(payer: Keypair): Transaction {
@@ -55,7 +59,7 @@ describe('JitoRelayer', () => {
     it('encodes a 64-byte signature as base58 (not hex)', () => {
       const sig = new Uint8Array(64).fill(7)
       const out = JitoRelayer.encodeSignature(sig)
-      expect(out).toBe(bs58.encode(sig))
+      expect(out).toBe(SIG_ALL_SEVENS_BASE58)
       // a hex encoding of 64 bytes would be 128 chars all in [0-9a-f]; base58 includes uppercase
       expect(out).not.toMatch(/^[0-9a-f]+$/)
     })
@@ -118,6 +122,24 @@ describe('JitoRelayer', () => {
       // user tx is the LAST entry in the bundle; signature must be base58
       expect(result.signature).toMatch(/^[1-9A-HJ-NP-Za-km-z]+$/)
       expect(fetchMock).toHaveBeenCalled()
+    })
+  })
+
+  // D2: encodeSignature must be byte-identical to the old bs58.encode after the
+  // swap to the in-repo bytesToBase58 encoder.
+  describe('encodeSignature byte-vector (D2)', () => {
+    it('matches a fixed known base58 vector', () => {
+      // Deterministic 64-byte input: bytes 0..63.
+      const sig = new Uint8Array(64)
+      for (let i = 0; i < 64; i++) sig[i] = i
+      const out = JitoRelayer.encodeSignature(sig)
+      // Hard-coded expectation (base58 of bytes 0x00..0x3f) captured from the
+      // historical bs58.encode output — proving the in-repo encoder is byte-identical.
+      const expected =
+        '1GMkH3brNXiNNs1tiFZHu4yZSRrzJwxi5wB9bHFtMinfCXNnR1adh8Vo8NTheK4evneedH4qmvjeqcBBNAefgS'
+      expect(out).toBe(expected)
+      // Leading zero byte must map to a single '1' prefix (base58 leading-zero rule).
+      expect(out.startsWith('1')).toBe(true)
     })
   })
 })

--- a/packages/sdk/tests/solana/jito-relayer.test.ts
+++ b/packages/sdk/tests/solana/jito-relayer.test.ts
@@ -12,18 +12,33 @@ const SIG_ALL_SEVENS_BASE58 =
   '99eUso3aSbE9tqGSTXzo3TLfKb9RkMTURrHKQ1K7Zh3BbeqPevr5E1iCbpTjqHuTFLtfxTTD5ekfVuZFzQyEQf8'
 
 // Helper: build a signed legacy transfer tx for bundle tests.
-function buildSignedTransferTx(payer: Keypair): Transaction {
+function buildSignedTransferTx(
+  payer: Keypair,
+  opts?: { recentBlockhash?: string; lastValidBlockHeight?: number }
+): Transaction {
   const tx = new Transaction()
   tx.add(SystemProgram.transfer({
     fromPubkey: payer.publicKey,
     toPubkey: payer.publicKey,
     lamports: 1,
   }))
-  tx.recentBlockhash = '11111111111111111111111111111111'
+  tx.recentBlockhash = opts?.recentBlockhash ?? '11111111111111111111111111111111'
+  if (opts?.lastValidBlockHeight !== undefined) {
+    // Mirror how the SDK tags legacy cash-out txs with their valid-block window.
+    ;(tx as Transaction & { lastValidBlockHeight?: number }).lastValidBlockHeight =
+      opts.lastValidBlockHeight
+  }
   tx.feePayer = payer.publicKey
   tx.sign(payer)
   return tx
 }
+
+// Valid 32-byte base58 blockhashes (a tx must serialize/sign with these, so the
+// strings have to decode to 32 bytes). Distinct values so we can prove which one
+// the relayer actually adopts.
+const USER_TX_BLOCKHASH = '8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR'
+const FRESH_BLOCKHASH = 'cGfHiC6Kgg3FpFZvgwGcswsCRtp4aBP2fzuXRQPizuN'
+const OWN_TX_BLOCKHASH = 'LbUiWL3xVV8hTFYBVdbTNrpDo41NKS6o3LHHuDzjfcY'
 
 describe('JitoRelayer', () => {
   afterEach(() => vi.restoreAllMocks())
@@ -122,6 +137,170 @@ describe('JitoRelayer', () => {
       // user tx is the LAST entry in the bundle; signature must be base58
       expect(result.signature).toMatch(/^[1-9A-HJ-NP-Za-km-z]+$/)
       expect(fetchMock).toHaveBeenCalled()
+    })
+  })
+
+  // J3 + J4: the prepended tip tx and the confirmation window must ADOPT the
+  // cash-out (user) tx's blockhash window — the relayer cannot re-sign the
+  // cash-out tx, so a fresh blockhash would orphan it.
+  describe('blockhash window reconciliation (J3/J4)', () => {
+    it('tip tx adopts the user tx blockhash; no fresh getLatestBlockhash (J3)', async () => {
+      const fetchMock = vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ result: 'bundle-j3' }),
+      }) as unknown as Response)
+      vi.stubGlobal('fetch', fetchMock)
+
+      const tipPayer = Keypair.generate()
+      const getLatestBlockhash = vi.fn(async () => ({
+        blockhash: FRESH_BLOCKHASH,
+        lastValidBlockHeight: 999999,
+      }))
+      const r = new JitoRelayer({ blockEngineUrl: 'https://x.test/api/v1' })
+      // @ts-expect-error override private connection for the test
+      r.connection = { getLatestBlockhash }
+
+      const userTx = buildSignedTransferTx(tipPayer, {
+        recentBlockhash: USER_TX_BLOCKHASH,
+        lastValidBlockHeight: 1000,
+      })
+
+      // Spy on the private prep step to capture the prepared tip tx.
+      const prepSpy = vi.spyOn(
+        r as unknown as {
+          prepareBundleTransactions: JitoRelayer['prepareBundleTransactions']
+        },
+        'prepareBundleTransactions'
+      )
+
+      await r.submitBundle({ transactions: [userTx], tipPayer })
+
+      // No fresh blockhash fetched — the user tx already carries a window.
+      expect(getLatestBlockhash).not.toHaveBeenCalled()
+      // The blockhash threaded into prepareBundleTransactions is the user tx's.
+      const blockhashArg = prepSpy.mock.calls[0][3]
+      expect(blockhashArg).toBe(USER_TX_BLOCKHASH)
+      // And the actually-prepared tip tx carries that same blockhash (not fresh).
+      const prepared = await prepSpy.mock.results[0].value
+      const tipTx = prepared[0] as Transaction
+      expect(tipTx.recentBlockhash).toBe(USER_TX_BLOCKHASH)
+    })
+
+    it('confirmation expiry is judged against the user tx lastValidBlockHeight (J4)', async () => {
+      const fetchMock = vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ result: 'bundle-j4' }),
+      }) as unknown as Response)
+      vi.stubGlobal('fetch', fetchMock)
+
+      const tipPayer = Keypair.generate()
+      const getBlockHeight = vi.fn(async () => 1001) // strictly > user tx's 1000 → expired
+      const getLatestBlockhash = vi.fn(async () => ({
+        blockhash: FRESH_BLOCKHASH,
+        lastValidBlockHeight: 999999, // a fresh window would NOT be expired
+      }))
+      const r = new JitoRelayer({ blockEngineUrl: 'https://x.test/api/v1' })
+      // @ts-expect-error override private connection for the test
+      r.connection = { getLatestBlockhash, getBlockHeight }
+
+      const userTx = buildSignedTransferTx(tipPayer, {
+        recentBlockhash: USER_TX_BLOCKHASH,
+        lastValidBlockHeight: 1000,
+      })
+
+      const res = await r.submitBundle({
+        transactions: [userTx],
+        tipPayer,
+        waitForConfirmation: true,
+      })
+
+      // The user tx's window (1000) drives expiry — a fresh window (999999) would not.
+      expect(res.status).toBe('failed')
+      expect(res.error).toMatch(/expired/i)
+      expect(getLatestBlockhash).not.toHaveBeenCalled()
+    })
+
+    it('falls back to a fresh blockhash when the user tx carries no window', async () => {
+      const fetchMock = vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ result: 'bundle-fallback' }),
+      }) as unknown as Response)
+      vi.stubGlobal('fetch', fetchMock)
+
+      const tipPayer = Keypair.generate()
+      const getLatestBlockhash = vi.fn(async () => ({
+        blockhash: FRESH_BLOCKHASH,
+        lastValidBlockHeight: 100,
+      }))
+      const r = new JitoRelayer({ blockEngineUrl: 'https://x.test/api/v1' })
+      // @ts-expect-error override private connection for the test
+      r.connection = { getLatestBlockhash }
+
+      // No lastValidBlockHeight on this tx → extractBlockhashContext returns null.
+      const userTx = buildSignedTransferTx(tipPayer)
+      const prepSpy = vi.spyOn(
+        r as unknown as {
+          prepareBundleTransactions: JitoRelayer['prepareBundleTransactions']
+        },
+        'prepareBundleTransactions'
+      )
+
+      await r.submitBundle({ transactions: [userTx], tipPayer })
+
+      expect(getLatestBlockhash).toHaveBeenCalledTimes(1)
+      const prepared = await prepSpy.mock.results[0].value
+      const tipTx = prepared[0] as Transaction
+      expect(tipTx.recentBlockhash).toBe(FRESH_BLOCKHASH)
+    })
+  })
+
+  // J7: directSubmit must confirm against the SENT tx's own blockhash window,
+  // not a freshly-fetched one (which could misreport confirmation).
+  describe('directSubmit confirmation window (J7)', () => {
+    it('confirms against the tx own blockhash, not a fresh fetch (J7)', async () => {
+      // Force the bundle path to throw so relayTransaction falls into directSubmit,
+      // while keeping waitForConfirmation:true to exercise the confirm call.
+      const tipPayer = Keypair.generate()
+      const confirmTransaction = vi.fn(async () => ({ value: { err: null } }))
+      const sendRawTransaction = vi.fn(async () => 'ownSig111')
+      const getLatestBlockhash = vi.fn(async () => ({
+        blockhash: FRESH_BLOCKHASH,
+        lastValidBlockHeight: 777777,
+      }))
+      const r = new JitoRelayer({ blockEngineUrl: 'https://x.test/api/v1' })
+      // @ts-expect-error override private connection for the test
+      r.connection = {
+        sendRawTransaction,
+        confirmTransaction,
+        getLatestBlockhash,
+        rpcEndpoint: 'https://api.mainnet-beta.solana.com',
+      }
+      // Force the relayer bundle path to fail → fallback to directSubmit.
+      vi.spyOn(
+        r as unknown as { submitBundle: JitoRelayer['submitBundle'] },
+        'submitBundle'
+      ).mockRejectedValue(new Error('relayer down'))
+
+      const userTx = buildSignedTransferTx(tipPayer, {
+        recentBlockhash: OWN_TX_BLOCKHASH,
+        lastValidBlockHeight: 500,
+      })
+
+      const result = await r.relayTransaction({
+        transaction: userTx,
+        tipPayer,
+        waitForConfirmation: true,
+      })
+
+      expect(result.relayed).toBe(false)
+      expect(result.status).toBe('confirmed')
+      expect(result.signature).toBe('ownSig111')
+      // Confirmed against the tx's OWN window, not a fresh one.
+      expect(confirmTransaction).toHaveBeenCalledWith(
+        { signature: 'ownSig111', blockhash: OWN_TX_BLOCKHASH, lastValidBlockHeight: 500 },
+        'confirmed'
+      )
+      expect(getLatestBlockhash).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/sdk/tests/solana/jito-relayer.test.ts
+++ b/packages/sdk/tests/solana/jito-relayer.test.ts
@@ -138,6 +138,37 @@ describe('JitoRelayer', () => {
       expect(result.signature).toMatch(/^[1-9A-HJ-NP-Za-km-z]+$/)
       expect(fetchMock).toHaveBeenCalled()
     })
+
+    // J6: a tip-less bundle is never included by the block engine. The no-tipPayer
+    // path must NOT fabricate a 'submitted' bundle — it must fail loud inside the
+    // try and fall back to honest direct submission (relayed:false), with no
+    // /bundles call made.
+    it('does NOT submit a tip-less bundle; falls back to direct submission (J6)', async () => {
+      const fetchMock = vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ result: 'should-not-be-used' }),
+      }) as unknown as Response)
+      vi.stubGlobal('fetch', fetchMock)
+
+      const payer = Keypair.generate()
+      const sendRaw = vi.fn(async () => 'directSig111')
+      const r = new JitoRelayer({ blockEngineUrl: 'https://x.test/api/v1' })
+      // @ts-expect-error override private connection for the test
+      r.connection = {
+        sendRawTransaction: sendRaw,
+        rpcEndpoint: 'https://api.mainnet-beta.solana.com',
+      }
+
+      const userTx = buildSignedTransferTx(payer)
+      const result = await r.relayTransaction({ transaction: userTx /* no tipPayer */ })
+
+      // Honest direct submission, not a doomed bundle.
+      expect(result.relayed).toBe(false)
+      expect(result.signature).toBe('directSig111')
+      expect(sendRaw).toHaveBeenCalledTimes(1)
+      // No Jito bundle endpoint should ever be hit on the tip-less path.
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
   })
 
   // J3 + J4: the prepended tip tx and the confirmation window must ADOPT the

--- a/packages/sdk/tests/solana/jito-relayer.test.ts
+++ b/packages/sdk/tests/solana/jito-relayer.test.ts
@@ -41,7 +41,10 @@ const FRESH_BLOCKHASH = 'cGfHiC6Kgg3FpFZvgwGcswsCRtp4aBP2fzuXRQPizuN'
 const OWN_TX_BLOCKHASH = 'LbUiWL3xVV8hTFYBVdbTNrpDo41NKS6o3LHHuDzjfcY'
 
 describe('JitoRelayer', () => {
-  afterEach(() => vi.restoreAllMocks())
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
 
   describe('constructor + helpers', () => {
     it('applies defaults', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,9 +386,6 @@ importers:
       '@triton-one/yellowstone-grpc':
         specifier: ^4.0.2
         version: 4.0.2
-      bs58:
-        specifier: ^6.0.0
-        version: 6.0.0
       langchain:
         specifier: ^1.4.4
         version: 1.4.4(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@4.4.3))


### PR DESCRIPTION
Follow-ups from the max-effort review of #1140 (gasless cash-out relayer). Pure SDK (`packages/sdk`) — no on-chain, app, or mobile changes. Closes both tracked follow-up issues.

Closes #1141
Closes #1142

## What changed

### Jito relayer hardening (#1141) — `src/solana/jito-relayer.ts`
The Jito bundle path is optional mainnet hardening (mock-tested; Jito has no devnet block engine). These correct the blockhash/confirmation reconciliation **before** Jito is enabled on mainnet:
- **J3 / J4** — the prepended tip tx and the confirmation window now adopt the **cash-out tx's own blockhash + `lastValidBlockHeight`** (the relayer can't re-sign the stealth-signed cash-out tx, so the whole bundle is judged on its window). Previously a fresh blockhash drove the tip + confirmation while the cash-out tx kept its own — an expired cash-out blockhash could never land, and confirmation watched the wrong window.
- **J6** — a tip-less `relayTransaction` now **fails loudly** (`INSUFFICIENT_TIP`) and falls back to direct submission, instead of reporting a never-included tip-less bundle as `submitted`.
- **J7** — `directSubmit` confirms against the **sent tx's own** blockhash, not a freshly-fetched one.

### Token-2022 + robustness/cleanup (#1142)
- **S1** — `buildGaslessCashout`, `claimStealthPayment`, and `getStealthBalance` accept an optional `tokenProgramId` (default = classic SPL Token). Token-2022 mints now derive the correct ATA and target the correct program (incl. the `getAccount` owner checks). Classic-mint callers are unaffected.
- **D1** — the 5 duplicated Solana `detectCluster` copies consolidated into one `constants.ts` export.
- **D2** — dropped the direct `bs58` dependency in favour of the in-repo `bytesToBase58`.
- **D3** — `signEd25519WithScalar` takes an optional precomputed public key to skip a redundant scalar-mult per signature (output byte-identical).
- **D4** — the three independent RPC reads in `buildGaslessCashout` now run concurrently (`Promise.allSettled`) with deterministic, byte-identical error precedence.
- **D5** — `StealthSigner.signMessage` documented (kept — it shipped in 0.12.0; removing it would break a days-old public interface).
- **S4** — Jito tests now `vi.unstubAllGlobals()` in `afterEach` to stop a `fetch` stub leaking order-dependently.

## Verification
- Full SDK suite: **6843 passed / 52 skipped / 0 failed** (test files +~16: jito 7→13, stealth-signer 9→12, gasless-cashout + new constants/claim coverage).
- `pnpm typecheck` clean; `pnpm lint` 0 errors (pre-existing warnings only).
- Each finding has a behavior-asserting test proven to fail pre-fix (reviewers verified several by reverting the fix).
- All additions are optional/additive ⇒ changeset bumps `@sip-protocol/sdk` **minor** on merge.

## Notes for review
- The **Jito path is mock-tested only** and gated off the default flow (direct fee-payer submission is primary; Jito requires an explicit `jitoRelayer`). No live-network test exists for it — by design, since Jito has no devnet engine. Do not enable Jito on mainnet beyond this.
- 12 focused commits (per finding) + changeset, all GPG-signed.
