### PR TITLE
feat(sdk): privacy-tier fee model

### DIFF
--- a/.changeset/privacy-tier-fee.md
+++ b/.changeset/privacy-tier-fee.md
@@ -1,0 +1,5 @@
+---
+"@sip-protocol/sdk": minor
+---
+
+Add a typed privacy-tier fee model. A new `PrivacyTier` enum and frozen fee schedule express the protocol fee in basis points (10 / 30 / 50 bps), gated on which privacy guarantee has shipped — not on volume or time. Includes `getPrivacyTierFee`, `getPrivacyTierFeeBps`, `getCurrentPrivacyTierFee`, `getPrivacyTierSchedule`, and a `computePrivacyTierFee(amount, tier)` helper (basis-point floor division, no flat floor). Exported from the package root and the `fees` subpath.

--- a/.changeset/privacy-tier-fee.md
+++ b/.changeset/privacy-tier-fee.md
@@ -2,4 +2,4 @@
 "@sip-protocol/sdk": minor
 ---
 
-Add a typed privacy-tier fee model. A new `PrivacyTier` enum and frozen fee schedule express the protocol fee in basis points (10 / 30 / 50 bps), gated on which privacy guarantee has shipped — not on volume or time. Includes `getPrivacyTierFee`, `getPrivacyTierFeeBps`, `getCurrentPrivacyTierFee`, `getPrivacyTierSchedule`, and a `computePrivacyTierFee(amount, tier)` helper (basis-point floor division, no flat floor). Exported from the package root and the `fees` subpath.
+Add a typed privacy-tier fee model. A new `PrivacyTier` enum and frozen fee schedule express the protocol fee in basis points (10 / 30 / 50 bps), gated on which privacy guarantee has shipped — not on volume or time. Includes `getPrivacyTierFee`, `getPrivacyTierFeeBps`, `getCurrentPrivacyTierFee`, `getPrivacyTierSchedule`, and a `computePrivacyTierFee(amount, tier)` helper (basis-point floor division, no flat floor). Exported from the package root (`@sip-protocol/sdk`).

--- a/docs/fees/privacy-tier-fee-schedule.md
+++ b/docs/fees/privacy-tier-fee-schedule.md
@@ -1,0 +1,53 @@
+# Privacy-Tier Fee Schedule
+
+The protocol fee charged by a SIP privacy vault is **gated on the privacy guarantee it delivers** — not on transaction volume or elapsed time. The fee rises only when a stronger cryptographic guarantee ships.
+
+## The schedule
+
+| Tier | Fee | Privacy guarantee |
+|------|-----|-------------------|
+| `TIER_1` | **10 bps** (0.10%) | **Commingled pool** — funds are pooled in a shared vault; withdrawals are authorized per-depositor. |
+| `TIER_2` | **30 bps** (0.30%) | **Unlinkable withdrawal** — trustless, nullifier-authorized withdrawal severs the on-chain deposit→withdrawal link without a trusted operator. |
+| `TIER_3` | **50 bps** (0.50%) | **Confidential amounts** — settlement amounts are cryptographically hidden (Pedersen commitments / proof composition). |
+
+`TIER_1` is live today. `TIER_2` and `TIER_3` are a published commitment: their rates apply **only when** the corresponding privacy guarantee ships. The single source of truth for what has shipped is `CURRENT_PRIVACY_TIER`.
+
+## Principles
+
+- **More privacy, higher fee — never the reverse.** The schedule is monotonic: a stronger tier never costs less than a weaker one.
+- **No volume or time component.** The rate is a pure function of the privacy tier. It does not change with how much you transact or when.
+- **Frozen commitment.** The basis-point values are a frozen constant in the SDK; there is no API to mutate them at runtime.
+
+## Usage
+
+```ts
+import {
+  PrivacyTier,
+  getCurrentPrivacyTierFee,
+  getPrivacyTierFee,
+  getPrivacyTierSchedule,
+  computePrivacyTierFee,
+} from '@sip-protocol/sdk'
+
+// What does the vault charge today?
+getCurrentPrivacyTierFee()
+// → { tier: 'tier_1', bps: 10, label: 'Commingled pool', description: '…', isActive: true }
+
+// Inspect a specific tier (including not-yet-shipped ones).
+getPrivacyTierFee(PrivacyTier.TIER_2).isActive // false (until unlinkable withdrawal ships)
+
+// Render the full roadmap.
+getPrivacyTierSchedule().map((f) => `${f.label}: ${f.bps} bps`)
+
+// Compute a concrete fee (base units, basis-point floor division, no flat floor).
+computePrivacyTierFee(1_000_000n, PrivacyTier.TIER_1) // 1_000n
+```
+
+## Two distinct fees
+
+A gasless vault cash-out involves **two additive fees**, kept separate in the SDK:
+
+1. **Protocol privacy fee** — `computePrivacyTierFee`, described here. The vault's revenue.
+2. **Relayer gas-recovery fee** — `computeRelayerFee`. Compensates whoever fronts the on-chain transaction fee on behalf of a stealth recipient. It floors at a fixed minimum to guarantee gas coverage; the protocol fee does not.
+
+They are computed independently and summed by the caller.

--- a/packages/sdk/src/fees/index.ts
+++ b/packages/sdk/src/fees/index.ts
@@ -85,3 +85,16 @@ export {
   type FeeCollectionParams,
   type FeeCollectionResult,
 } from './near-contract'
+
+// ─── Privacy-Tier Fee ──────────────────────────────────────────────────────────
+
+export {
+  PrivacyTier,
+  CURRENT_PRIVACY_TIER,
+  getPrivacyTierFee,
+  getPrivacyTierFeeBps,
+  getCurrentPrivacyTierFee,
+  getPrivacyTierSchedule,
+  computePrivacyTierFee,
+} from './privacy-tier'
+export type { PrivacyTierFee } from './privacy-tier'

--- a/packages/sdk/src/fees/privacy-tier.ts
+++ b/packages/sdk/src/fees/privacy-tier.ts
@@ -50,11 +50,11 @@ export interface PrivacyTierFee {
 }
 
 /** Canonical tier ordering, lowest privacy → highest. Drives ordinal comparisons and the monotonic invariant. */
-const PRIVACY_TIER_ORDER: readonly PrivacyTier[] = [
+const PRIVACY_TIER_ORDER: readonly PrivacyTier[] = Object.freeze([
   PrivacyTier.TIER_1,
   PrivacyTier.TIER_2,
   PrivacyTier.TIER_3,
-]
+])
 
 /** Static facts per tier. `isActive` is derived at read time, never stored here. */
 interface PrivacyTierSpec {
@@ -89,24 +89,36 @@ const PRIVACY_TIER_SCHEDULE: Readonly<Record<PrivacyTier, PrivacyTierSpec>> = Ob
 export const CURRENT_PRIVACY_TIER: PrivacyTier = PrivacyTier.TIER_1
 
 /**
- * Enforce the monotonic invariant at module load: the fee schedule must be
- * non-decreasing across tiers (equal is allowed; a decrease is not). Fails
- * fast if a future edit lowers a tier's fee below a less-private tier's.
+ * Validate the whole fee model at module load, so a bad future edit fails fast
+ * at import instead of crashing cryptically at call time. Asserts that every
+ * ordered tier has a schedule entry with a non-negative integer bps, that the
+ * bps values are non-decreasing across tiers (equal is allowed; a decrease is
+ * not), and that CURRENT_PRIVACY_TIER is one of the ordered tiers. This is what
+ * makes the "frozen public commitment" a real load-time invariant.
  */
-function assertScheduleMonotonic(): void {
+function assertScheduleIntegrity(): void {
   let prevBps = -1
   for (const tier of PRIVACY_TIER_ORDER) {
-    const bps = PRIVACY_TIER_SCHEDULE[tier].bps
-    if (bps < prevBps) {
+    const spec = PRIVACY_TIER_SCHEDULE[tier]
+    if (!spec) {
+      throw new Error(`Privacy-tier fee schedule is missing an entry for ${tier}`)
+    }
+    if (!Number.isInteger(spec.bps) || spec.bps < 0) {
+      throw new Error(`Privacy-tier fee for ${tier} must be a non-negative integer bps, got ${String(spec.bps)}`)
+    }
+    if (spec.bps < prevBps) {
       throw new Error(
-        `Privacy-tier fee schedule must be non-decreasing; ${tier} (${bps} bps) is below the preceding tier (${prevBps} bps)`,
+        `Privacy-tier fee schedule must be non-decreasing; ${tier} (${spec.bps} bps) is below the preceding tier (${prevBps} bps)`,
       )
     }
-    prevBps = bps
+    prevBps = spec.bps
+  }
+  if (!PRIVACY_TIER_ORDER.includes(CURRENT_PRIVACY_TIER)) {
+    throw new Error(`CURRENT_PRIVACY_TIER (${String(CURRENT_PRIVACY_TIER)}) must be one of the ordered privacy tiers`)
   }
 }
 
-assertScheduleMonotonic()
+assertScheduleIntegrity()
 
 function tierOrdinal(tier: PrivacyTier): number {
   const idx = PRIVACY_TIER_ORDER.indexOf(tier)

--- a/packages/sdk/src/fees/privacy-tier.ts
+++ b/packages/sdk/src/fees/privacy-tier.ts
@@ -1,0 +1,223 @@
+/**
+ * Privacy-Tier Fee Model
+ *
+ * The protocol fee charged by a SIP privacy vault is gated on which privacy
+ * milestone has SHIPPED — not on volume or time. The fee rises only when a
+ * stronger cryptographic guarantee is delivered:
+ *
+ * - TIER_1 (10 bps) — commingled pool. Funds are pooled in a shared vault;
+ *   withdrawals are authorized per-depositor. LIVE today.
+ * - TIER_2 (30 bps) — unlinkable withdrawal. Trustless, nullifier-authorized
+ *   withdrawal severs the on-chain deposit-to-withdrawal link. Scheduled.
+ * - TIER_3 (50 bps) — confidential amounts. Settlement amounts are
+ *   cryptographically hidden (Pedersen commitments / proof composition).
+ *   Scheduled.
+ *
+ * The schedule is a frozen public commitment: the basis-point values cannot be
+ * mutated at runtime. `CURRENT_PRIVACY_TIER` is the single source of truth for
+ * which tier's privacy has shipped — bump it (and only it) when a tier lands.
+ *
+ * This is the protocol fee (the vault's revenue). It is distinct from the
+ * relayer gas-recovery fee (`computeRelayerFee`) and from the legacy
+ * volume-tiered calculator in the `fees/` module. A gasless vault cash-out pays
+ * both the protocol fee and the relayer fee, additively.
+ *
+ * @module fees/privacy-tier
+ */
+
+/** Ordinal privacy milestone. The protocol fee rate is gated on which tier has shipped. */
+export enum PrivacyTier {
+  /** Commingled pool — 10 bps. Live. */
+  TIER_1 = 'tier_1',
+  /** Unlinkable withdrawal — 30 bps. Scheduled. */
+  TIER_2 = 'tier_2',
+  /** Confidential amounts — 50 bps. Scheduled. */
+  TIER_3 = 'tier_3',
+}
+
+/** A privacy tier's fee descriptor. */
+export interface PrivacyTierFee {
+  /** The tier this descriptor describes. */
+  tier: PrivacyTier
+  /** Protocol fee in basis points (1 bps = 0.01%). One of 10 | 30 | 50. */
+  bps: number
+  /** Short human-readable label. */
+  label: string
+  /** The privacy guarantee earned at this tier. */
+  description: string
+  /** Whether this tier's privacy has shipped (derived from CURRENT_PRIVACY_TIER). */
+  isActive: boolean
+}
+
+/** Canonical tier ordering, lowest privacy → highest. Drives ordinal comparisons and the monotonic invariant. */
+const PRIVACY_TIER_ORDER: readonly PrivacyTier[] = [
+  PrivacyTier.TIER_1,
+  PrivacyTier.TIER_2,
+  PrivacyTier.TIER_3,
+]
+
+/** Static facts per tier. `isActive` is derived at read time, never stored here. */
+interface PrivacyTierSpec {
+  bps: number
+  label: string
+  description: string
+}
+
+const PRIVACY_TIER_SCHEDULE: Readonly<Record<PrivacyTier, PrivacyTierSpec>> = Object.freeze({
+  [PrivacyTier.TIER_1]: Object.freeze({
+    bps: 10,
+    label: 'Commingled pool',
+    description: 'Funds are pooled in a shared vault; withdrawals are authorized per-depositor.',
+  }),
+  [PrivacyTier.TIER_2]: Object.freeze({
+    bps: 30,
+    label: 'Unlinkable withdrawal',
+    description:
+      'Trustless, nullifier-authorized withdrawal severs the on-chain deposit-to-withdrawal link without a trusted operator.',
+  }),
+  [PrivacyTier.TIER_3]: Object.freeze({
+    bps: 50,
+    label: 'Confidential amounts',
+    description: 'Settlement amounts are cryptographically hidden (Pedersen commitments / proof composition).',
+  }),
+})
+
+/**
+ * The single source of truth for which privacy tier has shipped.
+ * Bump this — and only this — when a stronger tier lands.
+ */
+export const CURRENT_PRIVACY_TIER: PrivacyTier = PrivacyTier.TIER_1
+
+/**
+ * Enforce the monotonic invariant at module load: the fee schedule must be
+ * non-decreasing across tiers (equal is allowed; a decrease is not). Fails
+ * fast if a future edit lowers a tier's fee below a less-private tier's.
+ */
+function assertScheduleMonotonic(): void {
+  let prevBps = -1
+  for (const tier of PRIVACY_TIER_ORDER) {
+    const bps = PRIVACY_TIER_SCHEDULE[tier].bps
+    if (bps < prevBps) {
+      throw new Error(
+        `Privacy-tier fee schedule must be non-decreasing; ${tier} (${bps} bps) is below the preceding tier (${prevBps} bps)`,
+      )
+    }
+    prevBps = bps
+  }
+}
+
+assertScheduleMonotonic()
+
+function tierOrdinal(tier: PrivacyTier): number {
+  const idx = PRIVACY_TIER_ORDER.indexOf(tier)
+  if (idx === -1) {
+    throw new Error(`Unknown privacy tier: ${String(tier)}`)
+  }
+  return idx
+}
+
+/** Whether `tier`'s privacy has shipped (its order <= the current tier's order). */
+function isTierActive(tier: PrivacyTier): boolean {
+  return tierOrdinal(tier) <= tierOrdinal(CURRENT_PRIVACY_TIER)
+}
+
+/**
+ * Get the full fee descriptor for a privacy tier.
+ *
+ * @param tier - The privacy tier
+ * @returns The descriptor (bps, label, description, derived isActive)
+ * @throws If `tier` is not a known PrivacyTier
+ *
+ * @example
+ * ```ts
+ * getPrivacyTierFee(PrivacyTier.TIER_1)
+ * // { tier: 'tier_1', bps: 10, label: 'Commingled pool', description: '…', isActive: true }
+ * ```
+ */
+export function getPrivacyTierFee(tier: PrivacyTier): PrivacyTierFee {
+  const spec = PRIVACY_TIER_SCHEDULE[tier]
+  if (!spec) {
+    throw new Error(`Unknown privacy tier: ${String(tier)}`)
+  }
+  return {
+    tier,
+    bps: spec.bps,
+    label: spec.label,
+    description: spec.description,
+    isActive: isTierActive(tier),
+  }
+}
+
+/**
+ * Get the basis-point fee for a privacy tier.
+ *
+ * @param tier - The privacy tier
+ * @returns Fee in basis points (10 | 30 | 50)
+ * @throws If `tier` is not a known PrivacyTier
+ *
+ * @example
+ * ```ts
+ * getPrivacyTierFeeBps(PrivacyTier.TIER_2) // 30
+ * ```
+ */
+export function getPrivacyTierFeeBps(tier: PrivacyTier): number {
+  return getPrivacyTierFee(tier).bps
+}
+
+/**
+ * Get the fee descriptor for the currently-shipped privacy tier.
+ *
+ * @returns The descriptor for CURRENT_PRIVACY_TIER (always isActive: true)
+ *
+ * @example
+ * ```ts
+ * getCurrentPrivacyTierFee().bps // 10 (today)
+ * ```
+ */
+export function getCurrentPrivacyTierFee(): PrivacyTierFee {
+  return getPrivacyTierFee(CURRENT_PRIVACY_TIER)
+}
+
+/**
+ * Get the full fee schedule, ordered lowest → highest privacy.
+ *
+ * @returns All tier descriptors in canonical order (for display / transparency)
+ *
+ * @example
+ * ```ts
+ * getPrivacyTierSchedule().map((f) => f.bps) // [10, 30, 50]
+ * ```
+ */
+export function getPrivacyTierSchedule(): PrivacyTierFee[] {
+  return PRIVACY_TIER_ORDER.map((tier) => getPrivacyTierFee(tier))
+}
+
+/** Basis-point denominator (10_000 bps = 100%). */
+const BPS_DENOMINATOR = 10_000n
+
+/**
+ * Compute the protocol fee for a gross amount at a given privacy tier.
+ *
+ * The fee is `amount * bps / 10_000` using bigint floor division — bps-only,
+ * with NO flat floor (deliberately unlike `computeRelayerFee`, which floors to
+ * guarantee gas coverage). A sub-threshold amount rounds to 0; it is never
+ * bumped to a minimum.
+ *
+ * @param amount - Gross amount in the token's base units (non-negative)
+ * @param tier - The privacy tier whose rate applies
+ * @returns Fee in the token's base units
+ * @throws If `amount` is negative, or `tier` is not a known PrivacyTier
+ *
+ * @example
+ * ```ts
+ * computePrivacyTierFee(1_000_000n, PrivacyTier.TIER_1) // 1_000n (10 bps)
+ * computePrivacyTierFee(99n, PrivacyTier.TIER_1)        // 0n     (no flat floor)
+ * ```
+ */
+export function computePrivacyTierFee(amount: bigint, tier: PrivacyTier): bigint {
+  if (typeof amount !== 'bigint' || amount < 0n) {
+    throw new Error('amount must be a non-negative bigint')
+  }
+  const bps = getPrivacyTierFeeBps(tier)
+  return (amount * BigInt(bps)) / BPS_DENOMINATOR
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1580,6 +1580,14 @@ export {
   calculateFeeForSwap,
   NEAR_FEE_CONTRACTS,
   DEFAULT_TREASURY,
+  // Privacy-Tier Fee
+  PrivacyTier,
+  CURRENT_PRIVACY_TIER,
+  getPrivacyTierFee,
+  getPrivacyTierFeeBps,
+  getCurrentPrivacyTierFee,
+  getPrivacyTierSchedule,
+  computePrivacyTierFee,
 } from './fees'
 
 export type {
@@ -1602,4 +1610,5 @@ export type {
   NEARFeeContractOptions,
   FeeCollectionParams,
   FeeCollectionResult,
+  PrivacyTierFee,
 } from './fees'

--- a/packages/sdk/tests/fees/privacy-tier-exports.test.ts
+++ b/packages/sdk/tests/fees/privacy-tier-exports.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import * as sdk from '../../src/index'
+import * as fees from '../../src/fees'
+
+describe('privacy-tier fee public exports', () => {
+  it('exposes the privacy-tier fee surface from the package root', () => {
+    expect(typeof sdk.getPrivacyTierFee).toBe('function')
+    expect(typeof sdk.getPrivacyTierFeeBps).toBe('function')
+    expect(typeof sdk.getCurrentPrivacyTierFee).toBe('function')
+    expect(typeof sdk.getPrivacyTierSchedule).toBe('function')
+    expect(typeof sdk.computePrivacyTierFee).toBe('function')
+    expect(sdk.PrivacyTier.TIER_1).toBe('tier_1')
+    expect(sdk.CURRENT_PRIVACY_TIER).toBe(sdk.PrivacyTier.TIER_1)
+  })
+
+  it('exposes the same surface from the fees subpath', () => {
+    expect(typeof fees.getPrivacyTierFee).toBe('function')
+    expect(typeof fees.computePrivacyTierFee).toBe('function')
+    expect(fees.PrivacyTier.TIER_2).toBe('tier_2')
+  })
+})

--- a/packages/sdk/tests/fees/privacy-tier-exports.test.ts
+++ b/packages/sdk/tests/fees/privacy-tier-exports.test.ts
@@ -13,7 +13,7 @@ describe('privacy-tier fee public exports', () => {
     expect(sdk.CURRENT_PRIVACY_TIER).toBe(sdk.PrivacyTier.TIER_1)
   })
 
-  it('exposes the same surface from the fees subpath', () => {
+  it('exposes the same surface from the fees barrel module', () => {
     expect(typeof fees.getPrivacyTierFee).toBe('function')
     expect(typeof fees.computePrivacyTierFee).toBe('function')
     expect(fees.PrivacyTier.TIER_2).toBe('tier_2')

--- a/packages/sdk/tests/fees/privacy-tier.test.ts
+++ b/packages/sdk/tests/fees/privacy-tier.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import {
+  PrivacyTier,
+  CURRENT_PRIVACY_TIER,
+  getPrivacyTierFee,
+  getPrivacyTierFeeBps,
+  getCurrentPrivacyTierFee,
+  getPrivacyTierSchedule,
+  computePrivacyTierFee,
+  type PrivacyTierFee,
+} from '../../src/fees/privacy-tier'
+
+describe('privacy-tier fee schedule', () => {
+  it('maps each tier to its locked basis-point rate', () => {
+    expect(getPrivacyTierFeeBps(PrivacyTier.TIER_1)).toBe(10)
+    expect(getPrivacyTierFeeBps(PrivacyTier.TIER_2)).toBe(30)
+    expect(getPrivacyTierFeeBps(PrivacyTier.TIER_3)).toBe(50)
+  })
+
+  it('returns a full descriptor for a tier', () => {
+    const fee: PrivacyTierFee = getPrivacyTierFee(PrivacyTier.TIER_1)
+    expect(fee).toEqual({
+      tier: PrivacyTier.TIER_1,
+      bps: 10,
+      label: 'Commingled pool',
+      description: 'Funds are pooled in a shared vault; withdrawals are authorized per-depositor.',
+      isActive: true,
+    })
+  })
+
+  it('marks only the current tier (and lower) as active', () => {
+    expect(getPrivacyTierFee(PrivacyTier.TIER_1).isActive).toBe(true)
+    expect(getPrivacyTierFee(PrivacyTier.TIER_2).isActive).toBe(false)
+    expect(getPrivacyTierFee(PrivacyTier.TIER_3).isActive).toBe(false)
+  })
+
+  it('exposes the current shipped tier as TIER_1', () => {
+    expect(CURRENT_PRIVACY_TIER).toBe(PrivacyTier.TIER_1)
+    expect(getCurrentPrivacyTierFee()).toEqual(getPrivacyTierFee(PrivacyTier.TIER_1))
+    expect(getCurrentPrivacyTierFee().bps).toBe(10)
+  })
+
+  it('returns the full schedule in canonical order, non-decreasing', () => {
+    const schedule = getPrivacyTierSchedule()
+    expect(schedule.map((f) => f.tier)).toEqual([PrivacyTier.TIER_1, PrivacyTier.TIER_2, PrivacyTier.TIER_3])
+    expect(schedule.map((f) => f.bps)).toEqual([10, 30, 50])
+    for (let i = 1; i < schedule.length; i++) {
+      expect(schedule[i].bps).toBeGreaterThanOrEqual(schedule[i - 1].bps)
+    }
+  })
+
+  it('throws on an unknown tier', () => {
+    expect(() => getPrivacyTierFee('tier_99' as PrivacyTier)).toThrow(/unknown privacy tier/i)
+    expect(() => getPrivacyTierFeeBps('nope' as PrivacyTier)).toThrow(/unknown privacy tier/i)
+  })
+
+  it('returns independent descriptor objects (callers cannot corrupt the schedule)', () => {
+    const a = getPrivacyTierFee(PrivacyTier.TIER_1)
+    a.bps = 999
+    a.label = 'mutated'
+    expect(getPrivacyTierFee(PrivacyTier.TIER_1).bps).toBe(10)
+    expect(getPrivacyTierFee(PrivacyTier.TIER_1).label).toBe('Commingled pool')
+    const schedule = getPrivacyTierSchedule()
+    schedule[0].bps = 999
+    expect(getPrivacyTierSchedule()[0].bps).toBe(10)
+  })
+})
+
+describe('computePrivacyTierFee', () => {
+  it('applies the tier rate via basis-point floor division', () => {
+    // 1 USDC (1_000_000 base units) * 10 bps = 1_000
+    expect(computePrivacyTierFee(1_000_000n, PrivacyTier.TIER_1)).toBe(1_000n)
+    expect(computePrivacyTierFee(1_000_000n, PrivacyTier.TIER_2)).toBe(3_000n)
+    expect(computePrivacyTierFee(1_000_000n, PrivacyTier.TIER_3)).toBe(5_000n)
+  })
+
+  it('returns 0 for a zero amount', () => {
+    expect(computePrivacyTierFee(0n, PrivacyTier.TIER_1)).toBe(0n)
+  })
+
+  it('has no flat floor — sub-threshold amounts round down to 0', () => {
+    // 99 * 10 / 10_000 = 0.099 -> 0n (unlike computeRelayerFee, which floors)
+    expect(computePrivacyTierFee(99n, PrivacyTier.TIER_1)).toBe(0n)
+  })
+
+  it('handles large bigint amounts without precision loss', () => {
+    // 1e18 * 50 / 10_000 = 5e15
+    expect(computePrivacyTierFee(1_000_000_000_000_000_000n, PrivacyTier.TIER_3)).toBe(5_000_000_000_000_000n)
+  })
+
+  it('throws on a negative amount', () => {
+    expect(() => computePrivacyTierFee(-1n, PrivacyTier.TIER_1)).toThrow(/non-negative bigint/i)
+  })
+
+  it('throws on a non-bigint amount (JS callers)', () => {
+    expect(() => computePrivacyTierFee(1_000_000 as unknown as bigint, PrivacyTier.TIER_1)).toThrow(
+      /non-negative bigint/i,
+    )
+  })
+
+  it('throws on an unknown tier', () => {
+    expect(() => computePrivacyTierFee(1_000_000n, 'tier_99' as PrivacyTier)).toThrow(/unknown privacy tier/i)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a typed, chain-agnostic **privacy-tier fee model** to `@sip-protocol/sdk`: a `PrivacyTier` enum and a **frozen** schedule expressing the protocol fee in basis points — **10 / 30 / 50 bps**, gated on which privacy guarantee has shipped (commingled pool → unlinkable withdrawal → confidential amounts), **never on volume or time**. The bps values are a public commitment and cannot be mutated at runtime.
- Public surface: `getPrivacyTierFee`, `getPrivacyTierFeeBps`, `getCurrentPrivacyTierFee`, `getPrivacyTierSchedule`, and `computePrivacyTierFee(amount, tier)` (basis-point bigint floor division, **no flat floor**). `CURRENT_PRIVACY_TIER` is the single source of truth for what's shipped; `isActive` derives from it (bump one constant when a tier lands). Exported from the package root and the `fees` subpath.
- Distinct from the relayer gas-recovery fee (`computeRelayerFee`) and the legacy volume-tiered `fees/` calculator. Documented in `docs/fees/privacy-tier-fee-schedule.md`.

## Test plan
- [x] 16 new tests (14 unit + 2 barrel-export), all green
- [x] Full SDK suite green (6858 passing); the lone suite failure is a pre-existing, unrelated `eip5564` statistical flake (57/57 on rerun)
- [x] `pnpm typecheck` clean
- [x] Additive only — no breaking changes; `minor` changeset publishes `@sip-protocol/sdk@0.14.0` on merge

Refs #1136