### PR TITLE
feat(sipher-vault): universal asset support — native SOL + Token-2022

### DIFF
--- a/docs/superpowers/plans/2026-06-16-sipher-vault-universal-asset-support.md
+++ b/docs/superpowers/plans/2026-06-16-sipher-vault-universal-asset-support.md
@@ -1,0 +1,515 @@
+# sipher-vault Universal Asset Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `sipher-vault` to custody native SOL (lamports) and Token-2022 mints (conservative extension allowlist) alongside the existing classic SPL, with the high-risk lamport path isolated and audit-ready.
+
+**Architecture:** Approach A — two custody tracks sharing one `VaultConfig` / `DepositRecord` / announcement-CPI spine. The existing token instructions migrate to the SPL **interface** (`Interface<TokenInterface>` + `transfer_checked`) so one path serves classic SPL *and* Token-2022; new `*_sol` instructions custody lamports in singleton `SolVault`/`SolFee` PDAs.
+
+**Tech Stack:** Rust + Anchor `0.30.1`, `anchor-spl` `0.30.1` (`token_interface`, `token_2022::spl_token_2022`); tests in TypeScript via **solana-bankrun `0.4.0`** (IDL-free raw instructions — the IDL generator is broken on this host, see Global Constraints).
+
+## Global Constraints
+
+- **Anchor 0.30.1** — do NOT upgrade Anchor in this plan (tracked separately: sip-protocol#1161). Build with `anchor build --no-idl` (the IDL generator fails on rustc 1.94.1; the SBF binary is unaffected).
+- **IDL-free tests only.** The Anchor TS client can't be used (no regenerable IDL). All tests use `solana-bankrun` with **raw `TransactionInstruction`s**: 8-byte discriminator = `sha256("global:"+name)[..8]`, manual Borsh arg encoding, explicit account metas, and account reads parsed by byte offset. Pattern reference: `programs/sipher-vault/scripts/e2e-cpi-test.ts`.
+- **Build+test command (run from `programs/sipher-vault/`):** `anchor build --no-idl && cp ../sip-privacy/target/deploy/sip_privacy.so tests/fixtures/sip_privacy.so && pnpm exec ts-mocha -p ./tsconfig.json -t 1000000 tests/sipher-vault/<file>.test.ts`. (`startAnchor('.', extraPrograms, …)` auto-loads `target/deploy/sipher_vault.so`; `sip_privacy.so` must be in a bankrun search path — `tests/fixtures/`.)
+- **Lamport safety (load-bearing):** BPF runs in release mode where `+=`/`-=` on `u64` **wrap silently**. Every lamport mutation MUST compute a checked value and assign it (never `**x -= n`). A wrap here is a vault-drain bug.
+- **Sentinel:** `NATIVE_SOL_MINT = Pubkey::new_from_array([0u8; 32])` (the zero/System-Program pubkey). Used as the `DepositRecord` mint key and the announcement `token_mint` for native SOL.
+- **Token-2022 allowlist is fail-closed:** accept ONLY {no extensions, MetadataPointer, TokenMetadata, InterestBearingConfig}; reject everything else (including unknown/future).
+- **Naming gate (public repo):** no external-partner or privacy-competitor names anywhere in code/comments/commits/PR. Run the confidential naming-gate regex (kept in the private session handoff, deliberately not reproduced in-repo) against the diff before any push; expect zero hits.
+- **Commits:** GPG-signed (`-S`), conventional, **no AI attribution**. Work in a git **worktree** off `origin/main` (shared-clone constraint) — created via `superpowers:using-git-worktrees` at execution start; commit the spec + this plan + code on that branch.
+- **Out of scope:** IDL regeneration / Anchor upgrade (#1161); SDK native-SOL scan/cash-out + client (follow-on specs); **mainnet deploy** (B6-audit-gated). Devnet redeploy IS in scope (final task).
+
+---
+
+### Task 1: bankrun harness + classic-SPL regression baseline
+
+Establishes the IDL-free test infrastructure and a green baseline of the *current* program behavior, so the interface migration (Task 3) can be proven non-regressing.
+
+**Files:**
+- Create: `programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts`
+- Create: `programs/sipher-vault/tests/sipher-vault/10-bankrun-classic-spl.test.ts`
+- Create: `programs/sipher-vault/tests/fixtures/.gitkeep` (dir for `sip_privacy.so`)
+- Reference: `scripts/e2e-cpi-test.ts` (raw-ix pattern), `tests/sipher-vault/setup.ts` (PDA helpers)
+
+**Interfaces (Produces — later tasks consume these):**
+- `disc(name: string): Buffer`
+- `startVault(): Promise<ProgramTestContext>` — `startAnchor('.', [{name:'sip_privacy', programId: SIP_PRIVACY_PROGRAM_ID}], [])`
+- `sendIx(ctx, ixs: TransactionInstruction[], signers: Keypair[]): Promise<void>`
+- `getAccountData(ctx, pubkey): Promise<Buffer>` (throws if missing)
+- `parseDepositRecord(data: Buffer): { depositor, tokenMint, balance, lockedAmount, cumulativeVolume, lastDepositAt, bump }`
+- `parseVaultConfig(data: Buffer): { authority, feeBps, refundTimeout, paused, totalDeposits, totalDepositors, bump }`
+- `u64le(n: bigint): Buffer`
+- Existing classic ix-builders: `ixCreateVaultToken`, `ixDeposit`, `ixWithdrawPrivate`, `ixRefund`, `ixCollectFee` (account orders copied verbatim from `lib.rs` contexts / `e2e-cpi-test.ts`).
+
+- [ ] **Step 1: Write the harness module.** Implement the Produces interfaces above. Account-data parsing is byte-offset based (Anchor 8-byte discriminator prefix, then fields in declaration order — `DepositRecord`: 8 + 32 + 32 + 8 + 8 + 8 + 8 + 1). Example:
+
+```ts
+import { createHash } from 'crypto'
+import { PublicKey, Transaction, TransactionInstruction, Keypair } from '@solana/web3.js'
+import { startAnchor, ProgramTestContext } from 'solana-bankrun'
+import { SIP_PRIVACY_PROGRAM_ID } from './setup'
+
+export const VAULT_PROGRAM_ID = new PublicKey('S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB')
+export function disc(name: string): Buffer {
+  return createHash('sha256').update(`global:${name}`).digest().subarray(0, 8)
+}
+export function u64le(n: bigint): Buffer { const b = Buffer.alloc(8); b.writeBigUInt64LE(n); return b }
+
+export async function startVault(): Promise<ProgramTestContext> {
+  return startAnchor('.', [{ name: 'sip_privacy', programId: SIP_PRIVACY_PROGRAM_ID }], [])
+}
+export async function sendIx(ctx: ProgramTestContext, ixs: TransactionInstruction[], signers: Keypair[]) {
+  const tx = new Transaction()
+  tx.recentBlockhash = ctx.lastBlockhash
+  tx.feePayer = signers[0].publicKey
+  ixs.forEach((i) => tx.add(i))
+  tx.sign(...signers)
+  await ctx.banksClient.processTransaction(tx)
+}
+export async function getAccountData(ctx: ProgramTestContext, pk: PublicKey): Promise<Buffer> {
+  const acct = await ctx.banksClient.getAccount(pk)
+  if (!acct) throw new Error(`account ${pk.toBase58()} not found`)
+  return Buffer.from(acct.data)
+}
+export function parseDepositRecord(d: Buffer) {
+  let o = 8
+  const depositor = new PublicKey(d.subarray(o, o += 32))
+  const tokenMint = new PublicKey(d.subarray(o, o += 32))
+  const balance = d.readBigUInt64LE(o); o += 8
+  const lockedAmount = d.readBigUInt64LE(o); o += 8
+  const cumulativeVolume = d.readBigUInt64LE(o); o += 8
+  const lastDepositAt = d.readBigInt64LE(o); o += 8
+  const bump = d.readUInt8(o)
+  return { depositor, tokenMint, balance, lockedAmount, cumulativeVolume, lastDepositAt, bump }
+}
+```
+(Implement `parseVaultConfig` + the five existing ix-builders the same way — copy each account list verbatim from the matching `#[derive(Accounts)]` in `lib.rs`; copy the `deposit`/`withdraw_private` arg layouts from `e2e-cpi-test.ts`.)
+
+- [ ] **Step 2: Write the failing regression test** in `10-bankrun-classic-spl.test.ts`: `before()` → `startVault()`, then `initialize` (fee 10 bps, timeout small e.g. 5s), create a classic SPL mint + depositor ATA (via `@solana/spl-token` ixs sent through `sendIx`), `createVaultToken`. Then one `it()` that `deposit`s 500_000, asserts `parseDepositRecord(...).balance === 500_000n` and the vault token balance.
+
+- [ ] **Step 3: Build + run — verify it passes against the current binary.** Run the Global build+test command on this file. Expected: PASS (this is the *current* program, unmigrated — establishes the baseline + proves the harness works).
+
+- [ ] **Step 4: Extend the test** with `withdraw_private` (stealth ATA pre-created, all 12 accounts incl. the sip-privacy CPI trio + `sip_transfer_record` PDA derived from `sip_privacy` config `total_transfers`), `refund` (after `ctx.setClock` past the timeout), and a `collect_fee`. Assert net/fee splits + the `sip_privacy` `TransferRecord` PDA exists. Run — Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts \
+        programs/sipher-vault/tests/sipher-vault/10-bankrun-classic-spl.test.ts \
+        programs/sipher-vault/tests/fixtures/.gitkeep
+git commit -S -m "test(sipher-vault): IDL-free bankrun harness + classic-SPL regression baseline"
+```
+
+---
+
+### Task 2: Shared spine — constants, errors, account types, event field
+
+**Files:**
+- Modify: `programs/sipher-vault/programs/sipher-vault/src/constants.rs`
+- Modify: `programs/sipher-vault/programs/sipher-vault/src/errors.rs`
+- Modify: `programs/sipher-vault/programs/sipher-vault/src/state.rs`
+- Modify: `programs/sipher-vault/programs/sipher-vault/src/lib.rs` (add `mint` to `VaultWithdrawEvent`; set it in existing `withdraw_private`)
+
+**Interfaces (Produces):** `NATIVE_SOL_MINT`, `VAULT_SOL_SEED`, `FEE_SOL_SEED`, `SolVault{bump}`, `SolFee{bump}`, errors `UnsupportedMintExtension`/`RentReserveViolation`/`InvalidSolVault`, `VaultWithdrawEvent.mint: Pubkey`.
+
+- [ ] **Step 1: Add constants** (`constants.rs`):
+```rust
+use anchor_lang::prelude::Pubkey;
+pub const VAULT_SOL_SEED: &[u8] = b"vault_sol";
+pub const FEE_SOL_SEED: &[u8] = b"fee_sol";
+/// Sentinel mint representing native SOL (zero / System-Program pubkey).
+pub const NATIVE_SOL_MINT: Pubkey = Pubkey::new_from_array([0u8; 32]);
+```
+
+- [ ] **Step 2: Add errors** (`errors.rs`):
+```rust
+#[msg("Mint carries an unsupported Token-2022 extension")]
+UnsupportedMintExtension,
+#[msg("Operation would drain a SOL PDA below its rent-exempt minimum")]
+RentReserveViolation,
+#[msg("Invalid SOL vault or fee PDA")]
+InvalidSolVault,
+```
+
+- [ ] **Step 3: Add account types** (`state.rs`):
+```rust
+#[account]
+#[derive(InitSpace)]
+pub struct SolVault { pub bump: u8 }
+
+#[account]
+#[derive(InitSpace)]
+pub struct SolFee { pub bump: u8 }
+```
+
+- [ ] **Step 4: Add `mint` to the event + set it in `withdraw_private`** (`lib.rs`): add `pub mint: Pubkey,` to `VaultWithdrawEvent` (after `depositor`); in the existing `withdraw_private` `emit!`, add `mint: ctx.accounts.token_mint.key(),`.
+
+- [ ] **Step 5: Build + regression + commit.** `anchor build --no-idl` (Expected: compiles). Re-run Task 1's test (Expected: PASS — additive event field doesn't affect account/balance assertions).
+```bash
+git add programs/sipher-vault/programs/sipher-vault/src/
+git commit -S -m "feat(sipher-vault): shared spine for multi-asset custody (sol PDAs, errors, event mint)"
+```
+
+---
+
+### Task 3: Token-track interface migration (classic SPL + Token-2022 transport)
+
+Migrate the five token instructions + their contexts to the SPL interface. **No behavior change for classic SPL** — Task 1's regression test is the gate.
+
+**Files:** Modify `lib.rs` (imports + `deposit`, `withdraw_private`, `refund`, `authority_refund`, `collect_fee` + their `#[derive(Accounts)]`).
+
+**Interfaces (Consumes):** Task 1 regression test. **(Produces):** token instructions accept both `Token` and `Token-2022` mints.
+
+- [ ] **Step 1: Swap imports + account types.** Replace `use anchor_spl::token::{self, Mint, Token, TokenAccount, Transfer}` with `use anchor_spl::token_interface::{self, Mint, TokenAccount, TokenInterface, TransferChecked}`. In every token context: `Account<'info, TokenAccount>` → `InterfaceAccount<'info, TokenAccount>`, `Account<'info, Mint>` → `InterfaceAccount<'info, Mint>`, `Program<'info, Token>` → `Interface<'info, TokenInterface>`.
+
+- [ ] **Step 2: Swap transfers to `transfer_checked`.** Each `token::transfer(CpiContext…Transfer{from,to,authority}, amt)` becomes:
+```rust
+let cpi = CpiContext::new_with_signer(
+  ctx.accounts.token_program.to_account_info(),
+  TransferChecked {
+    from: ctx.accounts.vault_token.to_account_info(),
+    mint: ctx.accounts.token_mint.to_account_info(),
+    to: ctx.accounts.<dest>.to_account_info(),
+    authority: ctx.accounts.config.to_account_info(),
+  },
+  signer_seeds,
+);
+token_interface::transfer_checked(cpi, amount, ctx.accounts.token_mint.decimals)?;
+```
+(The `deposit` transfer is depositor-authority — use `CpiContext::new` without signer seeds. `token_mint.decimals` requires the mint account in the context — already present in every token ix.)
+
+- [ ] **Step 2b: Confirm exact symbol paths** against installed `anchor-spl` 0.30.1 (`anchor_spl::token_interface`), via Context7 if needed. Keep the code above; adjust only import paths if the crate differs.
+
+- [ ] **Step 3: Build.** `anchor build --no-idl`. Expected: compiles.
+
+- [ ] **Step 4: Run Task 1's regression test.** Expected: **PASS** (classic SPL behavior unchanged). If the `deposit` test's mint was created with the classic Token program, `transfer_checked` still works identically. This green run is the migration's acceptance gate.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add programs/sipher-vault/programs/sipher-vault/src/lib.rs
+git commit -S -m "refactor(sipher-vault): migrate token instructions to SPL interface + transfer_checked"
+```
+
+---
+
+### Task 4: Token-2022 extension allowlist at `create_vault_token`
+
+**Files:** Modify `lib.rs` (`create_vault_token` body + its context to expose the mint account-info).
+
+**Interfaces (Consumes):** Task 3 interface migration. **(Produces):** `create_vault_token` rejects mints with non-allowlisted extensions (`UnsupportedMintExtension`).
+
+- [ ] **Step 1: Write failing tests** in a new `11-token2022-allowlist.test.ts`. Build a Token-2022 mint with each extension using `@solana/spl-token` (`TOKEN_2022_PROGRAM_ID`, `createInitializeTransferFeeConfigInstruction`, `createInitializePermanentDelegateInstruction`, `…NonTransferableMint…`, `…DefaultAccountState…`, `…TransferHook…`, plus a metadata-pointer "accept" case), then call `createVaultToken` via raw ix:
+  - accepts: plain T2022 mint, metadata-pointer mint → PASS (vault token PDA created).
+  - rejects (assert `UnsupportedMintExtension`): permanent-delegate, transfer-fee, transfer-hook, non-transferable, default-account-state.
+  Run — Expected: FAIL (allowlist not implemented; rejects don't fire).
+
+- [ ] **Step 2: Implement the allowlist** in `create_vault_token`:
+```rust
+use anchor_spl::token_2022::spl_token_2022::{
+    extension::{BaseStateWithExtensions, ExtensionType, StateWithExtensions},
+    state::Mint as Token2022Mint,
+};
+// inside create_vault_token, before Ok(()):
+let mint_ai = ctx.accounts.token_mint.to_account_info();
+let data = mint_ai.try_borrow_data()?;
+if let Ok(state) = StateWithExtensions::<Token2022Mint>::unpack(&data) {
+    for ext in state.get_extension_types()? {
+        let allowed = matches!(
+            ext,
+            ExtensionType::MetadataPointer
+                | ExtensionType::TokenMetadata
+                | ExtensionType::InterestBearingConfig
+        );
+        require!(allowed, VaultError::UnsupportedMintExtension);
+    }
+}
+```
+(Classic SPL mints unpack with zero extensions → loop is empty → allowed. Confirm the `anchor_spl::token_2022::spl_token_2022` re-export path under 0.30.1.)
+
+- [ ] **Step 3: Build + run.** `anchor build --no-idl`; run `11-token2022-allowlist.test.ts`. Expected: PASS (accepts allow-listed, rejects the rest). Also re-run Task 1 (classic SPL still accepted).
+
+- [ ] **Step 4: Add the unknown-extension fail-closed case** — a mint with an extension NOT in the accept-list that isn't one of the explicitly-named rejects (e.g. `MintCloseAuthority`) must also reject. Run — Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add programs/sipher-vault/programs/sipher-vault/src/lib.rs \
+        programs/sipher-vault/tests/sipher-vault/11-token2022-allowlist.test.ts
+git commit -S -m "feat(sipher-vault): fail-closed Token-2022 extension allowlist at vault-token creation"
+```
+
+---
+
+### Task 5: `create_sol_vault`
+
+**Files:** Modify `lib.rs` (instruction + `CreateSolVault` context).
+
+**Interfaces (Produces):** `create_sol_vault`; `SolVault`@`[VAULT_SOL_SEED]`, `SolFee`@`[FEE_SOL_SEED]` initialized.
+
+- [ ] **Step 1: Failing test** in `12-native-sol.test.ts`: derive `solVaultPda`/`solFeePda`, call `createSolVault` (accounts: config, sol_vault, sol_fee, payer, system_program), assert both accounts now exist (`getAccount` non-null, owner = program). Run — Expected: FAIL (instruction missing).
+
+- [ ] **Step 2: Implement:**
+```rust
+pub fn create_sol_vault(ctx: Context<CreateSolVault>) -> Result<()> {
+    ctx.accounts.sol_vault.bump = ctx.bumps.sol_vault;
+    ctx.accounts.sol_fee.bump = ctx.bumps.sol_fee;
+    msg!("SOL vault + fee PDAs created");
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct CreateSolVault<'info> {
+    #[account(seeds = [VAULT_CONFIG_SEED], bump = config.bump)]
+    pub config: Account<'info, VaultConfig>,
+    #[account(init, payer = payer, space = 8 + SolVault::INIT_SPACE, seeds = [VAULT_SOL_SEED], bump)]
+    pub sol_vault: Account<'info, SolVault>,
+    #[account(init, payer = payer, space = 8 + SolFee::INIT_SPACE, seeds = [FEE_SOL_SEED], bump)]
+    pub sol_fee: Account<'info, SolFee>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+```
+
+- [ ] **Step 3: Build + run.** Expected: PASS.
+- [ ] **Step 4: Commit.** `git commit -S -m "feat(sipher-vault): create_sol_vault — initialize native SOL vault + fee PDAs"`
+
+---
+
+### Task 6: `deposit_sol`
+
+**Files:** Modify `lib.rs` (instruction + `DepositSol` context).
+
+**Interfaces (Consumes):** Task 5 PDAs. **(Produces):** `deposit_sol`; `DepositRecord` keyed `(depositor, NATIVE_SOL_MINT)`.
+
+- [ ] **Step 1: Failing test** (`12-native-sol.test.ts`): after `createSolVault`, `depositSol(1_000_000)`; assert `parseDepositRecord(depositRecordPda(depositor, NATIVE_SOL_MINT)).balance === 1_000_000n` and `solVault` lamports increased by 1_000_000. Run — Expected: FAIL.
+
+- [ ] **Step 2: Implement** (debit-record + `system_program::transfer` in):
+```rust
+pub fn deposit_sol(ctx: Context<DepositSol>, amount: u64) -> Result<()> {
+    require!(!ctx.accounts.config.paused, VaultError::ProgramPaused);
+    require!(amount > 0, VaultError::ZeroDeposit);
+    let cpi = CpiContext::new(
+        ctx.accounts.system_program.to_account_info(),
+        anchor_lang::system_program::Transfer {
+            from: ctx.accounts.depositor.to_account_info(),
+            to: ctx.accounts.sol_vault.to_account_info(),
+        },
+    );
+    anchor_lang::system_program::transfer(cpi, amount)?;
+    let record = &mut ctx.accounts.deposit_record;
+    let is_new = record.balance == 0 && record.cumulative_volume == 0;
+    record.depositor = ctx.accounts.depositor.key();
+    record.token_mint = NATIVE_SOL_MINT;
+    record.balance = record.balance.checked_add(amount).ok_or(VaultError::MathOverflow)?;
+    record.cumulative_volume = record.cumulative_volume.checked_add(amount).ok_or(VaultError::MathOverflow)?;
+    record.last_deposit_at = Clock::get()?.unix_timestamp;
+    record.bump = ctx.bumps.deposit_record;
+    let config = &mut ctx.accounts.config;
+    config.total_deposits = config.total_deposits.saturating_add(1);
+    if is_new {
+        config.total_depositors = config.total_depositors.checked_add(1).ok_or(VaultError::MathOverflow)?;
+    }
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct DepositSol<'info> {
+    #[account(mut, seeds = [VAULT_CONFIG_SEED], bump = config.bump)]
+    pub config: Account<'info, VaultConfig>,
+    #[account(init_if_needed, payer = depositor, space = 8 + DepositRecord::INIT_SPACE,
+        seeds = [DEPOSIT_RECORD_SEED, depositor.key().as_ref(), NATIVE_SOL_MINT.as_ref()], bump)]
+    pub deposit_record: Account<'info, DepositRecord>,
+    #[account(mut, seeds = [VAULT_SOL_SEED], bump = sol_vault.bump)]
+    pub sol_vault: Account<'info, SolVault>,
+    #[account(mut)]
+    pub depositor: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+```
+
+- [ ] **Step 3: Build + run.** Expected: PASS. Add a `rejects zero deposit` case.
+- [ ] **Step 4: Commit.** `git commit -S -m "feat(sipher-vault): deposit_sol — native SOL deposit with debit-first record"`
+
+---
+
+### Task 7: `withdraw_private_sol` (the high-risk task)
+
+**Files:** Modify `lib.rs` (instruction + `WithdrawPrivateSol` context).
+
+**Interfaces (Consumes):** Tasks 5–6; the `sip_privacy::create_transfer_announcement` CPI (already done in `withdraw_private` — copy its data-encoding block verbatim, swapping `token_mint` for `NATIVE_SOL_MINT`). **(Produces):** `withdraw_private_sol`.
+
+- [ ] **Step 1: Failing tests** (`12-native-sol.test.ts`): after a deposit of 1_000_000, `withdrawPrivateSol(500_000, …)` to a fresh stealth pubkey; assert: stealth lamports `+= 499_500` (net), `solFee += 500` (10 bps), `solVault -= 500_000`, `depositRecord.balance == 500_000`, and the `sip_privacy` `TransferRecord` PDA exists. Plus: `rejects withdrawal exceeding available` (InsufficientBalance). Run — Expected: FAIL.
+
+- [ ] **Step 2: Implement — checked lamport mutation + rent guard:**
+```rust
+pub fn withdraw_private_sol(
+    ctx: Context<WithdrawPrivateSol>,
+    amount: u64,
+    amount_commitment: [u8; 33],
+    stealth_pubkey: Pubkey,
+    ephemeral_pubkey: [u8; 33],
+    viewing_key_hash: [u8; 32],
+    _encrypted_amount: Vec<u8>,
+    _proof: Vec<u8>,
+) -> Result<()> {
+    require!(!ctx.accounts.config.paused, VaultError::ProgramPaused);
+    require!(amount > 0, VaultError::ZeroDeposit);
+
+    let record = &mut ctx.accounts.deposit_record;
+    let available = record.balance.checked_sub(record.locked_amount).ok_or(VaultError::MathOverflow)?;
+    require!(available >= amount, VaultError::InsufficientBalance);
+    record.balance = record.balance.checked_sub(amount).ok_or(VaultError::MathOverflow)?;
+
+    let fee = (amount as u128)
+        .checked_mul(ctx.accounts.config.fee_bps as u128).ok_or(VaultError::MathOverflow)?
+        .checked_div(10_000).ok_or(VaultError::MathOverflow)? as u64;
+    let net = amount.checked_sub(fee).ok_or(VaultError::MathOverflow)?;
+
+    // CHECKED lamport mutation (BPF release wraps on +=/-= — never use those here).
+    let vault_ai = ctx.accounts.sol_vault.to_account_info();
+    let new_vault = vault_ai.lamports().checked_sub(amount).ok_or(VaultError::MathOverflow)?;
+    let rent_min = Rent::get()?.minimum_balance(vault_ai.data_len());
+    require!(new_vault >= rent_min, VaultError::RentReserveViolation);
+    let stealth_ai = ctx.accounts.stealth.to_account_info();
+    let fee_ai = ctx.accounts.sol_fee.to_account_info();
+    let new_stealth = stealth_ai.lamports().checked_add(net).ok_or(VaultError::MathOverflow)?;
+    let new_fee = fee_ai.lamports().checked_add(fee).ok_or(VaultError::MathOverflow)?;
+    **vault_ai.try_borrow_mut_lamports()? = new_vault;
+    **stealth_ai.try_borrow_mut_lamports()? = new_stealth;
+    **fee_ai.try_borrow_mut_lamports()? = new_fee;
+
+    // CPI announcement — copy the encoding block from `withdraw_private`, with token_mint = NATIVE_SOL_MINT.
+    // (depositor is the announcement signer/rent-payer; accounts: sip_config, sip_transfer_record, depositor, system_program)
+    // … identical to withdraw_private except the final token_mint bytes use NATIVE_SOL_MINT …
+
+    emit!(VaultWithdrawEvent {
+        depositor: ctx.accounts.depositor.key(),
+        mint: NATIVE_SOL_MINT,
+        stealth_recipient: stealth_pubkey,
+        amount_commitment,
+        ephemeral_pubkey,
+        viewing_key_hash,
+        transfer_amount: net,
+        fee_amount: fee,
+        timestamp: Clock::get()?.unix_timestamp,
+    });
+    Ok(())
+}
+```
+Context `WithdrawPrivateSol`: config (seeds, not mut), `deposit_record` (mut, seeds `[…, depositor, NATIVE_SOL_MINT]`, `has_one = depositor`), `sol_vault` (mut, seeds `[VAULT_SOL_SEED]`, bump), `sol_fee` (mut, seeds `[FEE_SOL_SEED]`, bump), `stealth: SystemAccount<'info>` (mut), `depositor: Signer` (mut), + the three sip-privacy CPI accounts (`sip_config`, `sip_transfer_record`, `sip_privacy_program`) + `system_program` (same as `WithdrawPrivate`, minus all token accounts).
+
+- [ ] **Step 3: Build + run.** Expected: PASS (net/fee/vault deltas + TransferRecord exist + InsufficientBalance rejects).
+
+- [ ] **Step 4: Add the rent-reserve guard test.** Deposit a tiny amount into a *fresh* SOL vault whose lamports are near the rent floor, attempt a withdrawal that would breach `rent_min`; assert `RentReserveViolation`. (Construct by depositing exactly enough that `vault.lamports() - amount < rent_min`.) Run — Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add programs/sipher-vault/programs/sipher-vault/src/lib.rs \
+        programs/sipher-vault/tests/sipher-vault/12-native-sol.test.ts
+git commit -S -m "feat(sipher-vault): withdraw_private_sol — checked native withdrawal + rent guard + announcement"
+```
+
+---
+
+### Task 8: `refund_sol` + `authority_refund_sol`
+
+**Files:** Modify `lib.rs` (two instructions + `RefundSol` / `AuthorityRefundSol` contexts).
+
+**Interfaces (Produces):** native refunds; destination = original depositor only; timeout enforced.
+
+- [ ] **Step 1: Failing tests** (`12-native-sol.test.ts`): `refund_sol` after `ctx.setClock` past `refund_timeout` returns the unlocked balance to the depositor (lamport delta) and zeroes `balance` to `locked_amount`; before the timeout → `RefundNotExpired`. `authority_refund_sol`: authority-signed, depositor is non-signer account, same timeout enforced; wrong-authority → `Unauthorized`. Run — Expected: FAIL.
+
+- [ ] **Step 2: Implement** (mirror `refund`/`authority_refund`, checked lamport mutation `sol_vault → depositor`):
+```rust
+pub fn refund_sol(ctx: Context<RefundSol>) -> Result<()> {
+    let record = &mut ctx.accounts.deposit_record;
+    let available = record.balance.checked_sub(record.locked_amount).ok_or(VaultError::MathOverflow)?;
+    require!(available > 0, VaultError::NothingToRefund);
+    let now = Clock::get()?.unix_timestamp;
+    let elapsed = now.checked_sub(record.last_deposit_at).ok_or(VaultError::MathOverflow)?;
+    require!(elapsed >= ctx.accounts.config.refund_timeout, VaultError::RefundNotExpired);
+
+    let vault_ai = ctx.accounts.sol_vault.to_account_info();
+    let new_vault = vault_ai.lamports().checked_sub(available).ok_or(VaultError::MathOverflow)?;
+    let rent_min = Rent::get()?.minimum_balance(vault_ai.data_len());
+    require!(new_vault >= rent_min, VaultError::RentReserveViolation);
+    let dep_ai = ctx.accounts.depositor.to_account_info();
+    let new_dep = dep_ai.lamports().checked_add(available).ok_or(VaultError::MathOverflow)?;
+    **vault_ai.try_borrow_mut_lamports()? = new_vault;
+    **dep_ai.try_borrow_mut_lamports()? = new_dep;
+    record.balance = record.locked_amount;
+    Ok(())
+}
+```
+`authority_refund_sol` is identical except: context `config` has `has_one = authority`, `authority: Signer`, `depositor: SystemAccount` (non-signer, used for the `deposit_record` seed + as the lamport destination), and it adds `require!(!ctx.accounts.config.paused, …)` (matching `authority_refund`). Contexts: `RefundSol` = config, deposit_record(mut, seeds `[…, depositor, NATIVE_SOL_MINT]`, has_one depositor), sol_vault(mut), depositor(Signer, mut). `AuthorityRefundSol` = config(has_one authority), deposit_record(mut, has_one depositor), sol_vault(mut), depositor(SystemAccount, mut), authority(Signer, mut).
+
+- [ ] **Step 3: Build + run.** Expected: PASS (both, incl. timeout + unauthorized rejects).
+- [ ] **Step 4: Commit.** `git commit -S -m "feat(sipher-vault): refund_sol + authority_refund_sol — depositor-only native refunds"`
+
+---
+
+### Task 9: `collect_fee_sol`
+
+**Files:** Modify `lib.rs` (instruction + `CollectFeeSol` context).
+
+**Interfaces (Produces):** authority drains `SolFee` lamports above its rent floor.
+
+- [ ] **Step 1: Failing test** (`12-native-sol.test.ts`): after a native withdrawal accrued fees, `collectFeeSol(0)` moves all collectable `solFee` lamports (above rent_min) to the authority; wrong authority → `Unauthorized`. Run — Expected: FAIL.
+
+- [ ] **Step 2: Implement:**
+```rust
+pub fn collect_fee_sol(ctx: Context<CollectFeeSol>, amount: u64) -> Result<()> {
+    let fee_ai = ctx.accounts.sol_fee.to_account_info();
+    let rent_min = Rent::get()?.minimum_balance(fee_ai.data_len());
+    let collectable = fee_ai.lamports().checked_sub(rent_min).ok_or(VaultError::MathOverflow)?;
+    require!(collectable > 0, VaultError::NoFeesToCollect);
+    let take = if amount == 0 || amount > collectable { collectable } else { amount };
+    let auth_ai = ctx.accounts.authority.to_account_info();
+    let new_fee = fee_ai.lamports().checked_sub(take).ok_or(VaultError::MathOverflow)?;
+    let new_auth = auth_ai.lamports().checked_add(take).ok_or(VaultError::MathOverflow)?;
+    **fee_ai.try_borrow_mut_lamports()? = new_fee;
+    **auth_ai.try_borrow_mut_lamports()? = new_auth;
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct CollectFeeSol<'info> {
+    #[account(seeds = [VAULT_CONFIG_SEED], bump = config.bump, has_one = authority @ VaultError::Unauthorized)]
+    pub config: Account<'info, VaultConfig>,
+    #[account(mut, seeds = [FEE_SOL_SEED], bump = sol_fee.bump)]
+    pub sol_fee: Account<'info, SolFee>,
+    #[account(mut)]
+    pub authority: Signer<'info>,
+}
+```
+
+- [ ] **Step 3: Build + run.** Expected: PASS.
+- [ ] **Step 4: Run the full bankrun suite** (`tests/sipher-vault/1*.test.ts`) — Expected: ALL PASS (classic regression + T2022 allowlist + native track).
+- [ ] **Step 5: Commit.** `git commit -S -m "feat(sipher-vault): collect_fee_sol — authority drains native fees above rent floor"`
+
+---
+
+### Task 10: Devnet redeploy + integration
+
+**Files:** Modify `programs/sipher-vault/DEPLOYMENT.md` (record the new instructions + the devnet upgrade); add `scripts/create-sol-vault.ts` (raw-ix, mirrors `e2e-cpi-test.ts` style).
+
+- [ ] **Step 1: Naming-gate sweep.** Run the confidential naming-gate regex (from the private handoff) over `programs/sipher-vault/ docs/superpowers/` → Expected: no hits. Fix any.
+- [ ] **Step 2: Build the deployable binary.** `anchor build --no-idl`; note the new binary size. (IDL regeneration is out of scope — tracked in #1161.)
+- [ ] **Step 3: Deploy to devnet** (program-upgrade, authority `FGSkt8…`, per `DEPLOYMENT.md`): `solana program deploy target/deploy/sipher_vault.so --program-id ~/Documents/secret/sipher-vault-program-id.json --keypair ~/Documents/secret/solana-devnet.json --url devnet --with-compute-unit-price 10000`.
+- [ ] **Step 4: Initialize the SOL vault on devnet.** Run `scripts/create-sol-vault.ts` (raw `create_sol_vault` ix). Verify `SolVault`/`SolFee` PDAs exist on devnet.
+- [ ] **Step 5: Update `DEPLOYMENT.md`** (new instruction list: +`create_sol_vault`, `deposit_sol`, `withdraw_private_sol`, `refund_sol`, `authority_refund_sol`, `collect_fee_sol`; devnet upgrade TX + slot; note mainnet deploy is B6-gated). Commit.
+```bash
+git add programs/sipher-vault/DEPLOYMENT.md programs/sipher-vault/scripts/create-sol-vault.ts
+git commit -S -m "chore(sipher-vault): devnet redeploy of universal-asset vault + SOL vault init"
+```
+- [ ] **Step 6: Open the PR** (base `main`; body partner-name-free; includes the spec + this plan). Do NOT self-merge — RECTOR reviews.
+
+---
+
+## Self-Review
+
+**Spec coverage:** §4 two-track architecture → Tasks 2/3/5–9. §5.1 PDAs/sentinel → Task 2. §5.2 native track (all `*_sol`) → Tasks 5–9. §5.3 interface + allowlist → Tasks 3/4. §5.4 sentinel announcement → Task 7 (+event mint Task 2). §5.5 event field → Task 2. §5.6 errors → Task 2. §8 lamport safety + rent guard → Tasks 7/8/9 (checked math + `RentReserveViolation` tests). §9 testing (one reject per extension + unknown) → Task 4. §10 devnet redeploy → Task 10. Classic-SPL regression → Task 1 baseline + Task 3 gate. **No gaps.**
+
+**Placeholder scan:** the only deferred-detail markers are explicit "confirm symbol path against installed crate" notes (Tasks 3/4) and "copy the announcement encoding block verbatim from `withdraw_private`" (Task 7) — both reference concrete existing code, not missing content. No TBD/TODO.
+
+**Type consistency:** `NATIVE_SOL_MINT`, `SolVault`/`SolFee`, `VaultWithdrawEvent.mint`, and the helper signatures (`disc`, `parseDepositRecord`, `sendIx`, `startVault`) are defined in Tasks 1–2 and consumed unchanged downstream. Lamport-mutation pattern (compute-checked-then-assign) is identical across Tasks 7/8/9.

--- a/docs/superpowers/specs/2026-06-16-sipher-vault-universal-asset-support-design.md
+++ b/docs/superpowers/specs/2026-06-16-sipher-vault-universal-asset-support-design.md
@@ -1,0 +1,150 @@
+# sipher-vault: Universal Asset Support (native SOL + Token-2022)
+
+**Date:** 2026-06-16
+**Status:** Design approved — implementation pending
+**Scope:** `programs/sipher-vault` on-chain program only (devnet redeploy). SDK native-SOL support (scan / gasless cash-out) and the integrator client are separate follow-on specs.
+**Related:** `2026-04-16-authority-refund-design.md`; tracking issue for the equivalent mainnet `sip-privacy` upgrade: sip-protocol#1160.
+
+---
+
+## 1. Motivation
+
+`sipher-vault` is a deposit-first commingling privacy vault: depositors fund a shared PDA, then withdraw privately to stealth addresses with a Pedersen-committed announcement. Today it custodies **classic SPL tokens only**. Two gaps limit its reach as a general privacy primitive:
+
+1. **No native SOL.** SOL is the dominant payment asset on Solana; integrators with native-SOL flows must wrap to wSOL on every leg (ATA rent, wrap/unwrap instructions, dust cleanup). The vault has no lamport custody path.
+2. **No Token-2022.** The program is bound to the classic SPL Token program (`Program<'info, Token>`), so any Token-2022 mint is rejected.
+
+This design makes the vault a **universal asset custody primitive**: native SOL + every classic SPL token + Token-2022 (with a safety allowlist), in one audited pass. Doing all asset classes together avoids a second program change + redeploy + audit later.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Custody and privately withdraw **native SOL** (lamports) directly — no wrapping.
+- Custody and privately withdraw **Token-2022** mints, gated by a **conservative extension allowlist** that fails closed.
+- Preserve existing **classic SPL** behavior and the commingling / depositor-as-signer model unchanged.
+- Keep the on-chain↔SDK contract explicit so the SDK follow-on cannot drift.
+- Leave the **mainnet `sip-privacy`** program untouched.
+
+**Non-goals (this spec)**
+- SDK native-SOL scan / gasless cash-out, and the integrator client — separate follow-on specs.
+- Token-2022 **fee-bearing** (transfer-fee), **transfer-hook**, **confidential**, **permanent-delegate**, **non-transferable**, **default-frozen** mints — explicitly rejected in v1; fee-bearing support may be a later upgrade.
+- Trustless nullifier-authorized withdrawal (separate co-build).
+- Mainnet deployment — gated on the self-audit (see §10).
+
+## 3. Current state (verified vs source)
+
+- `deposit` / `withdraw_private` / `refund` / `authority_refund` / `collect_fee` move funds via `anchor_spl::token::Transfer` over `Account<'info, TokenAccount>` + `Account<'info, Mint>`, `token_program: Program<'info, Token>` (classic SPL only) — `lib.rs`.
+- `withdraw_private` CPIs `sip_privacy::create_transfer_announcement` (metadata-only; records `token_mint` as opaque bytes — no validation, no token movement) — verified in `sip-privacy/.../lib.rs:330`.
+- `DepositRecord { depositor, token_mint, balance, locked_amount, cumulative_volume, last_deposit_at, bump }`; PDA seeds `[DEPOSIT_RECORD_SEED, depositor, token_mint]`.
+- `withdraw_private` / `refund` / `authority_refund` require the **depositor as signer**, `DepositRecord` is `has_one`-keyed on `depositor` → the depositor authorizes their own withdrawal (commingling vault, not a trustless mixer).
+- Toolchain: Anchor `0.30.1`; `anchor-spl 0.30.1` ships `token_interface` (so `Interface<TokenInterface>` + `InterfaceAccount` + `transfer_checked` are available without a toolchain bump). Tests: TS / ts-mocha under `tests/sipher-vault/`.
+
+## 4. Architecture — two asset tracks, shared spine (Approach A)
+
+One `VaultConfig`, one `DepositRecord` shape, one announcement CPI. Two custody tracks:
+
+- **Token track (classic SPL + Token-2022):** the *existing* instructions, migrated to the SPL **interface** so a single code path serves both token programs.
+- **Native-SOL track:** *new* `*_sol` instructions custodying lamports in dedicated PDAs.
+
+Shared internal helpers — `compute_fee(amount, bps)`, debit-first balance update, and the `create_transfer_announcement` CPI — keep the tracks DRY without merging their custody logic. The high-risk lamport handling stays isolated in the native track so each track audits independently.
+
+## 5. Detailed design
+
+### 5.1 New constants & PDAs
+
+- `VAULT_SOL_SEED = b"vault_sol"`, `FEE_SOL_SEED = b"fee_sol"`.
+- `SolVault { bump }` and `SolFee { bump }` — minimal marker accounts, program-owned, rent-exempt. They hold native lamports above their own rent-exempt minimum. **Singletons** — native SOL is a single asset, so there is one global vault + fee pair (seeds carry no mint), unlike the per-mint token vault/fee PDAs.
+- `NATIVE_SOL_MINT: Pubkey = Pubkey::default()` — the sentinel "mint" representing native SOL (the all-zero / System-Program pubkey; no real SPL mint collides with it, unlike the wSOL mint which is a legitimate SPL deposit).
+
+### 5.2 Native-SOL track (new instructions)
+
+- **`create_sol_vault`** — one-time init of the `SolVault` + `SolFee` PDAs (payer funds the rent-exempt minimum). Mirrors `create_vault_token` / `create_fee_token`.
+- **`deposit_sol(amount)`** — `system_program::transfer(depositor → sol_vault, amount)` (depositor signs); create/update `DepositRecord` keyed `(depositor, NATIVE_SOL_MINT)`. Reverts on `paused` / `amount == 0`.
+- **`withdraw_private_sol(amount, amount_commitment, stealth_pubkey, ephemeral_pubkey, viewing_key_hash, encrypted_amount, proof)`**
+  1. Debit-first: `available = balance − locked_amount`; require `available ≥ amount`; `balance −= amount`.
+  2. `fee = amount · fee_bps / 10_000`; `net = amount − fee` (checked).
+  3. **Checked lamport mutation** (source is the program-owned `SolVault`): `sol_vault −= amount`, `stealth += net`, `sol_fee += fee`.
+  4. **Rent-reserve guard:** require `sol_vault.lamports() − amount ≥ Rent::minimum_balance(sol_vault.data_len())`. The reserve sits *under* all depositor balances, so correct accounting never reaches it; the guard is a fail-safe.
+  5. CPI `create_transfer_announcement` with `token_mint = NATIVE_SOL_MINT` (depositor is the announcement signer / rent payer).
+  6. Emit `VaultWithdrawEvent` (with `mint = NATIVE_SOL_MINT`).
+
+  `encrypted_amount` / `proof` mirror the token `withdraw_private` signature — carried for announcement parity and off-chain verification; format-checked, unused on-chain (as today).
+- **`refund_sol` / `authority_refund_sol`** — return the depositor's unlocked balance to the depositor via checked lamport mutation. Same constraints as the token refunds: destination is the **original depositor only**, `refund_timeout` enforced (authority does not bypass the cooldown), reverts on `paused` (authority variant).
+- **`collect_fee_sol(amount)`** — authority-only; drains `SolFee` lamports to the authority (above the fee PDA's rent reserve). `amount == 0` collects all available.
+
+The stealth recipient in `withdraw_private_sol` is a plain writable account (no ATA, no mint check) — simpler than the token path. Lamport mutation (rather than a system CPI) is required because the source is a program-owned PDA; this is the single highest-risk operation and is fenced by checked arithmetic + the rent guard.
+
+### 5.3 Token track (migration + Token-2022 allowlist)
+
+- Migrate the existing token instructions: `Token → Interface<'info, TokenInterface>`, `Account<'info, TokenAccount> → InterfaceAccount<'info, TokenAccount>`, `Account<'info, Mint> → InterfaceAccount<'info, Mint>`, `token::transfer → token_interface::transfer_checked(.., amount, decimals)` (Token-2022 requires checked transfers). Classic SPL rides the identical path.
+- **Extension allowlist, enforced at `create_vault_token`** — the choke point, since `deposit` requires the per-mint vault PDA to exist. On creation, parse the mint's extension TLV (`spl_token_2022::extension::StateWithExtensions::<Mint>::unpack(..).get_extension_types()`) and apply a **fail-closed accept-list**:
+  - ✅ **Accept** only: *no extensions* (classic SPL), `MetadataPointer`, `TokenMetadata`, `InterestBearingConfig`.
+  - ❌ **Reject** everything else — explicitly including `PermanentDelegate`, `ConfidentialTransferMint`, `TransferHook`, `TransferFeeConfig`, `NonTransferable`, `DefaultAccountState`, and any **unknown/future** extension (fail closed) → `UnsupportedMintExtension`.
+- **Why the choke point suffices:** every rejected extension is **init-immutable** on the mint (cannot be added after mint creation), so gating at vault-creation cannot be bypassed by a later mint mutation. Documented as a security invariant; revisit if a future Token-2022 version makes any rejected extension mutable.
+
+### 5.4 Sentinel mint + announcement contract (SDK-facing — pinned here)
+
+- Native SOL is represented by `NATIVE_SOL_MINT = Pubkey::default()` in the `DepositRecord` seed and the `create_transfer_announcement` `token_mint` argument.
+- `sip-privacy` records it as opaque metadata → **no `sip-privacy` change**.
+- **Contract the SDK follow-on MUST honor:** a `TransferRecord` / `VaultWithdrawEvent` with `mint == Pubkey::default()` ⇒ native SOL → the scanner reads the stealth account's **lamports** (not an ATA); any other value ⇒ an SPL/Token-2022 mint → read the stealth ATA.
+
+### 5.5 DepositRecord & events
+
+- `DepositRecord` is reused unchanged; `token_mint` holds the real mint or `NATIVE_SOL_MINT`; `balance` is lamports or token base units.
+- `VaultWithdrawEvent` gains an explicit **`mint: Pubkey`** field for clean off-chain native-vs-token decode (the only struct change).
+
+### 5.6 Errors (new variants)
+
+- `UnsupportedMintExtension` — mint carries a non-allowlisted (or unknown) Token-2022 extension.
+- `RentReserveViolation` — a native withdrawal/refund/fee-collect would drain a SOL PDA below its rent-exempt minimum.
+- `InvalidSolVault` — SOL vault / fee PDA mismatch.
+
+## 6. Instruction inventory
+
+| Instruction | Before | After |
+|---|---|---|
+| `initialize`, `set_paused` | ✅ | ✅ unchanged |
+| `create_vault_token` | classic only | + Token-2022 interface **+ extension allowlist gate** |
+| `create_fee_token` | classic only | + interface |
+| `deposit` / `withdraw_private` / `refund` / `authority_refund` / `collect_fee` | classic `Transfer` | interface + `transfer_checked` |
+| `create_sol_vault` | — | **new** |
+| `deposit_sol` / `withdraw_private_sol` / `refund_sol` / `authority_refund_sol` / `collect_fee_sol` | — | **new** |
+
+## 7. Account contexts
+
+- **Modified token contexts:** swap concrete `Token`/`TokenAccount`/`Mint` types for the `*Interface` equivalents; `CreateVaultToken` additionally receives the mint account-info to parse extensions.
+- **New native contexts:** `CreateSolVault` (config, sol_vault `init`, sol_fee `init`, payer, system_program); `DepositSol` (config, deposit_record `init_if_needed`, sol_vault, depositor signer, system_program); `WithdrawPrivateSol` (config, deposit_record `has_one = depositor`, sol_vault, sol_fee, stealth `AccountInfo` mut, depositor signer, + the three sip-privacy CPI accounts + system_program); `RefundSol` / `AuthorityRefundSol` / `CollectFeeSol` mirroring their token counterparts without token accounts.
+
+## 8. Security considerations
+
+- **Lamport mutation** (`withdraw_private_sol`, `refund_sol`, `authority_refund_sol`, `collect_fee_sol`): all arithmetic checked; rent-reserve guard on every debit of a SOL PDA; debit-first ordering (reduce `DepositRecord.balance` before moving lamports).
+- **Allowlist completeness:** fail-closed (unknown extensions rejected). One test per rejected extension; the accept-list is the only path that proceeds.
+- **Custody boundary unchanged:** `authority_refund_sol` returns funds to the original depositor only; `collect_fee_sol` touches the fee PDA only; neither can redirect principal. Upgrade authority remains the residual trust (mainnet → Squads v4 2-of-3).
+- **Commingling model unchanged:** depositor signs every withdrawal; native and token tracks share this property.
+- **Sub-rent-exempt native payouts:** a stealth recipient receiving a native amount below the rent-exempt minimum yields a non-rent-exempt account; it persists while lamports remain `> 0` and the recipient can move it later (no fund loss). Noted for the audit; v1 adds no minimum-payout floor.
+
+## 9. Testing strategy (TS / ts-mocha, matching `tests/sipher-vault/`)
+
+- **Native:** `create_sol_vault`; `deposit_sol`; `withdraw_private_sol` (debit-first, fee split, **rent-reserve guard**, announcement with sentinel mint); `refund_sol`; `authority_refund_sol` (timeout + depositor-only); `collect_fee_sol`.
+- **Token-2022:** `create_vault_token` accepts a plain T22 mint and an accept-listed-extension mint; **rejects each disallowed extension** (one test each: permanent-delegate, transfer-fee, transfer-hook, confidential, non-transferable, default-frozen) + an unknown-extension fail-closed case; `transfer_checked` happy path; deposit + withdraw round-trip.
+- **Classic SPL regression:** the existing suite passes unchanged after the interface migration.
+- **Sentinel:** a native withdrawal emits `VaultWithdrawEvent { mint == Pubkey::default() }` and an announcement with `token_mint == Pubkey::default()`.
+
+## 10. Deployment
+
+- **Devnet (now):** `anchor build` → `solana program deploy` to devnet (authority `FGSkt8…`, per CLAUDE.md), regenerate the IDL, run `create_sol_vault`. `VaultConfig` is unchanged (same fee / timeout). The pilot uses native SOL directly.
+- **Mainnet (gated):** deferred behind the **self-audit complete** rule and the upgrade + config authority moving to the **Squads v4 2-of-3** multisig.
+
+## 11. Out of scope / follow-ons
+
+- SDK native-SOL **scan** + **gasless cash-out** (consume the §5.4 contract) — next spec.
+- Integrator client — separate spec; partly gated externally.
+- `sip-privacy` Token-2022 parity — tracked as sip-protocol#1160 (mainnet, separately gated).
+
+## 12. Decisions log
+
+1. **Approach A** (separate native instructions; token path widened in place) over unified-branching (B) or program-side wrapping (C) — isolates high-risk lamport code; single-purpose instructions; smallest audit blast radius.
+2. **Sentinel = `Pubkey::default()`** over the wSOL mint (which is an ambiguous, legitimate SPL deposit).
+3. **`mint: Pubkey` added to `VaultWithdrawEvent`** for clean off-chain decode.
+4. **Allowlist enforced at `create_vault_token`**, fail-closed, justified by the init-immutability of every rejected extension.
+5. **Conservative Token-2022 v1** (reject fee/hook/confidential/delegate/non-transferable/default-frozen) — minimize audit surface; fee-bearing support is a possible later multisig-governed upgrade.

--- a/programs/sipher-vault/.gitignore
+++ b/programs/sipher-vault/.gitignore
@@ -4,3 +4,6 @@ target/
 
 # Node
 node_modules/
+
+# Compiled program fixtures (large binaries, rebuilt from source)
+tests/fixtures/*.so

--- a/programs/sipher-vault/DEPLOYMENT.md
+++ b/programs/sipher-vault/DEPLOYMENT.md
@@ -26,6 +26,41 @@ Deployment records and procedures for the `sipher_vault` Anchor program — a pr
 > the on-chain SBF binary is unaffected. The IDL artifact at `target/idl/sipher_vault.json`
 > is regenerated from earlier compatible host toolchains.
 
+## Instruction Inventory
+
+The program currently exposes **15 instructions** (9 original + 6 native-SOL track added in the universal-asset feature).
+
+### Token-track instructions (original 9)
+
+| # | Instruction | Description |
+|---|-------------|-------------|
+| 1 | `initialize` | Create `VaultConfig` PDA; set fee_bps, refund_timeout, authority |
+| 2 | `create_vault_token` | Create per-mint `VaultToken` + `FeeToken` SPL ATAs (classic SPL + Token-2022, fail-closed allowlist) |
+| 3 | `create_fee_token` | (unused standalone path — called internally via `create_vault_token`) |
+| 4 | `deposit` | Deposit SPL tokens from depositor ATA into `vault_token` PDA |
+| 5 | `withdraw_private` | Deduct from `deposit_record`, pay fee → `fee_token`, CPI `sip_privacy::create_transfer_announcement` to stealth ATA |
+| 6 | `refund` | Return tokens after `refund_timeout` has elapsed (depositor-signed) |
+| 7 | `authority_refund` | Emergency authority-gated refund (bypasses timeout) |
+| 8 | `collect_fee` | Sweep accumulated `fee_token` balance to authority ATA |
+| 9 | `set_paused` | Authority-gated pause/unpause; emits `VaultPausedEvent` |
+
+### Native-SOL track instructions (added in universal-asset feature)
+
+| # | Instruction | Description |
+|---|-------------|-------------|
+| 10 | `create_sol_vault` | Init singleton `SolVault` PDA (`b"vault_sol"`) + `SolFee` PDA (`b"fee_sol"`) |
+| 11 | `deposit_sol` | Transfer lamports from depositor → `SolVault` PDA via `system_program::transfer`; upsert `DepositRecord` keyed by `NATIVE_SOL_MINT` sentinel |
+| 12 | `withdraw_private_sol` | Debit `deposit_record`, pay fee → `SolFee`, checked-lamport transfer to stealth system account; CPI `sip_privacy::create_transfer_announcement`; rent-reserve guard on `SolVault` |
+| 13 | `refund_sol` | Return lamports after `refund_timeout` (depositor-signed); checked-lamport transfer from `SolVault` |
+| 14 | `authority_refund_sol` | Emergency authority-gated SOL refund |
+| 15 | `collect_fee_sol` | Sweep `SolFee` lamports to authority; preserves rent-exempt floor |
+
+> **SDK/relayer integrators:** native `withdraw_private_sol` sends lamports to a stealth system account. If
+> the stealth account is freshly created (zero balance), the receiving transaction must leave it at or above
+> the rent-exempt minimum (currently ~890,880 lamports for a 0-byte account). Pre-fund the stealth account
+> or ensure the withdrawn amount ≥ rent-exempt minimum; the Solana runtime will reject the transaction
+> otherwise.
+
 ## Devnet Deployments
 
 ### Devnet — Initial Deploy (2026-03-31)
@@ -81,11 +116,50 @@ emergency lever works before mainnet (PR-B1 Risk B2/B3).
 - Verified script: `programs/sipher-vault/scripts/set-paused.ts`
 - Authority signed: `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr`
 
+### Devnet — Universal-Asset Upgrade (PENDING — to be filled in by RECTOR)
+
+Universal-asset feature branch adds native SOL support (6 new instructions, 9 → 15 total).
+Binary: `492888` bytes (Δ from `383144` — +109 KB for two new account structs + 6 instruction handlers).
+
+- **Upgrade TX:** `[TODO — run scripts/upgrade-devnet.ts and paste TX signature here]`
+- **New deployed slot:** `[TODO — paste slot from upgrade-devnet.ts output]`
+- **SOL vault init TX:** `[TODO — run scripts/create-sol-vault.ts after redeploy and paste TX here]`
+- **SolVault PDA:** `[TODO — paste from create-sol-vault.ts output]`
+- **SolFee PDA:** `[TODO — paste from create-sol-vault.ts output]`
+- Binary size: `492888` bytes
+- Authority signed: `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr`
+
 ## Mainnet Deployments
 
-_Not deployed. See Phase 4b plan for mainnet rollout sequencing._
+_Not deployed. Mainnet deploy is gated on the self-audit completing (B6) — out of scope for this feature branch._
 
 ## Procedures
+
+### Running the Bankrun Test Suite
+
+The test suite is IDL-free (solana-bankrun raw-ix). It requires the `sip_privacy.so` fixture for CPI tests:
+
+```bash
+# Step 1: Build sip_privacy to get its .so (from the repo root or programs/sip-privacy)
+cd programs/sip-privacy
+anchor build --no-idl
+cp target/deploy/sip_privacy.so ../sipher-vault/tests/fixtures/sip_privacy.so
+cd ../sipher-vault
+```
+
+Then run the suite:
+
+```bash
+# All three test files (10 = token-track, 11 = SOL-track, 12 = cross-track)
+pnpm exec ts-mocha -p tsconfig.json -t 60000 'tests/sipher-vault/{10,11,12}-*.ts'
+
+# Or individually:
+pnpm exec ts-mocha -p tsconfig.json -t 60000 'tests/sipher-vault/10-*.ts'
+pnpm exec ts-mocha -p tsconfig.json -t 60000 'tests/sipher-vault/11-*.ts'
+pnpm exec ts-mocha -p tsconfig.json -t 60000 'tests/sipher-vault/12-*.ts'
+```
+
+Expected: **25 passing**, 0 failing.
 
 ### Devnet Upgrade
 
@@ -102,6 +176,19 @@ The script verifies the program keypair, runs `anchor build --no-idl` (increment
 preserves the IDL artifact), deploys via `BPFLoaderUpgradeable`, and prints the new
 deployed slot. Idempotent — running again redeploys.
 
+### Initialize Native SOL Vault on Devnet
+
+After the universal-asset binary is deployed, run:
+
+```bash
+cd programs/sipher-vault
+ANCHOR_WALLET=~/Documents/secret/solana-devnet.json \
+ANCHOR_PROVIDER_URL=https://api.devnet.solana.com \
+pnpm exec tsx scripts/create-sol-vault.ts
+```
+
+This creates the `SolVault` and `SolFee` PDAs. Idempotent — safe to re-run.
+
 ### Mainnet Upgrade
 
-_TODO: add `upgrade-mainnet.ts` in PR-B1._
+_TODO: add `upgrade-mainnet.ts` in PR-B1. Mainnet deploy is B6-gated (self-audit)._

--- a/programs/sipher-vault/DEPLOYMENT.md
+++ b/programs/sipher-vault/DEPLOYMENT.md
@@ -35,8 +35,8 @@ The program currently exposes **15 instructions** (9 original + 6 native-SOL tra
 | # | Instruction | Description |
 |---|-------------|-------------|
 | 1 | `initialize` | Create `VaultConfig` PDA; set fee_bps, refund_timeout, authority |
-| 2 | `create_vault_token` | Create per-mint `VaultToken` + `FeeToken` SPL ATAs (classic SPL + Token-2022, fail-closed allowlist) |
-| 3 | `create_fee_token` | (unused standalone path — called internally via `create_vault_token`) |
+| 2 | `create_vault_token` | Create the per-mint `vault_token` PDA (classic SPL + Token-2022, fail-closed extension allowlist). Must be called before `deposit` |
+| 3 | `create_fee_token` | Create the per-mint `fee_token` PDA. Separate instruction — NOT invoked by `create_vault_token`; must be called before the first `withdraw_private` |
 | 4 | `deposit` | Deposit SPL tokens from depositor ATA into `vault_token` PDA |
 | 5 | `withdraw_private` | Deduct from `deposit_record`, pay fee → `fee_token`, CPI `sip_privacy::create_transfer_announcement` to stealth ATA |
 | 6 | `refund` | Return tokens after `refund_timeout` has elapsed (depositor-signed) |
@@ -119,14 +119,14 @@ emergency lever works before mainnet (PR-B1 Risk B2/B3).
 ### Devnet — Universal-Asset Upgrade (PENDING — to be filled in by RECTOR)
 
 Universal-asset feature branch adds native SOL support (6 new instructions, 9 → 15 total).
-Binary: `492888` bytes (Δ from `383144` — +109 KB for two new account structs + 6 instruction handlers).
+Binary: `492536` bytes (Δ from `383144` — ~107 KB for two new account structs + 6 instruction handlers).
 
 - **Upgrade TX:** `[TODO — run scripts/upgrade-devnet.ts and paste TX signature here]`
 - **New deployed slot:** `[TODO — paste slot from upgrade-devnet.ts output]`
 - **SOL vault init TX:** `[TODO — run scripts/create-sol-vault.ts after redeploy and paste TX here]`
 - **SolVault PDA:** `[TODO — paste from create-sol-vault.ts output]`
 - **SolFee PDA:** `[TODO — paste from create-sol-vault.ts output]`
-- Binary size: `492888` bytes
+- Binary size: `492536` bytes
 - Authority signed: `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr`
 
 ## Mainnet Deployments

--- a/programs/sipher-vault/package.json
+++ b/programs/sipher-vault/package.json
@@ -2,7 +2,7 @@
   "name": "sipher-vault-tests",
   "private": true,
   "scripts": {
-    "test": "ts-mocha -p ./tsconfig.json -t 1000000 \"tests/**/*.ts\""
+    "test": "ts-mocha -p ./tsconfig.json -t 1000000 \"tests/sipher-vault/{10,11,12}-*.ts\""
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.30.1",

--- a/programs/sipher-vault/programs/sipher-vault/src/constants.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/constants.rs
@@ -1,3 +1,5 @@
+use anchor_lang::prelude::Pubkey;
+
 pub const VAULT_CONFIG_SEED: &[u8] = b"vault_config";
 pub const DEPOSIT_RECORD_SEED: &[u8] = b"deposit_record";
 pub const VAULT_TOKEN_SEED: &[u8] = b"vault_token";
@@ -5,4 +7,9 @@ pub const FEE_TOKEN_SEED: &[u8] = b"fee_token";
 pub const DEFAULT_REFUND_TIMEOUT: i64 = 86400;
 pub const DEFAULT_FEE_BPS: u16 = 10;
 pub const MAX_FEE_BPS: u16 = 100;
+
+pub const VAULT_SOL_SEED: &[u8] = b"vault_sol";
+pub const FEE_SOL_SEED: &[u8] = b"fee_sol";
+/// Sentinel mint representing native SOL (zero / System-Program pubkey).
+pub const NATIVE_SOL_MINT: Pubkey = Pubkey::new_from_array([0u8; 32]);
 

--- a/programs/sipher-vault/programs/sipher-vault/src/errors.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/errors.rs
@@ -26,4 +26,10 @@ pub enum VaultError {
   BalanceLocked,
   #[msg("CPI to SIP Privacy program failed")]
   AnnouncementCpiFailed,
+  #[msg("Mint carries an unsupported Token-2022 extension")]
+  UnsupportedMintExtension,
+  #[msg("Operation would drain a SOL PDA below its rent-exempt minimum")]
+  RentReserveViolation,
+  #[msg("Invalid SOL vault or fee PDA")]
+  InvalidSolVault,
 }

--- a/programs/sipher-vault/programs/sipher-vault/src/errors.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/errors.rs
@@ -30,6 +30,4 @@ pub enum VaultError {
   UnsupportedMintExtension,
   #[msg("Operation would drain a SOL PDA below its rent-exempt minimum")]
   RentReserveViolation,
-  #[msg("Invalid SOL vault or fee PDA")]
-  InvalidSolVault,
 }

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -525,6 +525,97 @@ pub mod sipher_vault {
     Ok(())
   }
 
+  /// Refund available (unlocked) native SOL balance back to the depositor.
+  /// Depositor is the signer and the lamport destination.
+  /// Timeout is enforced on-chain — the depositor must wait `refund_timeout` seconds
+  /// since their last deposit before reclaiming funds.
+  pub fn refund_sol(ctx: Context<RefundSol>) -> Result<()> {
+    let record = &mut ctx.accounts.deposit_record;
+    let available = record.balance
+      .checked_sub(record.locked_amount)
+      .ok_or(VaultError::MathOverflow)?;
+    require!(available > 0, VaultError::NothingToRefund);
+
+    // Enforce refund timeout
+    let now = Clock::get()?.unix_timestamp;
+    let elapsed = now
+      .checked_sub(record.last_deposit_at)
+      .ok_or(VaultError::MathOverflow)?;
+    require!(
+      elapsed >= ctx.accounts.config.refund_timeout,
+      VaultError::RefundNotExpired
+    );
+
+    // CHECKED lamport mutation: sol_vault → depositor.
+    // BPF release mode silently WRAPS on `+=`/`-=` for u64 — compute all new
+    // values with checked ops and enforce the rent-reserve guard FIRST, then assign.
+    let vault_ai = ctx.accounts.sol_vault.to_account_info();
+    let new_vault = vault_ai.lamports()
+      .checked_sub(available)
+      .ok_or(VaultError::MathOverflow)?;
+    let rent_min = Rent::get()?.minimum_balance(vault_ai.data_len());
+    require!(new_vault >= rent_min, VaultError::RentReserveViolation);
+    let dep_ai = ctx.accounts.depositor.to_account_info();
+    let new_dep = dep_ai.lamports()
+      .checked_add(available)
+      .ok_or(VaultError::MathOverflow)?;
+    **vault_ai.try_borrow_mut_lamports()? = new_vault;
+    **dep_ai.try_borrow_mut_lamports()? = new_dep;
+
+    // Zero out the refunded (unlocked) portion; locked_amount is preserved.
+    record.balance = record.locked_amount;
+
+    msg!("Refunded {} lamports (native SOL)", available);
+    Ok(())
+  }
+
+  /// Authority-signed refund of available (unlocked) native SOL to the original depositor.
+  /// Mirrors `refund_sol` exactly except:
+  ///   - the authority signs instead of the depositor,
+  ///   - `config` carries `has_one = authority` (so wrong authority → Unauthorized),
+  ///   - the vault MUST NOT be paused (authority cannot bypass the emergency gate),
+  ///   - `depositor` is a non-signer SystemAccount (lamport destination + seed source).
+  /// Timeout is still enforced on-chain — authority does NOT bypass the cooldown.
+  pub fn authority_refund_sol(ctx: Context<AuthorityRefundSol>) -> Result<()> {
+    require!(!ctx.accounts.config.paused, VaultError::ProgramPaused);
+
+    let record = &mut ctx.accounts.deposit_record;
+    let available = record.balance
+      .checked_sub(record.locked_amount)
+      .ok_or(VaultError::MathOverflow)?;
+    require!(available > 0, VaultError::NothingToRefund);
+
+    // Enforce refund timeout — authority does NOT bypass the cooldown
+    let now = Clock::get()?.unix_timestamp;
+    let elapsed = now
+      .checked_sub(record.last_deposit_at)
+      .ok_or(VaultError::MathOverflow)?;
+    require!(
+      elapsed >= ctx.accounts.config.refund_timeout,
+      VaultError::RefundNotExpired
+    );
+
+    // CHECKED lamport mutation: sol_vault → depositor (identical pattern to refund_sol).
+    let vault_ai = ctx.accounts.sol_vault.to_account_info();
+    let new_vault = vault_ai.lamports()
+      .checked_sub(available)
+      .ok_or(VaultError::MathOverflow)?;
+    let rent_min = Rent::get()?.minimum_balance(vault_ai.data_len());
+    require!(new_vault >= rent_min, VaultError::RentReserveViolation);
+    let dep_ai = ctx.accounts.depositor.to_account_info();
+    let new_dep = dep_ai.lamports()
+      .checked_add(available)
+      .ok_or(VaultError::MathOverflow)?;
+    **vault_ai.try_borrow_mut_lamports()? = new_vault;
+    **dep_ai.try_borrow_mut_lamports()? = new_dep;
+
+    // Zero out the refunded (unlocked) portion; locked_amount is preserved.
+    record.balance = record.locked_amount;
+
+    msg!("Authority refunded {} lamports (native SOL) to {}", available, ctx.accounts.depositor.key());
+    Ok(())
+  }
+
   /// Authority-only: collect accumulated fees from the fee token account.
   /// Pass amount=0 to collect all available fees.
   pub fn collect_fee(ctx: Context<CollectFee>, amount: u64) -> Result<()> {
@@ -1073,6 +1164,76 @@ pub struct AuthorityRefund<'info> {
   pub authority: Signer<'info>,
 
   pub token_program: Interface<'info, TokenInterface>,
+}
+
+/// Native-SOL self-refund context. Depositor is the signer and the lamport
+/// destination. The `deposit_record` PDA is derived from the depositor's pubkey
+/// and NATIVE_SOL_MINT; `has_one = depositor` guards that only the original
+/// depositor can reclaim their own balance.
+#[derive(Accounts)]
+pub struct RefundSol<'info> {
+  #[account(
+    seeds = [VAULT_CONFIG_SEED],
+    bump = config.bump,
+  )]
+  pub config: Account<'info, VaultConfig>,
+
+  #[account(
+    mut,
+    seeds = [DEPOSIT_RECORD_SEED, depositor.key().as_ref(), NATIVE_SOL_MINT.as_ref()],
+    bump = deposit_record.bump,
+    has_one = depositor @ VaultError::Unauthorized,
+  )]
+  pub deposit_record: Account<'info, DepositRecord>,
+
+  #[account(
+    mut,
+    seeds = [VAULT_SOL_SEED],
+    bump = sol_vault.bump,
+  )]
+  pub sol_vault: Account<'info, SolVault>,
+
+  #[account(mut)]
+  pub depositor: Signer<'info>,
+}
+
+/// Authority-signed native-SOL refund context. The authority signs on behalf of
+/// the depositor (e.g., SENTINEL autonomous refunds). The depositor is a
+/// non-signer SystemAccount that receives the lamports — `has_one = depositor`
+/// on the `deposit_record` ensures the principal always returns to the original
+/// depositor, NOT to any authority-chosen address. Wrong authority → Unauthorized
+/// via `has_one = authority` on `config`.
+#[derive(Accounts)]
+pub struct AuthorityRefundSol<'info> {
+  #[account(
+    seeds = [VAULT_CONFIG_SEED],
+    bump = config.bump,
+    has_one = authority @ VaultError::Unauthorized,
+  )]
+  pub config: Account<'info, VaultConfig>,
+
+  #[account(
+    mut,
+    seeds = [DEPOSIT_RECORD_SEED, depositor.key().as_ref(), NATIVE_SOL_MINT.as_ref()],
+    bump = deposit_record.bump,
+    has_one = depositor @ VaultError::Unauthorized,
+  )]
+  pub deposit_record: Account<'info, DepositRecord>,
+
+  #[account(
+    mut,
+    seeds = [VAULT_SOL_SEED],
+    bump = sol_vault.bump,
+  )]
+  pub sol_vault: Account<'info, SolVault>,
+
+  /// Non-signer lamport destination + seed source for the deposit_record PDA.
+  /// Validated by the deposit_record.has_one constraint above.
+  #[account(mut)]
+  pub depositor: SystemAccount<'info>,
+
+  #[account(mut)]
+  pub authority: Signer<'info>,
 }
 
 #[derive(Accounts)]

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -81,14 +81,18 @@ pub mod sipher_vault {
   /// with UnsupportedMintExtension to protect the vault's transfer invariants.
   pub fn create_vault_token(ctx: Context<CreateVaultToken>) -> Result<()> {
     // ── Token-2022 extension allowlist (fail-closed) ──────────────────────
-    // If the mint belongs to the Token-2022 program, inspect its extensions.
-    // Classic SPL mints are owned by TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA;
-    // StateWithExtensions::unpack will return Err on classic mint layout (no
-    // extension TLV area) so the if-let silently skips the check for classic mints.
+    // Gate on the mint's program owner so the allowlist is truly fail-closed:
+    // - Classic SPL mints (owned by TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA)
+    //   have no TLV extension area — skip the check entirely.
+    // - Token-2022 mints (owned by anchor_spl::token_2022::ID) MUST unpack
+    //   successfully; a malformed TLV that causes Err is treated as a rejected
+    //   mint (fail-closed), not silently accepted (fail-open).
     {
       let mint_ai = ctx.accounts.token_mint.to_account_info();
-      let data = mint_ai.try_borrow_data()?;
-      if let Ok(state) = StateWithExtensions::<Token2022Mint>::unpack(&data) {
+      if *mint_ai.owner == anchor_spl::token_2022::ID {
+        let data = mint_ai.try_borrow_data()?;
+        let state = StateWithExtensions::<Token2022Mint>::unpack(&data)
+          .map_err(|_| VaultError::UnsupportedMintExtension)?;
         for ext in state.get_extension_types()? {
           let allowed = matches!(
             ext,

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -253,6 +253,7 @@ pub mod sipher_vault {
     // 6. Emit event
     emit!(VaultWithdrawEvent {
       depositor: ctx.accounts.depositor.key(),
+      mint: ctx.accounts.token_mint.key(),
       stealth_recipient: stealth_pubkey,
       amount_commitment,
       ephemeral_pubkey,
@@ -732,6 +733,7 @@ pub struct SetPaused<'info> {
 #[event]
 pub struct VaultWithdrawEvent {
   pub depositor: Pubkey,
+  pub mint: Pubkey,
   pub stealth_recipient: Pubkey,
   pub amount_commitment: [u8; 33],
   pub ephemeral_pubkey: [u8; 33],

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -27,7 +27,7 @@ pub mod state;
 
 use constants::*;
 use errors::VaultError;
-use state::{DepositRecord, VaultConfig};
+use state::{DepositRecord, SolFee, SolVault, VaultConfig};
 
 /// SIP Privacy program ID — used for CPI to create_transfer_announcement
 /// S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at
@@ -119,6 +119,16 @@ pub mod sipher_vault {
       "Fee token PDA created for mint {}",
       ctx.accounts.token_mint.key()
     );
+    Ok(())
+  }
+
+  /// Create the singleton native-SOL vault + fee PDAs.
+  /// Called once per deployment before any native-SOL deposits.
+  /// Payer funds the rent-exempt reserve for both PDAs.
+  pub fn create_sol_vault(ctx: Context<CreateSolVault>) -> Result<()> {
+    ctx.accounts.sol_vault.bump = ctx.bumps.sol_vault;
+    ctx.accounts.sol_fee.bump = ctx.bumps.sol_fee;
+    msg!("SOL vault + fee PDAs created");
     Ok(())
   }
 
@@ -518,6 +528,35 @@ pub struct CreateFeeToken<'info> {
   pub payer: Signer<'info>,
 
   pub token_program: Interface<'info, TokenInterface>,
+  pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct CreateSolVault<'info> {
+  #[account(seeds = [VAULT_CONFIG_SEED], bump = config.bump)]
+  pub config: Account<'info, VaultConfig>,
+
+  #[account(
+    init,
+    payer = payer,
+    space = 8 + SolVault::INIT_SPACE,
+    seeds = [VAULT_SOL_SEED],
+    bump,
+  )]
+  pub sol_vault: Account<'info, SolVault>,
+
+  #[account(
+    init,
+    payer = payer,
+    space = 8 + SolFee::INIT_SPACE,
+    seeds = [FEE_SOL_SEED],
+    bump,
+  )]
+  pub sol_fee: Account<'info, SolFee>,
+
+  #[account(mut)]
+  pub payer: Signer<'info>,
+
   pub system_program: Program<'info, System>,
 }
 

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -11,7 +11,8 @@
 //! - `deposit` — Transfer tokens from user to vault PDA, create/update DepositRecord
 //! - `withdraw_private` — Debit-first withdrawal to stealth address + fee split
 //! - `refund` — Return available (unlocked) balance to depositor
-//! - `collect_fee` — Authority-only fee withdrawal
+//! - `collect_fee` — Authority-only token-fee withdrawal
+//! - `collect_fee_sol` — Authority-only native-SOL fee withdrawal (above rent floor)
 
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program;
@@ -646,6 +647,35 @@ pub mod sipher_vault {
     Ok(())
   }
 
+  /// Authority-only: drain lamports above the rent-exempt minimum from the native
+  /// SOL fee PDA (`sol_fee`). Fees accrue during `withdraw_private_sol` (fee_bps
+  /// per withdrawal). Pass `amount = 0` to collect ALL collectable lamports.
+  ///
+  /// Safety: Uses the Task-7 checked lamport mutation pattern — every new balance
+  /// is computed with `checked_sub`/`checked_add` before any assignment. The rent
+  /// floor of `sol_fee` is preserved; the instruction reverts with `NoFeesToCollect`
+  /// if there is nothing above the floor.
+  pub fn collect_fee_sol(ctx: Context<CollectFeeSol>, amount: u64) -> Result<()> {
+    let fee_ai = ctx.accounts.sol_fee.to_account_info();
+    let rent_min = Rent::get()?.minimum_balance(fee_ai.data_len());
+    let collectable = fee_ai.lamports()
+      .checked_sub(rent_min)
+      .ok_or(VaultError::MathOverflow)?;
+    require!(collectable > 0, VaultError::NoFeesToCollect);
+    let take = if amount == 0 || amount > collectable { collectable } else { amount };
+    let auth_ai = ctx.accounts.authority.to_account_info();
+    let new_fee = fee_ai.lamports()
+      .checked_sub(take)
+      .ok_or(VaultError::MathOverflow)?;
+    let new_auth = auth_ai.lamports()
+      .checked_add(take)
+      .ok_or(VaultError::MathOverflow)?;
+    **fee_ai.try_borrow_mut_lamports()? = new_fee;
+    **auth_ai.try_borrow_mut_lamports()? = new_auth;
+    msg!("Collected {} native-SOL lamports from fee PDA", take);
+    Ok(())
+  }
+
   /// Pause or unpause the vault. Authority-only.
   ///
   /// While paused (`config.paused == true`), `deposit`, `withdraw_private`, and
@@ -1267,6 +1297,29 @@ pub struct CollectFee<'info> {
   pub authority: Signer<'info>,
 
   pub token_program: Interface<'info, TokenInterface>,
+}
+
+/// Authority-only context for draining native-SOL fees above the rent floor
+/// from the `sol_fee` PDA. `has_one = authority` on `config` enforces that only
+/// the vault authority can call this instruction (wrong authority → Unauthorized).
+#[derive(Accounts)]
+pub struct CollectFeeSol<'info> {
+  #[account(
+    seeds = [VAULT_CONFIG_SEED],
+    bump = config.bump,
+    has_one = authority @ VaultError::Unauthorized,
+  )]
+  pub config: Account<'info, VaultConfig>,
+
+  #[account(
+    mut,
+    seeds = [FEE_SOL_SEED],
+    bump = sol_fee.bump,
+  )]
+  pub sol_fee: Account<'info, SolFee>,
+
+  #[account(mut)]
+  pub authority: Signer<'info>,
 }
 
 #[derive(Accounts)]

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -678,10 +678,12 @@ pub mod sipher_vault {
 
   /// Pause or unpause the vault. Authority-only.
   ///
-  /// While paused (`config.paused == true`), `deposit`, `withdraw_private`, and
-  /// `authority_refund` revert with `VaultError::ProgramPaused`. The `refund` and
-  /// `collect_fee` paths intentionally remain available so depositors can recover
-  /// funds and the authority can still drain accumulated fees during an emergency.
+  /// While paused (`config.paused == true`), `deposit`, `withdraw_private`,
+  /// `authority_refund`, `deposit_sol`, `withdraw_private_sol`, and
+  /// `authority_refund_sol` revert with `VaultError::ProgramPaused`. The
+  /// `refund`, `collect_fee`, `refund_sol`, and `collect_fee_sol` paths
+  /// intentionally remain available so depositors can always self-recover funds
+  /// and the authority can still drain accumulated fees during an emergency.
   ///
   /// Idempotent — calling with the current state is a no-op success.
   ///

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -15,7 +15,7 @@
 
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program;
-use anchor_spl::token::{self, Mint, Token, TokenAccount, Transfer};
+use anchor_spl::token_interface::{self, Mint, TokenAccount, TokenInterface, TransferChecked};
 
 pub mod constants;
 pub mod errors;
@@ -95,13 +95,14 @@ pub mod sipher_vault {
     // Transfer tokens from depositor to vault
     let transfer_ctx = CpiContext::new(
       ctx.accounts.token_program.to_account_info(),
-      Transfer {
+      TransferChecked {
         from: ctx.accounts.depositor_token.to_account_info(),
+        mint: ctx.accounts.token_mint.to_account_info(),
         to: ctx.accounts.vault_token.to_account_info(),
         authority: ctx.accounts.depositor.to_account_info(),
       },
     );
-    token::transfer(transfer_ctx, amount)?;
+    token_interface::transfer_checked(transfer_ctx, amount, ctx.accounts.token_mint.decimals)?;
 
     // Update deposit record
     let record = &mut ctx.accounts.deposit_record;
@@ -177,27 +178,29 @@ pub mod sipher_vault {
 
     let transfer_to_stealth = CpiContext::new_with_signer(
       ctx.accounts.token_program.to_account_info(),
-      Transfer {
+      TransferChecked {
         from: ctx.accounts.vault_token.to_account_info(),
+        mint: ctx.accounts.token_mint.to_account_info(),
         to: ctx.accounts.stealth_token.to_account_info(),
         authority: ctx.accounts.config.to_account_info(),
       },
       signer_seeds,
     );
-    token::transfer(transfer_to_stealth, net_amount)?;
+    token_interface::transfer_checked(transfer_to_stealth, net_amount, ctx.accounts.token_mint.decimals)?;
 
     // 4. Transfer fee to fee token account (PDA signs)
     if fee > 0 {
       let transfer_fee = CpiContext::new_with_signer(
         ctx.accounts.token_program.to_account_info(),
-        Transfer {
+        TransferChecked {
           from: ctx.accounts.vault_token.to_account_info(),
+          mint: ctx.accounts.token_mint.to_account_info(),
           to: ctx.accounts.fee_token.to_account_info(),
           authority: ctx.accounts.config.to_account_info(),
         },
         signer_seeds,
       );
-      token::transfer(transfer_fee, fee)?;
+      token_interface::transfer_checked(transfer_fee, fee, ctx.accounts.token_mint.decimals)?;
     }
 
     // 5. CPI to sip_privacy::create_transfer_announcement
@@ -291,14 +294,15 @@ pub mod sipher_vault {
 
     let transfer_ctx = CpiContext::new_with_signer(
       ctx.accounts.token_program.to_account_info(),
-      Transfer {
+      TransferChecked {
         from: ctx.accounts.vault_token.to_account_info(),
+        mint: ctx.accounts.token_mint.to_account_info(),
         to: ctx.accounts.depositor_token.to_account_info(),
         authority: ctx.accounts.config.to_account_info(),
       },
       signer_seeds,
     );
-    token::transfer(transfer_ctx, available)?;
+    token_interface::transfer_checked(transfer_ctx, available, ctx.accounts.token_mint.decimals)?;
 
     // Zero out refunded balance
     record.balance = record.locked_amount;
@@ -336,14 +340,15 @@ pub mod sipher_vault {
 
     let transfer_ctx = CpiContext::new_with_signer(
       ctx.accounts.token_program.to_account_info(),
-      Transfer {
+      TransferChecked {
         from: ctx.accounts.vault_token.to_account_info(),
+        mint: ctx.accounts.token_mint.to_account_info(),
         to: ctx.accounts.depositor_token.to_account_info(),
         authority: ctx.accounts.config.to_account_info(),
       },
       signer_seeds,
     );
-    token::transfer(transfer_ctx, available)?;
+    token_interface::transfer_checked(transfer_ctx, available, ctx.accounts.token_mint.decimals)?;
 
     // Zero out refunded balance (locked_amount preserved)
     record.balance = record.locked_amount;
@@ -368,14 +373,15 @@ pub mod sipher_vault {
 
     let transfer_ctx = CpiContext::new_with_signer(
       ctx.accounts.token_program.to_account_info(),
-      Transfer {
+      TransferChecked {
         from: ctx.accounts.fee_token.to_account_info(),
+        mint: ctx.accounts.token_mint.to_account_info(),
         to: ctx.accounts.authority_token.to_account_info(),
         authority: ctx.accounts.config.to_account_info(),
       },
       signer_seeds,
     );
-    token::transfer(transfer_ctx, withdraw_amount)?;
+    token_interface::transfer_checked(transfer_ctx, withdraw_amount, ctx.accounts.token_mint.decimals)?;
 
     msg!("Collected {} fees", withdraw_amount);
     Ok(())
@@ -442,14 +448,14 @@ pub struct CreateVaultToken<'info> {
     token::mint = token_mint,
     token::authority = config,
   )]
-  pub vault_token: Account<'info, TokenAccount>,
+  pub vault_token: InterfaceAccount<'info, TokenAccount>,
 
-  pub token_mint: Account<'info, Mint>,
+  pub token_mint: InterfaceAccount<'info, Mint>,
 
   #[account(mut)]
   pub payer: Signer<'info>,
 
-  pub token_program: Program<'info, Token>,
+  pub token_program: Interface<'info, TokenInterface>,
   pub system_program: Program<'info, System>,
 }
 
@@ -469,14 +475,14 @@ pub struct CreateFeeToken<'info> {
     token::mint = token_mint,
     token::authority = config,
   )]
-  pub fee_token: Account<'info, TokenAccount>,
+  pub fee_token: InterfaceAccount<'info, TokenAccount>,
 
-  pub token_mint: Account<'info, Mint>,
+  pub token_mint: InterfaceAccount<'info, Mint>,
 
   #[account(mut)]
   pub payer: Signer<'info>,
 
-  pub token_program: Program<'info, Token>,
+  pub token_program: Interface<'info, TokenInterface>,
   pub system_program: Program<'info, System>,
 }
 
@@ -505,21 +511,21 @@ pub struct Deposit<'info> {
     token::mint = token_mint,
     token::authority = config,
   )]
-  pub vault_token: Account<'info, TokenAccount>,
+  pub vault_token: InterfaceAccount<'info, TokenAccount>,
 
   #[account(
     mut,
     constraint = depositor_token.owner == depositor.key() @ VaultError::Unauthorized,
     constraint = depositor_token.mint == token_mint.key() @ VaultError::InvalidMint,
   )]
-  pub depositor_token: Account<'info, TokenAccount>,
+  pub depositor_token: InterfaceAccount<'info, TokenAccount>,
 
-  pub token_mint: Account<'info, Mint>,
+  pub token_mint: InterfaceAccount<'info, Mint>,
 
   #[account(mut)]
   pub depositor: Signer<'info>,
 
-  pub token_program: Program<'info, Token>,
+  pub token_program: Interface<'info, TokenInterface>,
   pub system_program: Program<'info, System>,
 }
 
@@ -546,7 +552,7 @@ pub struct WithdrawPrivate<'info> {
     token::mint = token_mint,
     token::authority = config,
   )]
-  pub vault_token: Account<'info, TokenAccount>,
+  pub vault_token: InterfaceAccount<'info, TokenAccount>,
 
   #[account(
     mut,
@@ -555,7 +561,7 @@ pub struct WithdrawPrivate<'info> {
     token::mint = token_mint,
     token::authority = config,
   )]
-  pub fee_token: Account<'info, TokenAccount>,
+  pub fee_token: InterfaceAccount<'info, TokenAccount>,
 
   /// The stealth token account to receive the net amount.
   /// Owned by any pubkey (the stealth address), we just verify the mint.
@@ -563,14 +569,14 @@ pub struct WithdrawPrivate<'info> {
     mut,
     constraint = stealth_token.mint == token_mint.key() @ VaultError::InvalidMint,
   )]
-  pub stealth_token: Account<'info, TokenAccount>,
+  pub stealth_token: InterfaceAccount<'info, TokenAccount>,
 
-  pub token_mint: Account<'info, Mint>,
+  pub token_mint: InterfaceAccount<'info, Mint>,
 
   #[account(mut)]
   pub depositor: Signer<'info>,
 
-  pub token_program: Program<'info, Token>,
+  pub token_program: Interface<'info, TokenInterface>,
 
   // ── CPI accounts for sip_privacy::create_transfer_announcement ──
 
@@ -621,19 +627,25 @@ pub struct Refund<'info> {
     token::mint = deposit_record.token_mint,
     token::authority = config,
   )]
-  pub vault_token: Account<'info, TokenAccount>,
+  pub vault_token: InterfaceAccount<'info, TokenAccount>,
 
   #[account(
     mut,
     constraint = depositor_token.owner == depositor.key() @ VaultError::Unauthorized,
     constraint = depositor_token.mint == deposit_record.token_mint @ VaultError::InvalidMint,
   )]
-  pub depositor_token: Account<'info, TokenAccount>,
+  pub depositor_token: InterfaceAccount<'info, TokenAccount>,
+
+  /// Mint account required by transfer_checked (must match deposit_record.token_mint)
+  #[account(
+    address = deposit_record.token_mint @ VaultError::InvalidMint,
+  )]
+  pub token_mint: InterfaceAccount<'info, Mint>,
 
   #[account(mut)]
   pub depositor: Signer<'info>,
 
-  pub token_program: Program<'info, Token>,
+  pub token_program: Interface<'info, TokenInterface>,
 }
 
 #[derive(Accounts)]
@@ -660,14 +672,20 @@ pub struct AuthorityRefund<'info> {
     token::mint = deposit_record.token_mint,
     token::authority = config,
   )]
-  pub vault_token: Account<'info, TokenAccount>,
+  pub vault_token: InterfaceAccount<'info, TokenAccount>,
 
   #[account(
     mut,
     constraint = depositor_token.owner == depositor.key() @ VaultError::Unauthorized,
     constraint = depositor_token.mint == deposit_record.token_mint @ VaultError::InvalidMint,
   )]
-  pub depositor_token: Account<'info, TokenAccount>,
+  pub depositor_token: InterfaceAccount<'info, TokenAccount>,
+
+  /// Mint account required by transfer_checked (must match deposit_record.token_mint)
+  #[account(
+    address = deposit_record.token_mint @ VaultError::InvalidMint,
+  )]
+  pub token_mint: InterfaceAccount<'info, Mint>,
 
   /// CHECK: Not a signer — validated by deposit_record.has_one. Used for PDA
   /// derivation and token account ownership check. The authority (not depositor)
@@ -677,7 +695,7 @@ pub struct AuthorityRefund<'info> {
   #[account(mut)]
   pub authority: Signer<'info>,
 
-  pub token_program: Program<'info, Token>,
+  pub token_program: Interface<'info, TokenInterface>,
 }
 
 #[derive(Accounts)]
@@ -696,21 +714,21 @@ pub struct CollectFee<'info> {
     token::mint = token_mint,
     token::authority = config,
   )]
-  pub fee_token: Account<'info, TokenAccount>,
+  pub fee_token: InterfaceAccount<'info, TokenAccount>,
 
   #[account(
     mut,
     constraint = authority_token.owner == authority.key() @ VaultError::Unauthorized,
     constraint = authority_token.mint == token_mint.key() @ VaultError::InvalidMint,
   )]
-  pub authority_token: Account<'info, TokenAccount>,
+  pub authority_token: InterfaceAccount<'info, TokenAccount>,
 
-  pub token_mint: Account<'info, Mint>,
+  pub token_mint: InterfaceAccount<'info, Mint>,
 
   #[account(mut)]
   pub authority: Signer<'info>,
 
-  pub token_program: Program<'info, Token>,
+  pub token_program: Interface<'info, TokenInterface>,
 }
 
 #[derive(Accounts)]

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -227,6 +227,7 @@ pub mod sipher_vault {
   /// 3. Transfer net amount to stealth token account
   /// 4. Transfer fee to fee token account
   /// 5. Emit VaultWithdrawEvent
+  #[allow(clippy::too_many_arguments)]
   pub fn withdraw_private(
     ctx: Context<WithdrawPrivate>,
     amount: u64,
@@ -324,6 +325,116 @@ pub mod sipher_vault {
     });
 
     msg!("Private withdrawal: {} net, {} fee", net_amount, fee);
+    Ok(())
+  }
+
+  /// Withdraw native SOL privately to a stealth address. The native-track analog
+  /// of `withdraw_private`. Debit-first pattern, then a **checked lamport mutation**
+  /// of the program-owned `SolVault` PDA (no system CPI — the source is PDA-owned):
+  ///   1. Guards: not paused, amount > 0.
+  ///   2. Debit-first: reduce `DepositRecord.balance` before moving any lamports.
+  ///   3. Fee split: `fee = amount · fee_bps / 10_000`, `net = amount − fee`.
+  ///   4. Checked lamport mutation: compute every new balance with checked ops
+  ///      (BPF release WRAPS on `+=`/`-=`, which would be a vault drain), enforce
+  ///      the rent-reserve guard on the vault debit, THEN assign.
+  ///   5. CPI `create_transfer_announcement` (shared helper, mint = NATIVE_SOL_MINT).
+  ///   6. Emit `VaultWithdrawEvent` (mint = NATIVE_SOL_MINT).
+  ///
+  /// `encrypted_amount` / `proof` mirror the token signature — carried for
+  /// announcement parity + off-chain verification; format-checked, unused on-chain.
+  #[allow(clippy::too_many_arguments)]
+  pub fn withdraw_private_sol(
+    ctx: Context<WithdrawPrivateSol>,
+    amount: u64,
+    amount_commitment: [u8; 33],
+    stealth_pubkey: Pubkey,
+    ephemeral_pubkey: [u8; 33],
+    viewing_key_hash: [u8; 32],
+    _encrypted_amount: Vec<u8>,
+    _proof: Vec<u8>,
+  ) -> Result<()> {
+    require!(!ctx.accounts.config.paused, VaultError::ProgramPaused);
+    require!(amount > 0, VaultError::ZeroDeposit);
+
+    // 1. Debit-first: reduce balance before any lamport movement.
+    let record = &mut ctx.accounts.deposit_record;
+    let available = record.balance
+      .checked_sub(record.locked_amount)
+      .ok_or(VaultError::MathOverflow)?;
+    require!(available >= amount, VaultError::InsufficientBalance);
+
+    record.balance = record.balance
+      .checked_sub(amount)
+      .ok_or(VaultError::MathOverflow)?;
+
+    // 2. Compute fee + net (checked).
+    let fee = (amount as u128)
+      .checked_mul(ctx.accounts.config.fee_bps as u128)
+      .ok_or(VaultError::MathOverflow)?
+      .checked_div(10_000)
+      .ok_or(VaultError::MathOverflow)? as u64;
+    let net = amount
+      .checked_sub(fee)
+      .ok_or(VaultError::MathOverflow)?;
+
+    // 3. CHECKED lamport mutation — the load-bearing safety code.
+    //    BPF release mode silently WRAPS on `+=`/`-=` for u64, so a wrap here
+    //    would be a vault drain. Compute every new value with checked ops and the
+    //    rent-reserve guard FIRST, then assign via try_borrow_mut_lamports. Never
+    //    use `**x -= n` / `**x += n` on these accounts.
+    let vault_ai = ctx.accounts.sol_vault.to_account_info();
+    let stealth_ai = ctx.accounts.stealth.to_account_info();
+    let fee_ai = ctx.accounts.sol_fee.to_account_info();
+
+    let new_vault = vault_ai.lamports()
+      .checked_sub(amount)
+      .ok_or(VaultError::MathOverflow)?;
+    // Rent-reserve guard: the SolVault must never be drained below its own
+    // rent-exempt minimum. Under correct accounting the reserve sits beneath all
+    // depositor balances and is never reached; this is a fail-safe.
+    let rent_min = Rent::get()?.minimum_balance(vault_ai.data_len());
+    require!(new_vault >= rent_min, VaultError::RentReserveViolation);
+
+    let new_stealth = stealth_ai.lamports()
+      .checked_add(net)
+      .ok_or(VaultError::MathOverflow)?;
+    let new_fee = fee_ai.lamports()
+      .checked_add(fee)
+      .ok_or(VaultError::MathOverflow)?;
+
+    **vault_ai.try_borrow_mut_lamports()? = new_vault;
+    **stealth_ai.try_borrow_mut_lamports()? = new_stealth;
+    **fee_ai.try_borrow_mut_lamports()? = new_fee;
+
+    // 4. CPI announcement — shared helper, mint = NATIVE_SOL_MINT.
+    emit_transfer_announcement(
+      &ctx.accounts.sip_privacy_program,
+      &ctx.accounts.sip_config,
+      &ctx.accounts.sip_transfer_record,
+      &ctx.accounts.depositor.to_account_info(),
+      &ctx.accounts.system_program.to_account_info(),
+      NATIVE_SOL_MINT,
+      &amount_commitment,
+      stealth_pubkey,
+      &ephemeral_pubkey,
+      &viewing_key_hash,
+      &_encrypted_amount,
+    )?;
+
+    // 5. Emit event.
+    emit!(VaultWithdrawEvent {
+      depositor: ctx.accounts.depositor.key(),
+      mint: NATIVE_SOL_MINT,
+      stealth_recipient: stealth_pubkey,
+      amount_commitment,
+      ephemeral_pubkey,
+      viewing_key_hash,
+      transfer_amount: net,
+      fee_amount: fee,
+      timestamp: Clock::get()?.unix_timestamp,
+    });
+
+    msg!("Private SOL withdrawal: {} net, {} fee", net, fee);
     Ok(())
   }
 
@@ -773,6 +884,76 @@ pub struct WithdrawPrivate<'info> {
   pub depositor: Signer<'info>,
 
   pub token_program: Interface<'info, TokenInterface>,
+
+  // ── CPI accounts for sip_privacy::create_transfer_announcement ──
+
+  /// SIP Privacy program config PDA
+  /// CHECK: Validated by seeds against sip_privacy program
+  #[account(
+    mut,
+    seeds = [SIP_CONFIG_SEED],
+    bump,
+    seeds::program = SIP_PRIVACY_PROGRAM_ID,
+  )]
+  pub sip_config: AccountInfo<'info>,
+
+  /// Transfer record PDA — will be initialized by CPI to sip_privacy
+  /// CHECK: Initialized and validated by the CPI call to sip_privacy
+  #[account(mut)]
+  pub sip_transfer_record: AccountInfo<'info>,
+
+  /// SIP Privacy program for CPI
+  /// CHECK: Validated by address constraint
+  #[account(address = SIP_PRIVACY_PROGRAM_ID)]
+  pub sip_privacy_program: AccountInfo<'info>,
+
+  /// System program (needed by sip_privacy to init the transfer record)
+  pub system_program: Program<'info, System>,
+}
+
+/// Native-SOL withdrawal context. Mirrors `WithdrawPrivate` with every token
+/// account removed: the source is the lamport-holding `sol_vault` PDA, the fee
+/// sink is the `sol_fee` PDA, and the recipient is a plain writable system
+/// account (no ATA, no mint check). The three sip_privacy CPI accounts + the
+/// system program are identical to the token context.
+#[derive(Accounts)]
+pub struct WithdrawPrivateSol<'info> {
+  #[account(
+    seeds = [VAULT_CONFIG_SEED],
+    bump = config.bump,
+  )]
+  pub config: Account<'info, VaultConfig>,
+
+  #[account(
+    mut,
+    seeds = [DEPOSIT_RECORD_SEED, depositor.key().as_ref(), NATIVE_SOL_MINT.as_ref()],
+    bump = deposit_record.bump,
+    has_one = depositor @ VaultError::Unauthorized,
+  )]
+  pub deposit_record: Account<'info, DepositRecord>,
+
+  #[account(
+    mut,
+    seeds = [VAULT_SOL_SEED],
+    bump = sol_vault.bump,
+  )]
+  pub sol_vault: Account<'info, SolVault>,
+
+  #[account(
+    mut,
+    seeds = [FEE_SOL_SEED],
+    bump = sol_fee.bump,
+  )]
+  pub sol_fee: Account<'info, SolFee>,
+
+  /// The stealth recipient — a plain writable system account that receives the
+  /// net lamports. No mint check (native SOL); may be below the rent-exempt
+  /// minimum after a small payout (documented in the design — no fund loss).
+  #[account(mut)]
+  pub stealth: SystemAccount<'info>,
+
+  #[account(mut)]
+  pub depositor: Signer<'info>,
 
   // ── CPI accounts for sip_privacy::create_transfer_announcement ──
 

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -295,52 +295,20 @@ pub mod sipher_vault {
     // 5. CPI to sip_privacy::create_transfer_announcement
     //    Creates a TransferRecord PDA so the payment is scannable by recipients.
     //    This is metadata-only — no token movement happens here.
-    {
-      // Anchor discriminator: sha256("global:create_transfer_announcement")[..8]
-      let disc = solana_program::hash::hash(
-        b"global:create_transfer_announcement"
-      ).to_bytes();
-
-      let mut cpi_data = Vec::with_capacity(8 + 33 + 32 + 33 + 32 + 4 + _encrypted_amount.len() + 32);
-      cpi_data.extend_from_slice(&disc[..8]);
-      // amount_commitment: [u8; 33]
-      cpi_data.extend_from_slice(&amount_commitment);
-      // stealth_pubkey: Pubkey (32 bytes)
-      cpi_data.extend_from_slice(stealth_pubkey.as_ref());
-      // ephemeral_pubkey: [u8; 33]
-      cpi_data.extend_from_slice(&ephemeral_pubkey);
-      // viewing_key_hash: [u8; 32]
-      cpi_data.extend_from_slice(&viewing_key_hash);
-      // encrypted_amount: Vec<u8> (4-byte LE length prefix + data)
-      let enc_amt = &_encrypted_amount;
-      cpi_data.extend_from_slice(&(enc_amt.len() as u32).to_le_bytes());
-      cpi_data.extend_from_slice(enc_amt);
-      // token_mint: Pubkey (32 bytes)
-      cpi_data.extend_from_slice(ctx.accounts.token_mint.key().as_ref());
-
-      let cpi_accounts = vec![
-        AccountMeta::new(ctx.accounts.sip_config.key(), false),
-        AccountMeta::new(ctx.accounts.sip_transfer_record.key(), false),
-        AccountMeta::new(ctx.accounts.depositor.key(), true),
-        AccountMeta::new_readonly(ctx.accounts.system_program.key(), false),
-      ];
-
-      let cpi_ix = solana_program::instruction::Instruction {
-        program_id: ctx.accounts.sip_privacy_program.key(),
-        accounts: cpi_accounts,
-        data: cpi_data,
-      };
-
-      solana_program::program::invoke(
-        &cpi_ix,
-        &[
-          ctx.accounts.sip_config.to_account_info(),
-          ctx.accounts.sip_transfer_record.to_account_info(),
-          ctx.accounts.depositor.to_account_info(),
-          ctx.accounts.system_program.to_account_info(),
-        ],
-      )?;
-    }
+    //    Shared with `withdraw_private_sol`; only the `mint` argument differs.
+    emit_transfer_announcement(
+      &ctx.accounts.sip_privacy_program,
+      &ctx.accounts.sip_config,
+      &ctx.accounts.sip_transfer_record,
+      &ctx.accounts.depositor.to_account_info(),
+      &ctx.accounts.system_program.to_account_info(),
+      ctx.accounts.token_mint.key(),
+      &amount_commitment,
+      stealth_pubkey,
+      &ephemeral_pubkey,
+      &viewing_key_hash,
+      &_encrypted_amount,
+    )?;
 
     // 6. Emit event
     emit!(VaultWithdrawEvent {
@@ -498,6 +466,85 @@ pub mod sipher_vault {
     });
     Ok(())
   }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Emit a `sip_privacy::create_transfer_announcement` CPI so a vault withdrawal
+/// becomes a scannable, Pedersen-committed announcement (a `TransferRecord` PDA).
+///
+/// Shared verbatim by `withdraw_private` (token track) and `withdraw_private_sol`
+/// (native track) — the ONLY difference between the two call sites is the `mint`
+/// value (`token_mint` for tokens, `NATIVE_SOL_MINT` for native SOL). The Borsh
+/// argument layout, discriminator, account metas, and signer wiring are identical
+/// to the token-only encoding that shipped before this extraction.
+///
+/// The CPI is metadata-only: it moves no funds. `depositor` is the announcement
+/// signer / rent payer for the new `TransferRecord` PDA.
+///
+/// Argument byte layout (matches `create_transfer_announcement`):
+///   disc(8) ‖ amount_commitment([u8;33]) ‖ stealth_pubkey(Pubkey,32)
+///   ‖ ephemeral_pubkey([u8;33]) ‖ viewing_key_hash([u8;32])
+///   ‖ encrypted_amount(Vec<u8>: u32-LE len ‖ bytes) ‖ token_mint(Pubkey,32)
+#[allow(clippy::too_many_arguments)]
+fn emit_transfer_announcement<'info>(
+  sip_privacy_program: &AccountInfo<'info>,
+  sip_config: &AccountInfo<'info>,
+  sip_transfer_record: &AccountInfo<'info>,
+  depositor: &AccountInfo<'info>,
+  system_program: &AccountInfo<'info>,
+  mint: Pubkey,
+  amount_commitment: &[u8; 33],
+  stealth_pubkey: Pubkey,
+  ephemeral_pubkey: &[u8; 33],
+  viewing_key_hash: &[u8; 32],
+  encrypted_amount: &[u8],
+) -> Result<()> {
+  // Anchor discriminator: sha256("global:create_transfer_announcement")[..8]
+  let disc = solana_program::hash::hash(b"global:create_transfer_announcement").to_bytes();
+
+  let mut cpi_data = Vec::with_capacity(8 + 33 + 32 + 33 + 32 + 4 + encrypted_amount.len() + 32);
+  cpi_data.extend_from_slice(&disc[..8]);
+  // amount_commitment: [u8; 33]
+  cpi_data.extend_from_slice(amount_commitment);
+  // stealth_pubkey: Pubkey (32 bytes)
+  cpi_data.extend_from_slice(stealth_pubkey.as_ref());
+  // ephemeral_pubkey: [u8; 33]
+  cpi_data.extend_from_slice(ephemeral_pubkey);
+  // viewing_key_hash: [u8; 32]
+  cpi_data.extend_from_slice(viewing_key_hash);
+  // encrypted_amount: Vec<u8> (4-byte LE length prefix + data)
+  cpi_data.extend_from_slice(&(encrypted_amount.len() as u32).to_le_bytes());
+  cpi_data.extend_from_slice(encrypted_amount);
+  // token_mint: Pubkey (32 bytes)
+  cpi_data.extend_from_slice(mint.as_ref());
+
+  let cpi_accounts = vec![
+    AccountMeta::new(sip_config.key(), false),
+    AccountMeta::new(sip_transfer_record.key(), false),
+    AccountMeta::new(depositor.key(), true),
+    AccountMeta::new_readonly(system_program.key(), false),
+  ];
+
+  let cpi_ix = solana_program::instruction::Instruction {
+    program_id: sip_privacy_program.key(),
+    accounts: cpi_accounts,
+    data: cpi_data,
+  };
+
+  solana_program::program::invoke(
+    &cpi_ix,
+    &[
+      sip_config.clone(),
+      sip_transfer_record.clone(),
+      depositor.clone(),
+      system_program.clone(),
+    ],
+  )?;
+
+  Ok(())
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -122,6 +122,50 @@ pub mod sipher_vault {
     Ok(())
   }
 
+  /// Deposit native SOL into the vault. Creates DepositRecord keyed by
+  /// (depositor, NATIVE_SOL_MINT) on first deposit; accumulates on repeat calls.
+  pub fn deposit_sol(ctx: Context<DepositSol>, amount: u64) -> Result<()> {
+    require!(!ctx.accounts.config.paused, VaultError::ProgramPaused);
+    require!(amount > 0, VaultError::ZeroDeposit);
+
+    // Transfer SOL from depositor to sol_vault PDA via system_program::transfer
+    let cpi = CpiContext::new(
+      ctx.accounts.system_program.to_account_info(),
+      anchor_lang::system_program::Transfer {
+        from: ctx.accounts.depositor.to_account_info(),
+        to: ctx.accounts.sol_vault.to_account_info(),
+      },
+    );
+    anchor_lang::system_program::transfer(cpi, amount)?;
+
+    // Update deposit record
+    let record = &mut ctx.accounts.deposit_record;
+    let is_new = record.balance == 0 && record.cumulative_volume == 0;
+
+    record.depositor = ctx.accounts.depositor.key();
+    record.token_mint = NATIVE_SOL_MINT;
+    record.balance = record.balance
+      .checked_add(amount)
+      .ok_or(VaultError::MathOverflow)?;
+    record.cumulative_volume = record.cumulative_volume
+      .checked_add(amount)
+      .ok_or(VaultError::MathOverflow)?;
+    record.last_deposit_at = Clock::get()?.unix_timestamp;
+    record.bump = ctx.bumps.deposit_record;
+
+    // Update global counters
+    let config = &mut ctx.accounts.config;
+    config.total_deposits = config.total_deposits.saturating_add(1);
+    if is_new {
+      config.total_depositors = config.total_depositors
+        .checked_add(1)
+        .ok_or(VaultError::MathOverflow)?;
+    }
+
+    msg!("Deposited {} lamports (native SOL)", amount);
+    Ok(())
+  }
+
   /// Create the singleton native-SOL vault + fee PDAs.
   /// Called once per deployment before any native-SOL deposits.
   /// Payer funds the rent-exempt reserve for both PDAs.
@@ -556,6 +600,37 @@ pub struct CreateSolVault<'info> {
 
   #[account(mut)]
   pub payer: Signer<'info>,
+
+  pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct DepositSol<'info> {
+  #[account(
+    mut,
+    seeds = [VAULT_CONFIG_SEED],
+    bump = config.bump,
+  )]
+  pub config: Account<'info, VaultConfig>,
+
+  #[account(
+    init_if_needed,
+    payer = depositor,
+    space = 8 + DepositRecord::INIT_SPACE,
+    seeds = [DEPOSIT_RECORD_SEED, depositor.key().as_ref(), NATIVE_SOL_MINT.as_ref()],
+    bump,
+  )]
+  pub deposit_record: Account<'info, DepositRecord>,
+
+  #[account(
+    mut,
+    seeds = [VAULT_SOL_SEED],
+    bump = sol_vault.bump,
+  )]
+  pub sol_vault: Account<'info, SolVault>,
+
+  #[account(mut)]
+  pub depositor: Signer<'info>,
 
   pub system_program: Program<'info, System>,
 }

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -15,6 +15,10 @@
 
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program;
+use anchor_spl::token_2022::spl_token_2022::{
+  extension::{BaseStateWithExtensions, ExtensionType, StateWithExtensions},
+  state::Mint as Token2022Mint,
+};
 use anchor_spl::token_interface::{self, Mint, TokenAccount, TokenInterface, TransferChecked};
 
 pub mod constants;
@@ -69,7 +73,34 @@ pub mod sipher_vault {
 
   /// Create the vault token PDA for a given mint.
   /// Anyone can call this (first depositor pays rent). Must be called before deposit.
+  ///
+  /// For Token-2022 mints, a fail-closed extension allowlist is enforced.
+  /// Only MetadataPointer, TokenMetadata, and InterestBearingConfig are allowed.
+  /// Any other extension (TransferFeeConfig, PermanentDelegate, TransferHook,
+  /// NonTransferable, DefaultAccountState, MintCloseAuthority, etc.) is rejected
+  /// with UnsupportedMintExtension to protect the vault's transfer invariants.
   pub fn create_vault_token(ctx: Context<CreateVaultToken>) -> Result<()> {
+    // ── Token-2022 extension allowlist (fail-closed) ──────────────────────
+    // If the mint belongs to the Token-2022 program, inspect its extensions.
+    // Classic SPL mints are owned by TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA;
+    // StateWithExtensions::unpack will return Err on classic mint layout (no
+    // extension TLV area) so the if-let silently skips the check for classic mints.
+    {
+      let mint_ai = ctx.accounts.token_mint.to_account_info();
+      let data = mint_ai.try_borrow_data()?;
+      if let Ok(state) = StateWithExtensions::<Token2022Mint>::unpack(&data) {
+        for ext in state.get_extension_types()? {
+          let allowed = matches!(
+            ext,
+            ExtensionType::MetadataPointer
+              | ExtensionType::TokenMetadata
+              | ExtensionType::InterestBearingConfig
+          );
+          require!(allowed, VaultError::UnsupportedMintExtension);
+        }
+      }
+    }
+
     msg!(
       "Vault token PDA created for mint {}",
       ctx.accounts.token_mint.key()

--- a/programs/sipher-vault/programs/sipher-vault/src/state.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/state.rs
@@ -23,3 +23,15 @@ pub struct DepositRecord {
   pub last_deposit_at: i64,
   pub bump: u8,
 }
+
+#[account]
+#[derive(InitSpace)]
+pub struct SolVault {
+  pub bump: u8,
+}
+
+#[account]
+#[derive(InitSpace)]
+pub struct SolFee {
+  pub bump: u8,
+}

--- a/programs/sipher-vault/scripts/create-sol-vault.ts
+++ b/programs/sipher-vault/scripts/create-sol-vault.ts
@@ -41,6 +41,17 @@ async function main() {
   const rpc = process.env.ANCHOR_PROVIDER_URL ?? 'https://api.devnet.solana.com'
   const conn = new Connection(rpc, 'confirmed')
 
+  // Guard: refuse to run on mainnet-beta. This is a devnet-only initializer; the
+  // SOL vault PDAs on mainnet must be created through the gated mainnet deploy
+  // (self-audit → mainnet), never via this helper. A stray ANCHOR_PROVIDER_URL
+  // must not be able to initialize the singletons on the wrong cluster.
+  const MAINNET_GENESIS = '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d'
+  const genesisHash = await conn.getGenesisHash()
+  if (genesisHash === MAINNET_GENESIS) {
+    console.error('ERROR: refusing to run against mainnet-beta — this initializer is devnet-only')
+    process.exit(1)
+  }
+
   const walletPath = process.env.ANCHOR_WALLET ?? `${homedir()}/Documents/secret/solana-devnet.json`
   const payer = Keypair.fromSecretKey(
     Uint8Array.from(JSON.parse(readFileSync(walletPath, 'utf-8')))

--- a/programs/sipher-vault/scripts/create-sol-vault.ts
+++ b/programs/sipher-vault/scripts/create-sol-vault.ts
@@ -1,0 +1,130 @@
+// programs/sipher-vault/scripts/create-sol-vault.ts
+//
+// Initialises the native-SOL vault PDAs (SolVault + SolFee) on devnet.
+//
+// PREREQUISITES:
+//   1. The universal-asset binary MUST be redeployed first:
+//      `ANCHOR_WALLET=~/Documents/secret/solana-devnet.json pnpm exec tsx scripts/upgrade-devnet.ts`
+//   2. The vault config must already be initialised (scripts/init-devnet.ts).
+//
+// Usage: cd programs/sipher-vault && pnpm exec tsx scripts/create-sol-vault.ts
+//
+// Accounts:
+//   config      vault_config PDA   [seeds: b"vault_config"]     (read-only)
+//   sol_vault   SolVault PDA       [seeds: b"vault_sol"]        (init)
+//   sol_fee     SolFee PDA         [seeds: b"fee_sol"]          (init)
+//   payer       devnet wallet      (signer, mut)
+//   system_program
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+  sendAndConfirmTransaction,
+} from '@solana/web3.js'
+import { readFileSync } from 'fs'
+import { homedir } from 'os'
+import { createHash } from 'crypto'
+
+const PROGRAM_ID = new PublicKey('S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB')
+const VAULT_CONFIG_SEED = Buffer.from('vault_config')
+const VAULT_SOL_SEED = Buffer.from('vault_sol')
+const FEE_SOL_SEED = Buffer.from('fee_sol')
+
+function disc(name: string): Buffer {
+  return createHash('sha256').update(`global:${name}`).digest().subarray(0, 8)
+}
+
+async function main() {
+  const rpc = process.env.ANCHOR_PROVIDER_URL ?? 'https://api.devnet.solana.com'
+  const conn = new Connection(rpc, 'confirmed')
+
+  const walletPath = process.env.ANCHOR_WALLET ?? `${homedir()}/Documents/secret/solana-devnet.json`
+  const payer = Keypair.fromSecretKey(
+    Uint8Array.from(JSON.parse(readFileSync(walletPath, 'utf-8')))
+  )
+
+  const [configPda] = PublicKey.findProgramAddressSync([VAULT_CONFIG_SEED], PROGRAM_ID)
+  const [solVaultPda] = PublicKey.findProgramAddressSync([VAULT_SOL_SEED], PROGRAM_ID)
+  const [solFeePda] = PublicKey.findProgramAddressSync([FEE_SOL_SEED], PROGRAM_ID)
+
+  console.log('Program ID:   ', PROGRAM_ID.toString())
+  console.log('Config PDA:   ', configPda.toString())
+  console.log('SolVault PDA: ', solVaultPda.toString())
+  console.log('SolFee PDA:   ', solFeePda.toString())
+  console.log('Payer:        ', payer.publicKey.toString())
+
+  // Guard: vault config must exist — deployer must have run init-devnet.ts first
+  const configInfo = await conn.getAccountInfo(configPda)
+  if (!configInfo) {
+    console.error('ERROR: vault_config PDA not found — run scripts/init-devnet.ts first')
+    process.exit(1)
+  }
+  console.log('vault_config OK (size', configInfo.data.length, 'bytes)')
+
+  // Guard: idempotent — skip if already initialised
+  const existingVault = await conn.getAccountInfo(solVaultPda)
+  if (existingVault) {
+    console.log('SolVault already initialised (size', existingVault.data.length, 'bytes) — nothing to do')
+    const existingFee = await conn.getAccountInfo(solFeePda)
+    if (existingFee) {
+      console.log('SolFee already initialised (size', existingFee.data.length, 'bytes)')
+    }
+    return
+  }
+
+  // create_sol_vault takes no arguments — discriminator only
+  const ix = new TransactionInstruction({
+    programId: PROGRAM_ID,
+    keys: [
+      { pubkey: configPda,              isSigner: false, isWritable: false },
+      { pubkey: solVaultPda,            isSigner: false, isWritable: true  },
+      { pubkey: solFeePda,              isSigner: false, isWritable: true  },
+      { pubkey: payer.publicKey,        isSigner: true,  isWritable: true  },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data: disc('create_sol_vault'),
+  })
+
+  console.log('\nSending create_sol_vault...')
+  const tx = new Transaction().add(ix)
+  const sig = await sendAndConfirmTransaction(conn, tx, [payer])
+  console.log('TX:', sig)
+
+  // Verify both PDAs were created
+  const [vaultInfo, feeInfo] = await Promise.all([
+    conn.getAccountInfo(solVaultPda),
+    conn.getAccountInfo(solFeePda),
+  ])
+
+  if (!vaultInfo) {
+    console.error('FAIL — SolVault PDA not created after TX')
+    process.exit(1)
+  }
+  if (!feeInfo) {
+    console.error('FAIL — SolFee PDA not created after TX')
+    process.exit(1)
+  }
+
+  console.log('\nSolVault created. Size:', vaultInfo.data.length, 'bytes. Owner:', vaultInfo.owner.toString())
+  console.log('SolFee  created. Size:', feeInfo.data.length,  'bytes. Owner:', feeInfo.owner.toString())
+
+  if (!vaultInfo.owner.equals(PROGRAM_ID) || !feeInfo.owner.equals(PROGRAM_ID)) {
+    console.error('FAIL — unexpected owner (expected program ID)')
+    process.exit(1)
+  }
+
+  console.log('\nNative SOL vault initialised successfully.')
+  console.log({
+    tx: sig,
+    solVaultPda: solVaultPda.toString(),
+    solFeePda:   solFeePda.toString(),
+  })
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/programs/sipher-vault/tests/sipher-vault/10-bankrun-classic-spl.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/10-bankrun-classic-spl.test.ts
@@ -17,7 +17,6 @@ import {
   createMintToInstruction,
   getAssociatedTokenAddressSync,
   getMintLen,
-  MintLayout,
 } from '@solana/spl-token'
 import { ProgramTestContext, Clock } from 'solana-bankrun'
 import { randomBytes } from 'crypto'

--- a/programs/sipher-vault/tests/sipher-vault/10-bankrun-classic-spl.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/10-bankrun-classic-spl.test.ts
@@ -1,0 +1,372 @@
+// tests/sipher-vault/10-bankrun-classic-spl.test.ts
+//
+// IDL-free bankrun regression baseline for the current (classic-SPL) sipher_vault.
+// Validates: initialize → createVaultToken/FeeToken → deposit → withdraw_private →
+//            refund (after timeout) → collect_fee.
+//
+// All account orders match lib.rs verbatim. No Anchor IDL or TS client.
+
+import { assert } from 'chai'
+import { Keypair, PublicKey, SystemProgram } from '@solana/web3.js'
+import {
+  TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  createInitializeMintInstruction,
+  createAssociatedTokenAccountInstruction,
+  createAssociatedTokenAccountIdempotentInstruction,
+  createMintToInstruction,
+  getAssociatedTokenAddressSync,
+  getMintLen,
+  MintLayout,
+} from '@solana/spl-token'
+import { ProgramTestContext, Clock } from 'solana-bankrun'
+import { randomBytes } from 'crypto'
+
+import {
+  getVaultConfigPDA,
+  getDepositRecordPDA,
+  getVaultTokenPDA,
+  getFeeTokenPDA,
+  getSipConfigPDA,
+  getSipTransferRecordPDA,
+} from './setup'
+
+import {
+  VAULT_PROGRAM_ID,
+  disc,
+  u64le,
+  startVault,
+  sendIx,
+  getAccountData,
+  parseDepositRecord,
+  parseVaultConfig,
+  parseSipConfig,
+  ixInitialize,
+  ixCreateVaultToken,
+  ixCreateFeeToken,
+  ixDeposit,
+  ixWithdrawPrivate,
+  ixRefund,
+  ixCollectFee,
+  ixSipPrivacyInitialize,
+} from './bankrun-helpers'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const FEE_BPS = 10         // 10 bps = 0.1%
+const REFUND_TIMEOUT = 5n  // 5-second timeout for fast test iteration
+
+const DEPOSIT_AMOUNT = 500_000n
+const WITHDRAW_AMOUNT = 200_000n  // partial withdrawal to leave a refundable balance
+
+// Expected fee on withdrawal: floor(WITHDRAW_AMOUNT * FEE_BPS / 10_000)
+const EXPECTED_FEE = WITHDRAW_AMOUNT * BigInt(FEE_BPS) / 10_000n
+const EXPECTED_NET = WITHDRAW_AMOUNT - EXPECTED_FEE
+
+// Mint space for classic SPL (82 bytes)
+const MINT_SPACE = 82
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test suite
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('10 · bankrun classic-SPL regression baseline', function () {
+  this.timeout(120_000) // cold Anchor build + bankrun startup
+
+  let ctx: ProgramTestContext
+  let authority: Keypair  // bankrun payer — authority + mint authority + depositor
+  let mintKp: Keypair
+  let mint: PublicKey
+  let depositorAta: PublicKey
+  let stealthKp: Keypair
+  let stealthAta: PublicKey
+  let authorityAta: PublicKey // for collect_fee assertion
+
+  const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+
+  // ── before: initialize bankrun + setup mint + vault ───────────────────────
+
+  before(async function () {
+    // startVault spins up bankrun + loads sipher_vault (workspace binary) +
+    // sip_privacy (tests/fixtures/sip_privacy.so by name).
+    ctx = await startVault()
+    authority = ctx.payer // funded with 1,000,000,000 SOL by bankrun
+
+    mintKp = Keypair.generate()
+    mint = mintKp.publicKey
+    stealthKp = Keypair.generate()
+
+    // 1. Create classic SPL mint (2 ixs: create-account + init-mint)
+    const rent = await ctx.banksClient.getRent()
+    // rent.minimumBalance returns bigint; SystemProgram.createAccount needs number
+    const mintLamports = Number(rent.minimumBalance(BigInt(MINT_SPACE)))
+
+    await sendIx(ctx, [
+      SystemProgram.createAccount({
+        fromPubkey: authority.publicKey,
+        newAccountPubkey: mint,
+        lamports: mintLamports,
+        space: MINT_SPACE,
+        programId: TOKEN_PROGRAM_ID,
+      }),
+      createInitializeMintInstruction(
+        mint,
+        6,             // decimals
+        authority.publicKey,  // mint authority
+        null,          // freeze authority
+      ),
+    ], [authority, mintKp])
+
+    // 2. Create depositor ATA + stealth ATA + authority ATA
+    depositorAta = getAssociatedTokenAddressSync(mint, authority.publicKey)
+    stealthAta = getAssociatedTokenAddressSync(mint, stealthKp.publicKey)
+    authorityAta = getAssociatedTokenAddressSync(mint, authority.publicKey)
+    // depositorAta === authorityAta since payer == authority, which is fine
+
+    await sendIx(ctx, [
+      createAssociatedTokenAccountInstruction(
+        authority.publicKey, depositorAta, authority.publicKey, mint,
+      ),
+      createAssociatedTokenAccountInstruction(
+        authority.publicKey, stealthAta, stealthKp.publicKey, mint,
+      ),
+    ], [authority])
+
+    // 3. Mint tokens to depositor ATA
+    await sendIx(ctx, [
+      createMintToInstruction(mint, depositorAta, authority.publicKey, DEPOSIT_AMOUNT * 2n),
+    ], [authority])
+
+    // 4. Initialize sip_privacy config (prerequisite for CPI in withdraw_private)
+    await sendIx(ctx, [
+      ixSipPrivacyInitialize(authority.publicKey, 50), // 50 bps = sip_privacy default
+    ], [authority])
+
+    // 5. Initialize vault (fee=10 bps, timeout=5s)
+    await sendIx(ctx, [
+      ixInitialize(authority.publicKey, FEE_BPS, REFUND_TIMEOUT),
+    ], [authority])
+
+    // 6. Create vault token PDA + fee token PDA for the mint
+    await sendIx(ctx, [
+      ixCreateVaultToken(mint, authority.publicKey),
+    ], [authority])
+
+    await sendIx(ctx, [
+      ixCreateFeeToken(mint, authority.publicKey),
+    ], [authority])
+  })
+
+  // ── it: deposit 500_000 ───────────────────────────────────────────────────
+
+  it('deposit 500_000 → balance and vault_token match', async function () {
+    await sendIx(ctx, [
+      ixDeposit(authority.publicKey, depositorAta, mint, DEPOSIT_AMOUNT),
+    ], [authority])
+
+    // Assert DepositRecord.balance
+    const [depositRecordPda] = getDepositRecordPDA(authority.publicKey, mint, VAULT_PROGRAM_ID)
+    const recData = await getAccountData(ctx, depositRecordPda)
+    const rec = parseDepositRecord(recData)
+
+    assert.strictEqual(rec.balance, DEPOSIT_AMOUNT, 'deposit_record.balance mismatch')
+    assert.strictEqual(rec.lockedAmount, 0n, 'locked_amount should be 0 after deposit')
+    assert.strictEqual(rec.cumulativeVolume, DEPOSIT_AMOUNT, 'cumulative_volume mismatch')
+    assert.ok(rec.depositor.equals(authority.publicKey), 'depositor pubkey mismatch')
+    assert.ok(rec.tokenMint.equals(mint), 'token_mint mismatch')
+
+    // Assert vault_token balance
+    const [vaultTokenPda] = getVaultTokenPDA(mint, VAULT_PROGRAM_ID)
+    const vaultAcct = await ctx.banksClient.getAccount(vaultTokenPda)
+    assert.ok(vaultAcct, 'vault_token PDA not found')
+    // Token account data: 32(mint) + 32(owner) + 8(amount) at offset 64
+    const vaultBalance = Buffer.from(vaultAcct.data).readBigUInt64LE(64)
+    assert.strictEqual(vaultBalance, DEPOSIT_AMOUNT, 'vault_token balance mismatch')
+  })
+
+  // ── it: VaultConfig initialized correctly ────────────────────────────────
+
+  it('VaultConfig reflects fee_bps and refund_timeout', async function () {
+    const cfgData = await getAccountData(ctx, configPda)
+    const cfg = parseVaultConfig(cfgData)
+
+    assert.strictEqual(cfg.feeBps, FEE_BPS, 'fee_bps mismatch')
+    assert.strictEqual(cfg.refundTimeout, REFUND_TIMEOUT, 'refund_timeout mismatch')
+    assert.strictEqual(cfg.paused, false, 'paused should be false')
+    assert.strictEqual(cfg.totalDeposits, 1n, 'total_deposits should be 1')
+    assert.strictEqual(cfg.totalDepositors, 1n, 'total_depositors should be 1 for new depositor')
+    assert.ok(cfg.authority.equals(authority.publicKey), 'authority mismatch')
+  })
+
+  // ── it: withdraw_private → stealth gets net, fee_token gets fee ──────────
+
+  it('withdraw_private → net to stealth, fee to fee_token, TransferRecord PDA created', async function () {
+    // Snapshot vault and fee token balances before
+    const [vaultTokenPda] = getVaultTokenPDA(mint, VAULT_PROGRAM_ID)
+    const [feeTokenPda] = getFeeTokenPDA(mint, VAULT_PROGRAM_ID)
+
+    const vaultBefore = Buffer.from((await ctx.banksClient.getAccount(vaultTokenPda))!.data).readBigUInt64LE(64)
+    const feeBefore = Buffer.from((await ctx.banksClient.getAccount(feeTokenPda))!.data).readBigUInt64LE(64)
+
+    // Read sip_privacy total_transfers to derive the correct TransferRecord PDA
+    const [sipConfigPda] = getSipConfigPDA()
+    const sipCfgData = await getAccountData(ctx, sipConfigPda)
+    const { totalTransfers } = parseSipConfig(sipCfgData)
+
+    const [sipTransferRecordPda] = getSipTransferRecordPDA(authority.publicKey, totalTransfers)
+
+    // Deterministic dummy stealth params (not cryptographically meaningful for test)
+    const amountCommitment = Buffer.concat([Buffer.from([0x02]), randomBytes(32)]) // 33 bytes
+    const ephemeralPubkey = Buffer.concat([Buffer.from([0x02]), randomBytes(32)])  // 33 bytes
+    const viewingKeyHash = randomBytes(32) // 32 bytes
+    const encryptedAmount = Buffer.from([]) // empty
+    const proof = Buffer.from([])           // empty (stub-verified by program)
+
+    await sendIx(ctx, [
+      ixWithdrawPrivate(
+        authority.publicKey,
+        stealthAta,
+        mint,
+        sipTransferRecordPda,
+        WITHDRAW_AMOUNT,
+        amountCommitment,
+        stealthKp.publicKey,
+        ephemeralPubkey,
+        viewingKeyHash,
+        encryptedAmount,
+        proof,
+      ),
+    ], [authority])
+
+    // ── Assert: stealth_token received net amount ──
+    const stealthAcct = await ctx.banksClient.getAccount(stealthAta)
+    assert.ok(stealthAcct, 'stealth_token account not found')
+    const stealthBalance = Buffer.from(stealthAcct.data).readBigUInt64LE(64)
+    assert.strictEqual(stealthBalance, EXPECTED_NET, `stealth_token balance: expected ${EXPECTED_NET}, got ${stealthBalance}`)
+
+    // ── Assert: fee_token accumulated the fee ──
+    const feeAcct = await ctx.banksClient.getAccount(feeTokenPda)
+    assert.ok(feeAcct, 'fee_token account not found')
+    const feeBalance = Buffer.from(feeAcct.data).readBigUInt64LE(64)
+    const feeDelta = feeBalance - feeBefore
+    assert.strictEqual(feeDelta, EXPECTED_FEE, `fee_token delta: expected ${EXPECTED_FEE}, got ${feeDelta}`)
+
+    // ── Assert: vault_token reduced by full WITHDRAW_AMOUNT ──
+    const vaultAcct = await ctx.banksClient.getAccount(vaultTokenPda)
+    const vaultAfter = Buffer.from(vaultAcct!.data).readBigUInt64LE(64)
+    assert.strictEqual(
+      vaultBefore - vaultAfter,
+      WITHDRAW_AMOUNT,
+      `vault reduction: expected ${WITHDRAW_AMOUNT}, got ${vaultBefore - vaultAfter}`,
+    )
+
+    // ── Assert: DepositRecord.balance reduced ──
+    const [depositRecordPda] = getDepositRecordPDA(authority.publicKey, mint, VAULT_PROGRAM_ID)
+    const recData = await getAccountData(ctx, depositRecordPda)
+    const rec = parseDepositRecord(recData)
+    assert.strictEqual(
+      rec.balance,
+      DEPOSIT_AMOUNT - WITHDRAW_AMOUNT,
+      `deposit_record.balance after withdrawal mismatch`,
+    )
+
+    // ── Assert: sip_privacy TransferRecord PDA was created by CPI ──
+    const transferRecord = await ctx.banksClient.getAccount(sipTransferRecordPda)
+    assert.ok(transferRecord, 'sip_privacy TransferRecord PDA not created — CPI failed')
+    assert.ok(
+      new PublicKey(transferRecord.owner).equals(
+        new PublicKey('S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at'),
+      ),
+      'TransferRecord owner should be sip_privacy program',
+    )
+  })
+
+  // ── it: refund after timeout ─────────────────────────────────────────────
+
+  it('refund after timeout → depositor receives remaining balance', async function () {
+    const [depositRecordPda] = getDepositRecordPDA(authority.publicKey, mint, VAULT_PROGRAM_ID)
+    const [vaultTokenPda] = getVaultTokenPDA(mint, VAULT_PROGRAM_ID)
+
+    // Read current deposit record to know what's available
+    const recBefore = parseDepositRecord(await getAccountData(ctx, depositRecordPda))
+    const available = recBefore.balance - recBefore.lockedAmount
+    assert.ok(available > 0n, 'nothing to refund — test state error')
+
+    // Snapshot depositor ATA before refund
+    const depositorAcctBefore = await ctx.banksClient.getAccount(depositorAta)
+    const depositorBalBefore = Buffer.from(depositorAcctBefore!.data).readBigUInt64LE(64)
+
+    // Advance clock beyond refund_timeout to pass on-chain check
+    const currentClock = await ctx.banksClient.getClock()
+    const newClock = new Clock(
+      currentClock.slot,
+      currentClock.epochStartTimestamp,
+      currentClock.epoch,
+      currentClock.leaderScheduleEpoch,
+      // unix_timestamp past last_deposit_at + REFUND_TIMEOUT
+      recBefore.lastDepositAt + REFUND_TIMEOUT + 10n,
+    )
+    ctx.setClock(newClock)
+
+    await sendIx(ctx, [
+      ixRefund(authority.publicKey, depositorAta, mint),
+    ], [authority])
+
+    // ── Assert: depositor ATA received the refund ──
+    const depositorAcctAfter = await ctx.banksClient.getAccount(depositorAta)
+    const depositorBalAfter = Buffer.from(depositorAcctAfter!.data).readBigUInt64LE(64)
+    assert.strictEqual(
+      depositorBalAfter - depositorBalBefore,
+      available,
+      `depositor did not receive correct refund amount`,
+    )
+
+    // ── Assert: DepositRecord.balance is now 0 (locked_amount was 0) ──
+    const recAfter = parseDepositRecord(await getAccountData(ctx, depositRecordPda))
+    assert.strictEqual(recAfter.balance, 0n, 'deposit_record.balance should be 0 after full refund')
+
+    // ── Assert: vault_token balance reduced accordingly ──
+    const vaultAcct = await ctx.banksClient.getAccount(vaultTokenPda)
+    const vaultBalance = Buffer.from(vaultAcct!.data).readBigUInt64LE(64)
+    // vault should hold only the fee that was already collected into fee_token
+    // vault = original_deposit - withdraw_amount - refund
+    //       = DEPOSIT_AMOUNT - WITHDRAW_AMOUNT - available = 0
+    assert.strictEqual(vaultBalance, 0n, 'vault_token should be empty after refund')
+  })
+
+  // ── it: collect_fee → authority receives fee ─────────────────────────────
+
+  it('collect_fee → authority token account receives accumulated fees', async function () {
+    const [feeTokenPda] = getFeeTokenPDA(mint, VAULT_PROGRAM_ID)
+
+    // Snapshot fee_token balance
+    const feeAcctBefore = await ctx.banksClient.getAccount(feeTokenPda)
+    const feeBal = Buffer.from(feeAcctBefore!.data).readBigUInt64LE(64)
+    assert.ok(feeBal > 0n, 'fee_token is empty — nothing to collect (test state error)')
+
+    // Snapshot authority ATA before collect
+    const authAcctBefore = await ctx.banksClient.getAccount(authorityAta)
+    const authBalBefore = Buffer.from(authAcctBefore!.data).readBigUInt64LE(64)
+
+    // collect_fee(0) = drain all
+    await sendIx(ctx, [
+      ixCollectFee(authority.publicKey, authorityAta, mint, 0n),
+    ], [authority])
+
+    // ── Assert: authority ATA received all fees ──
+    const authAcctAfter = await ctx.banksClient.getAccount(authorityAta)
+    const authBalAfter = Buffer.from(authAcctAfter!.data).readBigUInt64LE(64)
+    assert.strictEqual(
+      authBalAfter - authBalBefore,
+      feeBal,
+      `authority did not receive all fees: expected ${feeBal}, got ${authBalAfter - authBalBefore}`,
+    )
+
+    // ── Assert: fee_token is empty ──
+    const feeAcctAfter = await ctx.banksClient.getAccount(feeTokenPda)
+    const feeBalAfter = Buffer.from(feeAcctAfter!.data).readBigUInt64LE(64)
+    assert.strictEqual(feeBalAfter, 0n, 'fee_token should be empty after collect_fee(0)')
+  })
+})

--- a/programs/sipher-vault/tests/sipher-vault/11-token2022-allowlist.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/11-token2022-allowlist.test.ts
@@ -28,7 +28,8 @@ import {
 } from '@solana/spl-token'
 import { ProgramTestContext } from 'solana-bankrun'
 
-import { ixInitialize, ixCreateVaultToken, sendIx, startVault } from './bankrun-helpers'
+import { ixInitialize, ixCreateVaultToken, sendIx, startVault, VAULT_PROGRAM_ID } from './bankrun-helpers'
+import { getVaultTokenPDA } from './setup'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Constants
@@ -76,7 +77,7 @@ async function assertUnsupportedMintExtension(fn: () => Promise<void>): Promise<
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('11 · Token-2022 extension allowlist (fail-closed)', function () {
-  this.timeout(180_000) // anchor build + bankrun startup
+  this.timeout(30_000)
 
   let ctx: ProgramTestContext
   let authority: Keypair
@@ -120,7 +121,16 @@ describe('11 · Token-2022 extension allowlist (fail-closed)', function () {
     await sendIx(ctx, [
       ixCreateVaultToken(mintKp.publicKey, authority.publicKey, TOKEN_2022_PROGRAM_ID),
     ], [authority])
-    // No assertion needed — no throw = pass
+
+    // Assert vault token PDA was actually created and is owned by the program
+    const [vaultTokenPda] = getVaultTokenPDA(mintKp.publicKey, VAULT_PROGRAM_ID)
+    const pdaAccount = await ctx.banksClient.getAccount(vaultTokenPda)
+    assert.isNotNull(pdaAccount, 'vault token PDA should exist after create_vault_token')
+    assert.strictEqual(
+      pdaAccount!.owner.toBase58(),
+      TOKEN_2022_PROGRAM_ID.toBase58(),
+      'vault token PDA should be owned by Token-2022 program',
+    )
   })
 
   // ── ACCEPT: MetadataPointer ─────────────────────────────────────────────
@@ -160,7 +170,16 @@ describe('11 · Token-2022 extension allowlist (fail-closed)', function () {
     await sendIx(ctx, [
       ixCreateVaultToken(mintKp.publicKey, authority.publicKey, TOKEN_2022_PROGRAM_ID),
     ], [authority])
-    // No assertion needed — no throw = pass
+
+    // Assert vault token PDA was actually created and is owned by the program
+    const [vaultTokenPda] = getVaultTokenPDA(mintKp.publicKey, VAULT_PROGRAM_ID)
+    const pdaAccount = await ctx.banksClient.getAccount(vaultTokenPda)
+    assert.isNotNull(pdaAccount, 'vault token PDA should exist after create_vault_token')
+    assert.strictEqual(
+      pdaAccount!.owner.toBase58(),
+      TOKEN_2022_PROGRAM_ID.toBase58(),
+      'vault token PDA should be owned by Token-2022 program',
+    )
   })
 
   // ── REJECT: PermanentDelegate ───────────────────────────────────────────

--- a/programs/sipher-vault/tests/sipher-vault/11-token2022-allowlist.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/11-token2022-allowlist.test.ts
@@ -1,0 +1,397 @@
+// tests/sipher-vault/11-token2022-allowlist.test.ts
+//
+// TDD — Task 4: fail-closed Token-2022 extension allowlist.
+//
+// The vault's create_vault_token instruction must:
+//   ACCEPT — plain T2022 (no extensions) and MetadataPointer
+//   REJECT  — PermanentDelegate, TransferFeeConfig, TransferHook,
+//             NonTransferable, DefaultAccountState, MintCloseAuthority
+//
+// All tests use fresh mints per case. The vault config is shared (initialized
+// once in before()). Error code for UnsupportedMintExtension: 6012 (0x177c).
+
+import { assert } from 'chai'
+import { Keypair, SystemProgram } from '@solana/web3.js'
+import {
+  TOKEN_2022_PROGRAM_ID,
+  getMintLen,
+  ExtensionType,
+  createInitializeMintInstruction,
+  createInitializeTransferFeeConfigInstruction,
+  createInitializePermanentDelegateInstruction,
+  createInitializeNonTransferableMintInstruction,
+  createInitializeDefaultAccountStateInstruction,
+  createInitializeTransferHookInstruction,
+  createInitializeMetadataPointerInstruction,
+  createInitializeMintCloseAuthorityInstruction,
+  AccountState,
+} from '@solana/spl-token'
+import { ProgramTestContext } from 'solana-bankrun'
+
+import { ixInitialize, ixCreateVaultToken, sendIx, startVault } from './bankrun-helpers'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Anchor custom errors start at 6000. UnsupportedMintExtension is index 12.
+const UNSUPPORTED_MINT_EXTENSION_CODE = 6012
+// Hex representation for log/message matching
+const UNSUPPORTED_MINT_EXTENSION_HEX = (UNSUPPORTED_MINT_EXTENSION_CODE).toString(16) // '177c'
+
+const FEE_BPS = 10
+const REFUND_TIMEOUT = 86400n // 24h — not relevant for these tests
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Assert a promise rejects with UnsupportedMintExtension (6012 / 0x177c).
+ * Bankrun embeds the error code in the transaction failure message.
+ */
+async function assertUnsupportedMintExtension(fn: () => Promise<void>): Promise<void> {
+  try {
+    await fn()
+    assert.fail('Expected transaction to fail with UnsupportedMintExtension but it succeeded')
+  } catch (e: unknown) {
+    const err = e as Error
+    if (err.message && err.message.includes('Expected transaction to fail')) {
+      throw err // re-throw the assert.fail
+    }
+    const msg = (err?.message ?? String(err)).toLowerCase()
+    const matchesCode =
+      msg.includes(String(UNSUPPORTED_MINT_EXTENSION_CODE)) ||
+      msg.includes(UNSUPPORTED_MINT_EXTENSION_HEX) ||
+      msg.includes('unsupportedmintextension')
+    assert.ok(
+      matchesCode,
+      `Expected UnsupportedMintExtension (${UNSUPPORTED_MINT_EXTENSION_CODE} / 0x${UNSUPPORTED_MINT_EXTENSION_HEX}), got: ${err?.message ?? String(err)}`,
+    )
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test suite
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('11 · Token-2022 extension allowlist (fail-closed)', function () {
+  this.timeout(180_000) // anchor build + bankrun startup
+
+  let ctx: ProgramTestContext
+  let authority: Keypair
+
+  // ── before: spin up bankrun + initialize vault config ───────────────────
+
+  before(async function () {
+    ctx = await startVault()
+    authority = ctx.payer
+
+    await sendIx(ctx, [
+      ixInitialize(authority.publicKey, FEE_BPS, REFUND_TIMEOUT),
+    ], [authority])
+  })
+
+  // ── ACCEPT: plain T2022 (no extensions) ────────────────────────────────
+
+  it('ACCEPT: plain T2022 mint (no extensions) → create_vault_token succeeds', async function () {
+    const mintKp = Keypair.generate()
+    const space = getMintLen([]) // 82 bytes — classic mint layout, T2022-owned
+    const rent = await ctx.banksClient.getRent()
+    const mintLamports = Number(rent.minimumBalance(BigInt(space)))
+
+    await sendIx(ctx, [
+      SystemProgram.createAccount({
+        fromPubkey: authority.publicKey,
+        newAccountPubkey: mintKp.publicKey,
+        lamports: mintLamports,
+        space,
+        programId: TOKEN_2022_PROGRAM_ID,
+      }),
+      createInitializeMintInstruction(
+        mintKp.publicKey,
+        6,
+        authority.publicKey,
+        null,
+        TOKEN_2022_PROGRAM_ID,
+      ),
+    ], [authority, mintKp])
+
+    await sendIx(ctx, [
+      ixCreateVaultToken(mintKp.publicKey, authority.publicKey, TOKEN_2022_PROGRAM_ID),
+    ], [authority])
+    // No assertion needed — no throw = pass
+  })
+
+  // ── ACCEPT: MetadataPointer ─────────────────────────────────────────────
+
+  it('ACCEPT: MetadataPointer mint → create_vault_token succeeds', async function () {
+    const mintKp = Keypair.generate()
+    const extTypes = [ExtensionType.MetadataPointer]
+    const space = getMintLen(extTypes)
+    const rent = await ctx.banksClient.getRent()
+    const mintLamports = Number(rent.minimumBalance(BigInt(space)))
+
+    const metadataPointerIx = createInitializeMetadataPointerInstruction(
+      mintKp.publicKey,
+      authority.publicKey,       // authority
+      mintKp.publicKey,          // metadataAddress = mint itself (standard pattern)
+      TOKEN_2022_PROGRAM_ID,
+    )
+
+    await sendIx(ctx, [
+      SystemProgram.createAccount({
+        fromPubkey: authority.publicKey,
+        newAccountPubkey: mintKp.publicKey,
+        lamports: mintLamports,
+        space,
+        programId: TOKEN_2022_PROGRAM_ID,
+      }),
+      metadataPointerIx,
+      createInitializeMintInstruction(
+        mintKp.publicKey,
+        6,
+        authority.publicKey,
+        null,
+        TOKEN_2022_PROGRAM_ID,
+      ),
+    ], [authority, mintKp])
+
+    await sendIx(ctx, [
+      ixCreateVaultToken(mintKp.publicKey, authority.publicKey, TOKEN_2022_PROGRAM_ID),
+    ], [authority])
+    // No assertion needed — no throw = pass
+  })
+
+  // ── REJECT: PermanentDelegate ───────────────────────────────────────────
+
+  it('REJECT: PermanentDelegate mint → create_vault_token fails with UnsupportedMintExtension', async function () {
+    const mintKp = Keypair.generate()
+    const extTypes = [ExtensionType.PermanentDelegate]
+    const space = getMintLen(extTypes)
+    const rent = await ctx.banksClient.getRent()
+    const mintLamports = Number(rent.minimumBalance(BigInt(space)))
+
+    await sendIx(ctx, [
+      SystemProgram.createAccount({
+        fromPubkey: authority.publicKey,
+        newAccountPubkey: mintKp.publicKey,
+        lamports: mintLamports,
+        space,
+        programId: TOKEN_2022_PROGRAM_ID,
+      }),
+      createInitializePermanentDelegateInstruction(
+        mintKp.publicKey,
+        authority.publicKey, // permanentDelegate
+        TOKEN_2022_PROGRAM_ID,
+      ),
+      createInitializeMintInstruction(
+        mintKp.publicKey,
+        6,
+        authority.publicKey,
+        null,
+        TOKEN_2022_PROGRAM_ID,
+      ),
+    ], [authority, mintKp])
+
+    await assertUnsupportedMintExtension(async () => {
+      await sendIx(ctx, [
+        ixCreateVaultToken(mintKp.publicKey, authority.publicKey, TOKEN_2022_PROGRAM_ID),
+      ], [authority])
+    })
+  })
+
+  // ── REJECT: TransferFeeConfig ───────────────────────────────────────────
+
+  it('REJECT: TransferFeeConfig mint → create_vault_token fails with UnsupportedMintExtension', async function () {
+    const mintKp = Keypair.generate()
+    const extTypes = [ExtensionType.TransferFeeConfig]
+    const space = getMintLen(extTypes)
+    const rent = await ctx.banksClient.getRent()
+    const mintLamports = Number(rent.minimumBalance(BigInt(space)))
+
+    await sendIx(ctx, [
+      SystemProgram.createAccount({
+        fromPubkey: authority.publicKey,
+        newAccountPubkey: mintKp.publicKey,
+        lamports: mintLamports,
+        space,
+        programId: TOKEN_2022_PROGRAM_ID,
+      }),
+      createInitializeTransferFeeConfigInstruction(
+        mintKp.publicKey,
+        authority.publicKey,   // transferFeeConfigAuthority
+        authority.publicKey,   // withdrawWithheldAuthority
+        100,                   // transferFeeBasisPoints
+        BigInt(1_000_000),     // maximumFee
+        TOKEN_2022_PROGRAM_ID,
+      ),
+      createInitializeMintInstruction(
+        mintKp.publicKey,
+        6,
+        authority.publicKey,
+        null,
+        TOKEN_2022_PROGRAM_ID,
+      ),
+    ], [authority, mintKp])
+
+    await assertUnsupportedMintExtension(async () => {
+      await sendIx(ctx, [
+        ixCreateVaultToken(mintKp.publicKey, authority.publicKey, TOKEN_2022_PROGRAM_ID),
+      ], [authority])
+    })
+  })
+
+  // ── REJECT: TransferHook ────────────────────────────────────────────────
+
+  it('REJECT: TransferHook mint → create_vault_token fails with UnsupportedMintExtension', async function () {
+    const mintKp = Keypair.generate()
+    const hookProgramId = Keypair.generate().publicKey // dummy hook program
+    const extTypes = [ExtensionType.TransferHook]
+    const space = getMintLen(extTypes)
+    const rent = await ctx.banksClient.getRent()
+    const mintLamports = Number(rent.minimumBalance(BigInt(space)))
+
+    await sendIx(ctx, [
+      SystemProgram.createAccount({
+        fromPubkey: authority.publicKey,
+        newAccountPubkey: mintKp.publicKey,
+        lamports: mintLamports,
+        space,
+        programId: TOKEN_2022_PROGRAM_ID,
+      }),
+      createInitializeTransferHookInstruction(
+        mintKp.publicKey,
+        authority.publicKey, // authority
+        hookProgramId,       // hook program
+        TOKEN_2022_PROGRAM_ID,
+      ),
+      createInitializeMintInstruction(
+        mintKp.publicKey,
+        6,
+        authority.publicKey,
+        null,
+        TOKEN_2022_PROGRAM_ID,
+      ),
+    ], [authority, mintKp])
+
+    await assertUnsupportedMintExtension(async () => {
+      await sendIx(ctx, [
+        ixCreateVaultToken(mintKp.publicKey, authority.publicKey, TOKEN_2022_PROGRAM_ID),
+      ], [authority])
+    })
+  })
+
+  // ── REJECT: NonTransferable ─────────────────────────────────────────────
+
+  it('REJECT: NonTransferable mint → create_vault_token fails with UnsupportedMintExtension', async function () {
+    const mintKp = Keypair.generate()
+    const extTypes = [ExtensionType.NonTransferable]
+    const space = getMintLen(extTypes)
+    const rent = await ctx.banksClient.getRent()
+    const mintLamports = Number(rent.minimumBalance(BigInt(space)))
+
+    await sendIx(ctx, [
+      SystemProgram.createAccount({
+        fromPubkey: authority.publicKey,
+        newAccountPubkey: mintKp.publicKey,
+        lamports: mintLamports,
+        space,
+        programId: TOKEN_2022_PROGRAM_ID,
+      }),
+      createInitializeNonTransferableMintInstruction(
+        mintKp.publicKey,
+        TOKEN_2022_PROGRAM_ID,
+      ),
+      createInitializeMintInstruction(
+        mintKp.publicKey,
+        6,
+        authority.publicKey,
+        null,
+        TOKEN_2022_PROGRAM_ID,
+      ),
+    ], [authority, mintKp])
+
+    await assertUnsupportedMintExtension(async () => {
+      await sendIx(ctx, [
+        ixCreateVaultToken(mintKp.publicKey, authority.publicKey, TOKEN_2022_PROGRAM_ID),
+      ], [authority])
+    })
+  })
+
+  // ── REJECT: DefaultAccountState ────────────────────────────────────────
+
+  it('REJECT: DefaultAccountState mint → create_vault_token fails with UnsupportedMintExtension', async function () {
+    const mintKp = Keypair.generate()
+    const extTypes = [ExtensionType.DefaultAccountState]
+    const space = getMintLen(extTypes)
+    const rent = await ctx.banksClient.getRent()
+    const mintLamports = Number(rent.minimumBalance(BigInt(space)))
+
+    await sendIx(ctx, [
+      SystemProgram.createAccount({
+        fromPubkey: authority.publicKey,
+        newAccountPubkey: mintKp.publicKey,
+        lamports: mintLamports,
+        space,
+        programId: TOKEN_2022_PROGRAM_ID,
+      }),
+      createInitializeDefaultAccountStateInstruction(
+        mintKp.publicKey,
+        AccountState.Frozen,   // default state = Frozen
+        TOKEN_2022_PROGRAM_ID,
+      ),
+      createInitializeMintInstruction(
+        mintKp.publicKey,
+        6,
+        authority.publicKey,
+        authority.publicKey, // freeze authority required by DefaultAccountState.Frozen
+        TOKEN_2022_PROGRAM_ID,
+      ),
+    ], [authority, mintKp])
+
+    await assertUnsupportedMintExtension(async () => {
+      await sendIx(ctx, [
+        ixCreateVaultToken(mintKp.publicKey, authority.publicKey, TOKEN_2022_PROGRAM_ID),
+      ], [authority])
+    })
+  })
+
+  // ── REJECT: MintCloseAuthority (unknown/non-listed) ─────────────────────
+
+  it('REJECT: MintCloseAuthority mint → create_vault_token fails with UnsupportedMintExtension', async function () {
+    const mintKp = Keypair.generate()
+    const extTypes = [ExtensionType.MintCloseAuthority]
+    const space = getMintLen(extTypes)
+    const rent = await ctx.banksClient.getRent()
+    const mintLamports = Number(rent.minimumBalance(BigInt(space)))
+
+    await sendIx(ctx, [
+      SystemProgram.createAccount({
+        fromPubkey: authority.publicKey,
+        newAccountPubkey: mintKp.publicKey,
+        lamports: mintLamports,
+        space,
+        programId: TOKEN_2022_PROGRAM_ID,
+      }),
+      createInitializeMintCloseAuthorityInstruction(
+        mintKp.publicKey,
+        authority.publicKey, // closeAuthority
+        TOKEN_2022_PROGRAM_ID,
+      ),
+      createInitializeMintInstruction(
+        mintKp.publicKey,
+        6,
+        authority.publicKey,
+        null,
+        TOKEN_2022_PROGRAM_ID,
+      ),
+    ], [authority, mintKp])
+
+    await assertUnsupportedMintExtension(async () => {
+      await sendIx(ctx, [
+        ixCreateVaultToken(mintKp.publicKey, authority.publicKey, TOKEN_2022_PROGRAM_ID),
+      ], [authority])
+    })
+  })
+})

--- a/programs/sipher-vault/tests/sipher-vault/11-token2022-allowlist.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/11-token2022-allowlist.test.ts
@@ -24,6 +24,7 @@ import {
   createInitializeTransferHookInstruction,
   createInitializeMetadataPointerInstruction,
   createInitializeMintCloseAuthorityInstruction,
+  createInitializeInterestBearingMintInstruction,
   AccountState,
 } from '@solana/spl-token'
 import { ProgramTestContext } from 'solana-bankrun'
@@ -158,6 +159,53 @@ describe('11 · Token-2022 extension allowlist (fail-closed)', function () {
         programId: TOKEN_2022_PROGRAM_ID,
       }),
       metadataPointerIx,
+      createInitializeMintInstruction(
+        mintKp.publicKey,
+        6,
+        authority.publicKey,
+        null,
+        TOKEN_2022_PROGRAM_ID,
+      ),
+    ], [authority, mintKp])
+
+    await sendIx(ctx, [
+      ixCreateVaultToken(mintKp.publicKey, authority.publicKey, TOKEN_2022_PROGRAM_ID),
+    ], [authority])
+
+    // Assert vault token PDA was actually created and is owned by the program
+    const [vaultTokenPda] = getVaultTokenPDA(mintKp.publicKey, VAULT_PROGRAM_ID)
+    const pdaAccount = await ctx.banksClient.getAccount(vaultTokenPda)
+    assert.isNotNull(pdaAccount, 'vault token PDA should exist after create_vault_token')
+    assert.strictEqual(
+      pdaAccount!.owner.toBase58(),
+      TOKEN_2022_PROGRAM_ID.toBase58(),
+      'vault token PDA should be owned by Token-2022 program',
+    )
+  })
+
+  // ── ACCEPT: InterestBearingConfig ───────────────────────────────────────
+
+  it('ACCEPT: InterestBearingConfig mint → create_vault_token succeeds', async function () {
+    const mintKp = Keypair.generate()
+    const extTypes = [ExtensionType.InterestBearingConfig]
+    const space = getMintLen(extTypes)
+    const rent = await ctx.banksClient.getRent()
+    const mintLamports = Number(rent.minimumBalance(BigInt(space)))
+
+    await sendIx(ctx, [
+      SystemProgram.createAccount({
+        fromPubkey: authority.publicKey,
+        newAccountPubkey: mintKp.publicKey,
+        lamports: mintLamports,
+        space,
+        programId: TOKEN_2022_PROGRAM_ID,
+      }),
+      createInitializeInterestBearingMintInstruction(
+        mintKp.publicKey,
+        authority.publicKey, // rateAuthority
+        100,                 // rate (bps) — interest is UI-only; raw vault accounting is unaffected
+        TOKEN_2022_PROGRAM_ID,
+      ),
       createInitializeMintInstruction(
         mintKp.publicKey,
         6,

--- a/programs/sipher-vault/tests/sipher-vault/12-native-sol.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/12-native-sol.test.ts
@@ -16,10 +16,11 @@ import { assert } from 'chai'
 import { Keypair, PublicKey } from '@solana/web3.js'
 import { ProgramTestContext } from 'solana-bankrun'
 
-import { getSolVaultPDA, getSolFeePDA, getDepositRecordPDA } from './setup'
+import { getSolVaultPDA, getSolFeePDA, getDepositRecordPDA, getVaultConfigPDA } from './setup'
 
 import {
   VAULT_PROGRAM_ID,
+  NATIVE_SOL_MINT,
   startVault,
   sendIx,
   ixInitialize,
@@ -27,10 +28,8 @@ import {
   ixDepositSol,
   getAccountData,
   parseDepositRecord,
+  parseVaultConfig,
 } from './bankrun-helpers'
-
-// NATIVE_SOL_MINT sentinel — all-zero pubkey
-const NATIVE_SOL_MINT = new PublicKey(new Uint8Array(32))
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Constants
@@ -137,19 +136,47 @@ describe('12 · native SOL vault track', function () {
       record.depositor.equals(authority.publicKey),
       `DepositRecord.depositor mismatch: expected ${authority.publicKey.toBase58()}, got ${record.depositor.toBase58()}`,
     )
+
+    // Assert VaultConfig counters — is_new=true means both incremented on first deposit
+    const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+    const configData = await getAccountData(ctx, configPda)
+    const config = parseVaultConfig(configData)
+
+    assert.strictEqual(
+      config.totalDeposits,
+      1n,
+      `VaultConfig.total_deposits mismatch: expected 1, got ${config.totalDeposits}`,
+    )
+    assert.strictEqual(
+      config.totalDepositors,
+      1n,
+      `VaultConfig.total_depositors mismatch: expected 1, got ${config.totalDepositors}`,
+    )
   })
 
-  it('deposit_sol → rejects zero-amount deposit with ZeroDeposit error', async function () {
+  // Anchor custom errors start at 6000; ZeroDeposit is index 4 → code 6004 (0x1774)
+  const ZERO_DEPOSIT_CODE = 6004
+  const ZERO_DEPOSIT_HEX = ZERO_DEPOSIT_CODE.toString(16) // '1774'
+
+  it('deposit_sol → rejects zero-amount deposit with ZeroDeposit error (6004 / 0x1774)', async function () {
     try {
       await sendIx(ctx, [
         ixDepositSol(authority.publicKey, 0n),
       ], [authority])
       assert.fail('Expected ZeroDeposit error but transaction succeeded')
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err)
+    } catch (e: unknown) {
+      const err = e as Error
+      if (err.message && err.message.includes('Expected ZeroDeposit error but transaction succeeded')) {
+        throw err // re-throw the assert.fail
+      }
+      const msg = (err?.message ?? String(err)).toLowerCase()
+      const matchesCode =
+        msg.includes(String(ZERO_DEPOSIT_CODE)) ||
+        msg.includes(ZERO_DEPOSIT_HEX) ||
+        msg.includes('zerodeposit')
       assert.ok(
-        msg.includes('ZeroDeposit') || msg.includes('Deposit amount must be greater than zero') || msg.includes('custom program error'),
-        `Expected ZeroDeposit error, got: ${msg}`,
+        matchesCode,
+        `Expected ZeroDeposit (${ZERO_DEPOSIT_CODE} / 0x${ZERO_DEPOSIT_HEX}), got: ${err?.message ?? String(err)}`,
       )
     }
   })

--- a/programs/sipher-vault/tests/sipher-vault/12-native-sol.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/12-native-sol.test.ts
@@ -1,0 +1,84 @@
+// tests/sipher-vault/12-native-sol.test.ts
+//
+// TDD — Task 5-9: native SOL vault track.
+// Tasks 6-9 will add more it() blocks below — the before() is shared for the
+// full native-SOL suite. This file owns the fixture for the native track.
+//
+// Task 5 scope: create_sol_vault
+//   - before(): startVault() + initialize + create_sol_vault
+//   - it(): both sol_vault PDA and sol_fee PDA exist, owned by vault program
+
+import { assert } from 'chai'
+import { Keypair, PublicKey } from '@solana/web3.js'
+import { ProgramTestContext } from 'solana-bankrun'
+
+import { getSolVaultPDA, getSolFeePDA } from './setup'
+
+import {
+  VAULT_PROGRAM_ID,
+  startVault,
+  sendIx,
+  ixInitialize,
+  ixCreateSolVault,
+} from './bankrun-helpers'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const FEE_BPS = 10
+const REFUND_TIMEOUT = 5n // 5-second timeout for fast test iteration
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Suite
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('12 · native SOL vault track', function () {
+  this.timeout(120_000) // cold Anchor build + bankrun startup
+
+  let ctx: ProgramTestContext
+  let authority: Keypair
+
+  // Pre-derive the PDAs once — used by all tasks in this suite
+  const [solVaultPda] = getSolVaultPDA(VAULT_PROGRAM_ID)
+  const [solFeePda] = getSolFeePDA(VAULT_PROGRAM_ID)
+
+  // ── before: initialize bankrun + vault config + create_sol_vault ──────────
+
+  before(async function () {
+    ctx = await startVault()
+    authority = ctx.payer // funded with 1,000,000,000 SOL by bankrun
+
+    // 1. Initialize vault config (fee=10 bps, timeout=5s)
+    await sendIx(ctx, [
+      ixInitialize(authority.publicKey, FEE_BPS, REFUND_TIMEOUT),
+    ], [authority])
+
+    // 2. Create the native-SOL vault + fee PDAs
+    await sendIx(ctx, [
+      ixCreateSolVault(authority.publicKey),
+    ], [authority])
+  })
+
+  // ── Task 5: create_sol_vault ─────────────────────────────────────────────
+
+  it('create_sol_vault → sol_vault and sol_fee PDAs exist and are program-owned', async function () {
+    // SolVault PDA must exist
+    const solVaultAcct = await ctx.banksClient.getAccount(solVaultPda)
+    assert.ok(solVaultAcct, 'sol_vault PDA not found — create_sol_vault did not initialize it')
+
+    // SolFee PDA must exist
+    const solFeeAcct = await ctx.banksClient.getAccount(solFeePda)
+    assert.ok(solFeeAcct, 'sol_fee PDA not found — create_sol_vault did not initialize it')
+
+    // Both must be owned by the vault program
+    assert.ok(
+      new PublicKey(solVaultAcct.owner).equals(VAULT_PROGRAM_ID),
+      `sol_vault owner mismatch: expected ${VAULT_PROGRAM_ID.toBase58()}, got ${new PublicKey(solVaultAcct.owner).toBase58()}`,
+    )
+    assert.ok(
+      new PublicKey(solFeeAcct.owner).equals(VAULT_PROGRAM_ID),
+      `sol_fee owner mismatch: expected ${VAULT_PROGRAM_ID.toBase58()}, got ${new PublicKey(solFeeAcct.owner).toBase58()}`,
+    )
+  })
+})

--- a/programs/sipher-vault/tests/sipher-vault/12-native-sol.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/12-native-sol.test.ts
@@ -526,6 +526,9 @@ describe('12 · native SOL vault track', function () {
 
     // Snapshot depositor lamports before refund (lamports live on the system account).
     const refunderBefore = BigInt((await ctx.banksClient.getAccount(refunder.publicKey))!.lamports)
+    // Snapshot sol_vault before refund — the vault side is exact (the depositor pays
+    // tx fees from their own account, but the vault debit is precisely `available`).
+    const solVaultBefore = BigInt((await ctx.banksClient.getAccount(solVaultPda))!.lamports)
 
     // Advance the clock past the refund_timeout to satisfy the on-chain check.
     const currentClock = await ctx.banksClient.getClock()
@@ -552,6 +555,14 @@ describe('12 · native SOL vault track', function () {
     assert.ok(
       lamportGain >= available - 10_000n && lamportGain <= available,
       `depositor lamport gain: expected ~+${available}, got +${lamportGain}`,
+    )
+
+    // ── sol_vault debited by exactly `available` (conservation — exact, no fee tolerance) ──
+    const solVaultAfter = BigInt((await ctx.banksClient.getAccount(solVaultPda))!.lamports)
+    assert.strictEqual(
+      solVaultBefore - solVaultAfter,
+      available,
+      `sol_vault lamport delta: expected -${available}, got -${solVaultBefore - solVaultAfter}`,
     )
 
     // ── record.balance == locked_amount (available portion zeroed) ──
@@ -635,6 +646,8 @@ describe('12 · native SOL vault track', function () {
 
     // Snapshot depositor lamports before the authority refund.
     const depositorBefore = BigInt((await ctx.banksClient.getAccount(authorityRefundDepositor.publicKey))!.lamports)
+    // Snapshot sol_vault before the refund (conservation: vault debit == depositor credit).
+    const solVaultBefore = BigInt((await ctx.banksClient.getAccount(solVaultPda))!.lamports)
 
     // Advance clock past the timeout.
     const currentClock3 = await ctx.banksClient.getClock()
@@ -659,6 +672,14 @@ describe('12 · native SOL vault track', function () {
       depositorAfter - depositorBefore,
       available3,
       `depositor lamport gain: expected +${available3}, got +${depositorAfter - depositorBefore}`,
+    )
+
+    // ── sol_vault debited by exactly the amount the depositor received (conservation) ──
+    const solVaultAfter = BigInt((await ctx.banksClient.getAccount(solVaultPda))!.lamports)
+    assert.strictEqual(
+      solVaultBefore - solVaultAfter,
+      available3,
+      `sol_vault lamport delta: expected -${available3}, got -${solVaultBefore - solVaultAfter}`,
     )
 
     // ── record.balance == locked_amount ──

--- a/programs/sipher-vault/tests/sipher-vault/12-native-sol.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/12-native-sol.test.ts
@@ -7,12 +7,16 @@
 // Task 5 scope: create_sol_vault
 //   - before(): startVault() + initialize + create_sol_vault
 //   - it(): both sol_vault PDA and sol_fee PDA exist, owned by vault program
+//
+// Task 6 scope: deposit_sol
+//   - it(): deposit 1_000_000 lamports → DepositRecord.balance + sol_vault lamport delta
+//   - it(): rejects zero-amount deposit
 
 import { assert } from 'chai'
 import { Keypair, PublicKey } from '@solana/web3.js'
 import { ProgramTestContext } from 'solana-bankrun'
 
-import { getSolVaultPDA, getSolFeePDA } from './setup'
+import { getSolVaultPDA, getSolFeePDA, getDepositRecordPDA } from './setup'
 
 import {
   VAULT_PROGRAM_ID,
@@ -20,7 +24,13 @@ import {
   sendIx,
   ixInitialize,
   ixCreateSolVault,
+  ixDepositSol,
+  getAccountData,
+  parseDepositRecord,
 } from './bankrun-helpers'
+
+// NATIVE_SOL_MINT sentinel — all-zero pubkey
+const NATIVE_SOL_MINT = new PublicKey(new Uint8Array(32))
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Constants
@@ -80,5 +90,67 @@ describe('12 · native SOL vault track', function () {
       new PublicKey(solFeeAcct.owner).equals(VAULT_PROGRAM_ID),
       `sol_fee owner mismatch: expected ${VAULT_PROGRAM_ID.toBase58()}, got ${new PublicKey(solFeeAcct.owner).toBase58()}`,
     )
+  })
+
+  // ── Task 6: deposit_sol ──────────────────────────────────────────────────
+
+  it('deposit_sol → DepositRecord balance equals deposited lamports and sol_vault lamports increase by exact amount', async function () {
+    const depositAmount = 1_000_000n // 1M lamports
+
+    // Read sol_vault lamports before deposit
+    const solVaultBefore = await ctx.banksClient.getAccount(solVaultPda)
+    assert.ok(solVaultBefore, 'sol_vault PDA not found before deposit')
+    const lamportsBefore = BigInt(solVaultBefore.lamports)
+
+    // Execute deposit
+    await sendIx(ctx, [
+      ixDepositSol(authority.publicKey, depositAmount),
+    ], [authority])
+
+    // Read sol_vault lamports after deposit
+    const solVaultAfter = await ctx.banksClient.getAccount(solVaultPda)
+    assert.ok(solVaultAfter, 'sol_vault PDA not found after deposit')
+    const lamportsAfter = BigInt(solVaultAfter.lamports)
+
+    // Assert lamport delta is exactly depositAmount
+    assert.strictEqual(
+      lamportsAfter - lamportsBefore,
+      depositAmount,
+      `sol_vault lamport delta mismatch: expected +${depositAmount}, got +${lamportsAfter - lamportsBefore}`,
+    )
+
+    // Assert DepositRecord balance
+    const [depositRecordPda] = getDepositRecordPDA(authority.publicKey, NATIVE_SOL_MINT, VAULT_PROGRAM_ID)
+    const recordData = await getAccountData(ctx, depositRecordPda)
+    const record = parseDepositRecord(recordData)
+
+    assert.strictEqual(
+      record.balance,
+      depositAmount,
+      `DepositRecord.balance mismatch: expected ${depositAmount}, got ${record.balance}`,
+    )
+    assert.ok(
+      record.tokenMint.equals(NATIVE_SOL_MINT),
+      `DepositRecord.token_mint mismatch: expected ${NATIVE_SOL_MINT.toBase58()}, got ${record.tokenMint.toBase58()}`,
+    )
+    assert.ok(
+      record.depositor.equals(authority.publicKey),
+      `DepositRecord.depositor mismatch: expected ${authority.publicKey.toBase58()}, got ${record.depositor.toBase58()}`,
+    )
+  })
+
+  it('deposit_sol → rejects zero-amount deposit with ZeroDeposit error', async function () {
+    try {
+      await sendIx(ctx, [
+        ixDepositSol(authority.publicKey, 0n),
+      ], [authority])
+      assert.fail('Expected ZeroDeposit error but transaction succeeded')
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err)
+      assert.ok(
+        msg.includes('ZeroDeposit') || msg.includes('Deposit amount must be greater than zero') || msg.includes('custom program error'),
+        `Expected ZeroDeposit error, got: ${msg}`,
+      )
+    }
   })
 })

--- a/programs/sipher-vault/tests/sipher-vault/12-native-sol.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/12-native-sol.test.ts
@@ -13,10 +13,18 @@
 //   - it(): rejects zero-amount deposit
 
 import { assert } from 'chai'
-import { Keypair, PublicKey } from '@solana/web3.js'
+import { Keypair, PublicKey, SystemProgram } from '@solana/web3.js'
 import { ProgramTestContext } from 'solana-bankrun'
+import { randomBytes } from 'crypto'
 
-import { getSolVaultPDA, getSolFeePDA, getDepositRecordPDA, getVaultConfigPDA } from './setup'
+import {
+  getSolVaultPDA,
+  getSolFeePDA,
+  getDepositRecordPDA,
+  getVaultConfigPDA,
+  getSipConfigPDA,
+  getSipTransferRecordPDA,
+} from './setup'
 
 import {
   VAULT_PROGRAM_ID,
@@ -26,9 +34,12 @@ import {
   ixInitialize,
   ixCreateSolVault,
   ixDepositSol,
+  ixWithdrawPrivateSol,
+  ixSipPrivacyInitialize,
   getAccountData,
   parseDepositRecord,
   parseVaultConfig,
+  parseSipConfig,
 } from './bankrun-helpers'
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -179,5 +190,289 @@ describe('12 · native SOL vault track', function () {
         `Expected ZeroDeposit (${ZERO_DEPOSIT_CODE} / 0x${ZERO_DEPOSIT_HEX}), got: ${err?.message ?? String(err)}`,
       )
     }
+  })
+
+  // ── Task 7: withdraw_private_sol ─────────────────────────────────────────
+  //
+  // High-risk: moves lamports OUT of the program-owned sol_vault PDA via checked
+  // lamport mutation. These tests use a dedicated depositor (`wd`) funded from the
+  // bankrun payer so they are independent of the deposit_sol tests above (which
+  // key their DepositRecord to `authority`). sip_privacy's Config PDA is NOT
+  // initialized by startVault(), so the first withdraw test bootstraps it (bankrun
+  // deploys sip_privacy.so but does not run its `initialize`).
+
+  // Anchor custom errors start at 6000. Enum order in errors.rs:
+  //   ProgramPaused=6000, Unauthorized=6001, InsufficientBalance=6002,
+  //   MathOverflow=6003, ZeroDeposit=6004, … , RentReserveViolation=6013.
+  const INSUFFICIENT_BALANCE_CODE = 6002
+  const INSUFFICIENT_BALANCE_HEX = INSUFFICIENT_BALANCE_CODE.toString(16) // '1772'
+  const RENT_RESERVE_CODE = 6013
+  const RENT_RESERVE_HEX = RENT_RESERVE_CODE.toString(16) // '177d'
+
+  const FEE_DENOM = 10_000n
+
+  // Dedicated withdraw depositor — funded once in a guarded helper below.
+  const wd = Keypair.generate()
+  let sipPrivacyInitialized = false
+
+  // Fund `wd` from the bankrun payer and (once) initialize sip_privacy Config.
+  async function ensureWithdrawSetup(): Promise<void> {
+    if (!sipPrivacyInitialized) {
+      // Bootstrap sip_privacy Config (CPI target for the announcement).
+      await sendIx(ctx, [
+        ixSipPrivacyInitialize(authority.publicKey, 50), // 50 bps = sip_privacy default
+      ], [authority])
+      // Fund the dedicated withdraw depositor (rent for DepositRecord + deposit + tx fees).
+      await sendIx(ctx, [
+        SystemProgram.transfer({
+          fromPubkey: authority.publicKey,
+          toPubkey: wd.publicKey,
+          lamports: 50_000_000, // generous: covers rent + deposits across all wd tests
+        }),
+      ], [authority])
+      sipPrivacyInitialized = true
+    }
+  }
+
+  // Build deterministic-but-valid announcement params. sip_privacy validates the
+  // commitment prefix is 0x02/0x03, so honor that (the 33-byte commitment is a
+  // compressed-point shape; the value is otherwise opaque to the program).
+  function announceParams() {
+    return {
+      amountCommitment: Buffer.concat([Buffer.from([0x02]), randomBytes(32)]), // 33 bytes
+      ephemeralPubkey: Buffer.concat([Buffer.from([0x02]), randomBytes(32)]),  // 33 bytes
+      viewingKeyHash: randomBytes(32),                                          // 32 bytes
+      encryptedAmount: Buffer.from([]),                                         // empty
+      proof: Buffer.from([]),                                                   // empty (stub-verified)
+    }
+  }
+
+  it('withdraw_private_sol → net to stealth, fee to sol_fee, vault debited, TransferRecord created', async function () {
+    await ensureWithdrawSetup()
+
+    const depositAmount = 1_000_000n
+    const withdrawAmount = 500_000n
+    const expectedFee = (withdrawAmount * BigInt(FEE_BPS)) / FEE_DENOM // floor → 500
+    const expectedNet = withdrawAmount - expectedFee                   // 499_500
+
+    // Deposit 1_000_000 from the dedicated withdraw depositor.
+    await sendIx(ctx, [ixDepositSol(wd.publicKey, depositAmount)], [wd])
+
+    // Snapshot sol_vault + sol_fee lamports before the withdrawal.
+    const solVaultBefore = BigInt((await ctx.banksClient.getAccount(solVaultPda))!.lamports)
+    const solFeeBefore = BigInt((await ctx.banksClient.getAccount(solFeePda))!.lamports)
+
+    // Stealth recipient. The on-chain program adds NO minimum-payout floor (spec
+    // §8), but the Solana runtime's post-transaction rent check rejects a tx that
+    // leaves a freshly-funded system account below the rent-exempt minimum
+    // (≈890_880 lamports for 0 data). A real stealth recipient already exists
+    // (created/funded by the relayer), so we pre-fund it to rent-exemption and
+    // then assert the *delta* from the withdrawal is exactly `net`.
+    const rent = await ctx.banksClient.getRent()
+    const stealthRentMin = rent.minimumBalance(0n)
+    const stealth = Keypair.generate().publicKey
+    await sendIx(ctx, [
+      SystemProgram.transfer({
+        fromPubkey: authority.publicKey,
+        toPubkey: stealth,
+        lamports: Number(stealthRentMin),
+      }),
+    ], [authority])
+    const stealthBefore = BigInt((await ctx.banksClient.getAccount(stealth))!.lamports)
+    assert.strictEqual(stealthBefore, stealthRentMin, 'stealth should be pre-funded to rent-exempt min')
+
+    // Derive the sip_privacy TransferRecord PDA from current total_transfers.
+    const [sipConfigPda] = getSipConfigPDA()
+    const { totalTransfers } = parseSipConfig(await getAccountData(ctx, sipConfigPda))
+    const [sipTransferRecordPda] = getSipTransferRecordPDA(wd.publicKey, totalTransfers)
+
+    const p = announceParams()
+    await sendIx(ctx, [
+      ixWithdrawPrivateSol(
+        wd.publicKey,
+        stealth,
+        sipTransferRecordPda,
+        withdrawAmount,
+        p.amountCommitment,
+        stealth, // stealth_pubkey arg == the recipient account here
+        p.ephemeralPubkey,
+        p.viewingKeyHash,
+        p.encryptedAmount,
+        p.proof,
+      ),
+    ], [wd])
+
+    // ── stealth received exactly net ──
+    const stealthAfter = BigInt((await ctx.banksClient.getAccount(stealth))!.lamports)
+    assert.strictEqual(
+      stealthAfter - BigInt(stealthBefore),
+      expectedNet,
+      `stealth lamport delta: expected +${expectedNet}, got +${stealthAfter - BigInt(stealthBefore)}`,
+    )
+
+    // ── sol_fee received exactly fee ──
+    const solFeeAfter = BigInt((await ctx.banksClient.getAccount(solFeePda))!.lamports)
+    assert.strictEqual(
+      solFeeAfter - solFeeBefore,
+      expectedFee,
+      `sol_fee lamport delta: expected +${expectedFee}, got +${solFeeAfter - solFeeBefore}`,
+    )
+
+    // ── sol_vault debited by the full gross amount ──
+    const solVaultAfter = BigInt((await ctx.banksClient.getAccount(solVaultPda))!.lamports)
+    assert.strictEqual(
+      solVaultBefore - solVaultAfter,
+      withdrawAmount,
+      `sol_vault lamport delta: expected -${withdrawAmount}, got -${solVaultBefore - solVaultAfter}`,
+    )
+
+    // ── DepositRecord.balance reduced by the gross amount ──
+    const [recordPda] = getDepositRecordPDA(wd.publicKey, NATIVE_SOL_MINT, VAULT_PROGRAM_ID)
+    const record = parseDepositRecord(await getAccountData(ctx, recordPda))
+    assert.strictEqual(
+      record.balance,
+      depositAmount - withdrawAmount, // 500_000
+      `DepositRecord.balance: expected ${depositAmount - withdrawAmount}, got ${record.balance}`,
+    )
+
+    // ── sip_privacy TransferRecord PDA created by the announcement CPI ──
+    const transferRecord = await ctx.banksClient.getAccount(sipTransferRecordPda)
+    assert.ok(transferRecord, 'sip_privacy TransferRecord PDA not created — announcement CPI failed')
+    assert.ok(
+      new PublicKey(transferRecord.owner).equals(
+        new PublicKey('S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at'),
+      ),
+      'TransferRecord owner should be the sip_privacy program',
+    )
+  })
+
+  it('withdraw_private_sol → rejects withdrawal exceeding available (InsufficientBalance 6002 / 0x1772)', async function () {
+    await ensureWithdrawSetup()
+
+    // After the happy path, wd's record balance is 500_000. Ask for more.
+    const [recordPda] = getDepositRecordPDA(wd.publicKey, NATIVE_SOL_MINT, VAULT_PROGRAM_ID)
+    const record = parseDepositRecord(await getAccountData(ctx, recordPda))
+    const overAsk = record.balance + 1n // 1 lamport above available
+
+    const [sipConfigPda] = getSipConfigPDA()
+    const { totalTransfers } = parseSipConfig(await getAccountData(ctx, sipConfigPda))
+    const [sipTransferRecordPda] = getSipTransferRecordPDA(wd.publicKey, totalTransfers)
+
+    const stealth = Keypair.generate().publicKey
+    const p = announceParams()
+
+    try {
+      await sendIx(ctx, [
+        ixWithdrawPrivateSol(
+          wd.publicKey, stealth, sipTransferRecordPda, overAsk,
+          p.amountCommitment, stealth, p.ephemeralPubkey, p.viewingKeyHash,
+          p.encryptedAmount, p.proof,
+        ),
+      ], [wd])
+      assert.fail('Expected InsufficientBalance error but transaction succeeded')
+    } catch (e: unknown) {
+      const err = e as Error
+      if (err.message && err.message.includes('Expected InsufficientBalance error but transaction succeeded')) {
+        throw err
+      }
+      const msg = (err?.message ?? String(err)).toLowerCase()
+      const matchesCode =
+        msg.includes(String(INSUFFICIENT_BALANCE_CODE)) ||
+        msg.includes(INSUFFICIENT_BALANCE_HEX) ||
+        msg.includes('insufficientbalance')
+      assert.ok(
+        matchesCode,
+        `Expected InsufficientBalance (${INSUFFICIENT_BALANCE_CODE} / 0x${INSUFFICIENT_BALANCE_HEX}), got: ${err?.message ?? String(err)}`,
+      )
+    }
+  })
+
+  it('withdraw_private_sol → rent guard fires when vault lamports are desynced below backing (RentReserveViolation 6013 / 0x177d)', async function () {
+    await ensureWithdrawSetup()
+
+    // Use a FRESH depositor so `available` is large and unrelated to wd's balance.
+    const rentDepositor = Keypair.generate()
+    await sendIx(ctx, [
+      SystemProgram.transfer({
+        fromPubkey: authority.publicKey,
+        toPubkey: rentDepositor.publicKey,
+        lamports: 10_000_000,
+      }),
+    ], [authority])
+
+    // (a) Deposit 1_000_000 so the depositor's available balance ≫ the tiny withdraw.
+    await sendIx(ctx, [ixDepositSol(rentDepositor.publicKey, 1_000_000n)], [rentDepositor])
+
+    // (b) Read the SolVault account, compute its rent-exempt minimum, then desync:
+    //     lower the vault's lamports to (rent_min + 100) while preserving its real
+    //     data + owner. This makes the *backing* lamports inconsistent with the
+    //     accounting (Σ balances), so a withdrawal that the balance check allows
+    //     can still breach the rent floor.
+    const solVaultAcct = (await ctx.banksClient.getAccount(solVaultPda))!
+    const rent = await ctx.banksClient.getRent()
+    const rentMin = rent.minimumBalance(BigInt(solVaultAcct.data.length)) // data = 8 + 1 = 9 bytes
+
+    // Snapshot the real account to restore afterward (keep the file order-independent).
+    const originalLamports = BigInt(solVaultAcct.lamports)
+    const originalData = Buffer.from(solVaultAcct.data)
+    const originalOwner = new PublicKey(solVaultAcct.owner)
+    const originalRentEpoch = solVaultAcct.rentEpoch
+    const originalExecutable = solVaultAcct.executable
+
+    ctx.setAccount(solVaultPda, {
+      lamports: Number(rentMin + 100n),
+      data: originalData,
+      owner: originalOwner,
+      executable: originalExecutable,
+      rentEpoch: originalRentEpoch,
+    })
+
+    // (c) Withdraw 200 lamports:
+    //   available (1_000_000) ≥ 200             → passes InsufficientBalance check
+    //   checked_sub(rentMin+100 − 200) ≥ 0      → no MathOverflow (rentMin ≫ 200)
+    //   (rentMin+100 − 200) < rentMin           → RentReserveViolation fires
+    const [sipConfigPda] = getSipConfigPDA()
+    const { totalTransfers } = parseSipConfig(await getAccountData(ctx, sipConfigPda))
+    const [sipTransferRecordPda] = getSipTransferRecordPDA(rentDepositor.publicKey, totalTransfers)
+
+    const stealth = Keypair.generate().publicKey
+    const p = announceParams()
+
+    let threw = false
+    try {
+      await sendIx(ctx, [
+        ixWithdrawPrivateSol(
+          rentDepositor.publicKey, stealth, sipTransferRecordPda, 200n,
+          p.amountCommitment, stealth, p.ephemeralPubkey, p.viewingKeyHash,
+          p.encryptedAmount, p.proof,
+        ),
+      ], [rentDepositor])
+      assert.fail('Expected RentReserveViolation error but transaction succeeded')
+    } catch (e: unknown) {
+      const err = e as Error
+      if (err.message && err.message.includes('Expected RentReserveViolation error but transaction succeeded')) {
+        throw err
+      }
+      threw = true
+      const msg = (err?.message ?? String(err)).toLowerCase()
+      const matchesCode =
+        msg.includes(String(RENT_RESERVE_CODE)) ||
+        msg.includes(RENT_RESERVE_HEX) ||
+        msg.includes('rentreserveviolation')
+      assert.ok(
+        matchesCode,
+        `Expected RentReserveViolation (${RENT_RESERVE_CODE} / 0x${RENT_RESERVE_HEX}), got: ${err?.message ?? String(err)}`,
+      )
+    } finally {
+      // Restore the real sol_vault account so later test files / runs are unaffected.
+      ctx.setAccount(solVaultPda, {
+        lamports: Number(originalLamports),
+        data: originalData,
+        owner: originalOwner,
+        executable: originalExecutable,
+        rentEpoch: originalRentEpoch,
+      })
+    }
+    assert.ok(threw, 'rent-guard test did not throw')
   })
 })

--- a/programs/sipher-vault/tests/sipher-vault/12-native-sol.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/12-native-sol.test.ts
@@ -35,6 +35,8 @@ import {
   ixCreateSolVault,
   ixDepositSol,
   ixWithdrawPrivateSol,
+  ixRefundSol,
+  ixAuthorityRefundSol,
   ixSipPrivacyInitialize,
   getAccountData,
   parseDepositRecord,
@@ -474,5 +476,234 @@ describe('12 · native SOL vault track', function () {
       })
     }
     assert.ok(threw, 'rent-guard test did not throw')
+  })
+
+  // ── Task 8: refund_sol + authority_refund_sol ────────────────────────────
+  //
+  // Anchor custom error codes (6000-base, enum order from errors.rs):
+  //   RefundNotExpired = index 5 → 6005 / 0x1775
+  //   NothingToRefund  = index 6 → 6006 / 0x1776
+  //   Unauthorized     = index 1 → 6001 / 0x1771
+  const REFUND_NOT_EXPIRED_CODE = 6005
+  const REFUND_NOT_EXPIRED_HEX = REFUND_NOT_EXPIRED_CODE.toString(16) // '1775'
+  const UNAUTHORIZED_CODE = 6001
+  const UNAUTHORIZED_HEX = UNAUTHORIZED_CODE.toString(16) // '1771'
+
+  // Dedicated keypair for refund_sol tests — independent of wd (withdraw tests above).
+  const refunder = Keypair.generate()
+  let refunderSetup = false
+
+  async function ensureRefunderSetup(): Promise<void> {
+    if (!refunderSetup) {
+      // ensureWithdrawSetup runs sip_privacy initialize + funds wd; we only need the sip init.
+      await ensureWithdrawSetup()
+      // Fund the refunder (covers rent for DepositRecord + deposit + tx fees).
+      await sendIx(ctx, [
+        SystemProgram.transfer({
+          fromPubkey: authority.publicKey,
+          toPubkey: refunder.publicKey,
+          lamports: 20_000_000,
+        }),
+      ], [authority])
+      refunderSetup = true
+    }
+  }
+
+  it('refund_sol → depositor receives unlocked lamports and record.balance equals locked_amount', async function () {
+    await ensureRefunderSetup()
+
+    const depositAmount = 2_000_000n
+
+    // Deposit so there is something to refund.
+    await sendIx(ctx, [ixDepositSol(refunder.publicKey, depositAmount)], [refunder])
+
+    // Confirm the record before the refund.
+    const [recordPda] = getDepositRecordPDA(refunder.publicKey, NATIVE_SOL_MINT, VAULT_PROGRAM_ID)
+    const recBefore = parseDepositRecord(await getAccountData(ctx, recordPda))
+    const available = recBefore.balance - recBefore.lockedAmount
+    assert.ok(available > 0n, 'no available balance to refund — test state error')
+
+    // Snapshot depositor lamports before refund (lamports live on the system account).
+    const refunderBefore = BigInt((await ctx.banksClient.getAccount(refunder.publicKey))!.lamports)
+
+    // Advance the clock past the refund_timeout to satisfy the on-chain check.
+    const currentClock = await ctx.banksClient.getClock()
+    const { Clock } = await import('solana-bankrun')
+    const newClock = new Clock(
+      currentClock.slot,
+      currentClock.epochStartTimestamp,
+      currentClock.epoch,
+      currentClock.leaderScheduleEpoch,
+      recBefore.lastDepositAt + REFUND_TIMEOUT + 10n,
+    )
+    ctx.setClock(newClock)
+
+    await sendIx(ctx, [ixRefundSol(refunder.publicKey)], [refunder])
+
+    // ── depositor lamports increased by exactly the available amount ──
+    const refunderAfter = BigInt((await ctx.banksClient.getAccount(refunder.publicKey))!.lamports)
+    // The depositor also pays tx fees, so we check the net gain ignoring fees:
+    // lamports_after should be > lamports_before + available - some_fee_budget
+    // To be precise, use a tolerance rather than an exact check since tx fees vary.
+    const lamportGain = refunderAfter - refunderBefore
+    // lamportGain = +available - tx_fees. tx_fees are tiny (< 10_000 lamports typically).
+    // Assert the gain is within [available - 10_000, available] to confirm the transfer.
+    assert.ok(
+      lamportGain >= available - 10_000n && lamportGain <= available,
+      `depositor lamport gain: expected ~+${available}, got +${lamportGain}`,
+    )
+
+    // ── record.balance == locked_amount (available portion zeroed) ──
+    const recAfter = parseDepositRecord(await getAccountData(ctx, recordPda))
+    assert.strictEqual(
+      recAfter.balance,
+      recAfter.lockedAmount,
+      `record.balance should equal locked_amount after refund_sol`,
+    )
+    // Since locked_amount was 0, balance should also be 0.
+    assert.strictEqual(recAfter.balance, 0n, 'balance should be 0 when locked_amount is 0')
+  })
+
+  it('refund_sol → rejects before timeout with RefundNotExpired (6005 / 0x1775)', async function () {
+    await ensureRefunderSetup()
+
+    const depositAmount2 = 1_000_000n
+
+    // Deposit a fresh amount using a new keypair so the refund_timeout restarts.
+    const prematureRefunder = Keypair.generate()
+    await sendIx(ctx, [
+      SystemProgram.transfer({
+        fromPubkey: authority.publicKey,
+        toPubkey: prematureRefunder.publicKey,
+        lamports: 10_000_000,
+      }),
+    ], [authority])
+    await sendIx(ctx, [ixDepositSol(prematureRefunder.publicKey, depositAmount2)], [prematureRefunder])
+
+    // Reset clock to the current timestamp WITHOUT advancing past the timeout.
+    const currentClock2 = await ctx.banksClient.getClock()
+    const { Clock: Clock2 } = await import('solana-bankrun')
+    // Set the unix_timestamp to "just now" — way before last_deposit_at + REFUND_TIMEOUT.
+    const nowClock = new Clock2(
+      currentClock2.slot,
+      currentClock2.epochStartTimestamp,
+      currentClock2.epoch,
+      currentClock2.leaderScheduleEpoch,
+      currentClock2.unixTimestamp, // do NOT advance
+    )
+    ctx.setClock(nowClock)
+
+    try {
+      await sendIx(ctx, [ixRefundSol(prematureRefunder.publicKey)], [prematureRefunder])
+      assert.fail('Expected RefundNotExpired error but transaction succeeded')
+    } catch (e: unknown) {
+      const err = e as Error
+      if (err.message && err.message.includes('Expected RefundNotExpired error but transaction succeeded')) {
+        throw err
+      }
+      const msg = (err?.message ?? String(err)).toLowerCase()
+      const matchesCode =
+        msg.includes(String(REFUND_NOT_EXPIRED_CODE)) ||
+        msg.includes(REFUND_NOT_EXPIRED_HEX) ||
+        msg.includes('refundnotexpired')
+      assert.ok(
+        matchesCode,
+        `Expected RefundNotExpired (${REFUND_NOT_EXPIRED_CODE} / 0x${REFUND_NOT_EXPIRED_HEX}), got: ${err?.message ?? String(err)}`,
+      )
+    }
+  })
+
+  it('authority_refund_sol → authority returns lamports to original depositor (non-signer) after timeout', async function () {
+    await ensureRefunderSetup()
+
+    const depositAmount3 = 3_000_000n
+    const authorityRefundDepositor = Keypair.generate()
+    await sendIx(ctx, [
+      SystemProgram.transfer({
+        fromPubkey: authority.publicKey,
+        toPubkey: authorityRefundDepositor.publicKey,
+        lamports: 15_000_000,
+      }),
+    ], [authority])
+    await sendIx(ctx, [ixDepositSol(authorityRefundDepositor.publicKey, depositAmount3)], [authorityRefundDepositor])
+
+    const [recordPda3] = getDepositRecordPDA(authorityRefundDepositor.publicKey, NATIVE_SOL_MINT, VAULT_PROGRAM_ID)
+    const rec3 = parseDepositRecord(await getAccountData(ctx, recordPda3))
+    const available3 = rec3.balance - rec3.lockedAmount
+    assert.ok(available3 > 0n, 'no available balance — test state error')
+
+    // Snapshot depositor lamports before the authority refund.
+    const depositorBefore = BigInt((await ctx.banksClient.getAccount(authorityRefundDepositor.publicKey))!.lamports)
+
+    // Advance clock past the timeout.
+    const currentClock3 = await ctx.banksClient.getClock()
+    const { Clock: Clock3 } = await import('solana-bankrun')
+    const fastClock = new Clock3(
+      currentClock3.slot,
+      currentClock3.epochStartTimestamp,
+      currentClock3.epoch,
+      currentClock3.leaderScheduleEpoch,
+      rec3.lastDepositAt + REFUND_TIMEOUT + 10n,
+    )
+    ctx.setClock(fastClock)
+
+    // authority signs; authorityRefundDepositor is the non-signer lamport destination.
+    await sendIx(ctx, [
+      ixAuthorityRefundSol(authorityRefundDepositor.publicKey, authority.publicKey),
+    ], [authority])
+
+    // ── depositor (non-signer) received the lamports ──
+    const depositorAfter = BigInt((await ctx.banksClient.getAccount(authorityRefundDepositor.publicKey))!.lamports)
+    assert.strictEqual(
+      depositorAfter - depositorBefore,
+      available3,
+      `depositor lamport gain: expected +${available3}, got +${depositorAfter - depositorBefore}`,
+    )
+
+    // ── record.balance == locked_amount ──
+    const rec3After = parseDepositRecord(await getAccountData(ctx, recordPda3))
+    assert.strictEqual(
+      rec3After.balance,
+      rec3After.lockedAmount,
+      'record.balance should equal locked_amount after authority_refund_sol',
+    )
+  })
+
+  it('authority_refund_sol → wrong authority is rejected with Unauthorized (6001 / 0x1771)', async function () {
+    await ensureRefunderSetup()
+
+    const wrongAuthority = Keypair.generate()
+    await sendIx(ctx, [
+      SystemProgram.transfer({
+        fromPubkey: authority.publicKey,
+        toPubkey: wrongAuthority.publicKey,
+        lamports: 5_000_000,
+      }),
+    ], [authority])
+
+    // Use the refunder's deposit_record that was created in the happy-path test.
+    // We don't need a fresh deposit — the record may already have balance=0,
+    // but the Unauthorized check fires BEFORE the balance check, so the record
+    // only needs to exist (which it does from the first refund_sol test above).
+    try {
+      await sendIx(ctx, [
+        ixAuthorityRefundSol(refunder.publicKey, wrongAuthority.publicKey),
+      ], [wrongAuthority])
+      assert.fail('Expected Unauthorized error but transaction succeeded')
+    } catch (e: unknown) {
+      const err = e as Error
+      if (err.message && err.message.includes('Expected Unauthorized error but transaction succeeded')) {
+        throw err
+      }
+      const msg = (err?.message ?? String(err)).toLowerCase()
+      const matchesCode =
+        msg.includes(String(UNAUTHORIZED_CODE)) ||
+        msg.includes(UNAUTHORIZED_HEX) ||
+        msg.includes('unauthorized')
+      assert.ok(
+        matchesCode,
+        `Expected Unauthorized (${UNAUTHORIZED_CODE} / 0x${UNAUTHORIZED_HEX}), got: ${err?.message ?? String(err)}`,
+      )
+    }
   })
 })

--- a/programs/sipher-vault/tests/sipher-vault/12-native-sol.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/12-native-sol.test.ts
@@ -37,6 +37,7 @@ import {
   ixWithdrawPrivateSol,
   ixRefundSol,
   ixAuthorityRefundSol,
+  ixCollectFeeSol,
   ixSipPrivacyInitialize,
   getAccountData,
   parseDepositRecord,
@@ -688,6 +689,146 @@ describe('12 · native SOL vault track', function () {
     try {
       await sendIx(ctx, [
         ixAuthorityRefundSol(refunder.publicKey, wrongAuthority.publicKey),
+      ], [wrongAuthority])
+      assert.fail('Expected Unauthorized error but transaction succeeded')
+    } catch (e: unknown) {
+      const err = e as Error
+      if (err.message && err.message.includes('Expected Unauthorized error but transaction succeeded')) {
+        throw err
+      }
+      const msg = (err?.message ?? String(err)).toLowerCase()
+      const matchesCode =
+        msg.includes(String(UNAUTHORIZED_CODE)) ||
+        msg.includes(UNAUTHORIZED_HEX) ||
+        msg.includes('unauthorized')
+      assert.ok(
+        matchesCode,
+        `Expected Unauthorized (${UNAUTHORIZED_CODE} / 0x${UNAUTHORIZED_HEX}), got: ${err?.message ?? String(err)}`,
+      )
+    }
+  })
+
+  // ── Task 9: collect_fee_sol ──────────────────────────────────────────────
+  //
+  // Authority drains lamports above the rent-exempt floor from the SolFee PDA.
+  // Fees accrue during withdraw_private_sol (10 bps per withdrawal).
+  // collect_fee_sol(0) drains ALL collectable lamports; partial amounts also
+  // supported. Wrong authority → Unauthorized (6001 / 0x1771).
+  //
+  // NoFeesToCollect = index 8 → 6008 / 0x1778
+  const NO_FEES_CODE = 6008
+  const NO_FEES_HEX = NO_FEES_CODE.toString(16) // '1778'
+
+  // Dedicated keypair for collect_fee_sol tests — ensures the withdrawal that
+  // accrues the fee is independent of refund_sol tests that zero out balances.
+  const feeCollector = Keypair.generate()
+  let feeCollectorSetup = false
+
+  async function ensureFeeCollectorSetup(): Promise<void> {
+    if (!feeCollectorSetup) {
+      await ensureWithdrawSetup() // ensures sip_privacy initialized
+      await sendIx(ctx, [
+        SystemProgram.transfer({
+          fromPubkey: authority.publicKey,
+          toPubkey: feeCollector.publicKey,
+          lamports: 50_000_000,
+        }),
+      ], [authority])
+      feeCollectorSetup = true
+    }
+  }
+
+  it('collect_fee_sol → drains all collectable lamports to authority, sol_fee left at rent_min', async function () {
+    await ensureFeeCollectorSetup()
+
+    // Accrue a fee: deposit + withdraw. Fee = 10 bps of 1_000_000 = 1_000 lamports (floor div).
+    const depositAmt = 5_000_000n
+    const withdrawAmt = 1_000_000n
+    const expectedFee = (withdrawAmt * BigInt(FEE_BPS)) / FEE_DENOM // 500 lamports
+
+    await sendIx(ctx, [ixDepositSol(feeCollector.publicKey, depositAmt)], [feeCollector])
+
+    const rent = await ctx.banksClient.getRent()
+    const stealthRentMin = rent.minimumBalance(0n)
+    const stealth = Keypair.generate().publicKey
+    await sendIx(ctx, [
+      SystemProgram.transfer({
+        fromPubkey: authority.publicKey,
+        toPubkey: stealth,
+        lamports: Number(stealthRentMin),
+      }),
+    ], [authority])
+
+    const [sipConfigPda] = getSipConfigPDA()
+    const { totalTransfers } = parseSipConfig(await getAccountData(ctx, sipConfigPda))
+    const [sipTransferRecordPda] = getSipTransferRecordPDA(feeCollector.publicKey, totalTransfers)
+
+    const p = announceParams()
+    await sendIx(ctx, [
+      ixWithdrawPrivateSol(
+        feeCollector.publicKey,
+        stealth,
+        sipTransferRecordPda,
+        withdrawAmt,
+        p.amountCommitment,
+        stealth,
+        p.ephemeralPubkey,
+        p.viewingKeyHash,
+        p.encryptedAmount,
+        p.proof,
+      ),
+    ], [feeCollector])
+
+    // Confirm the fee landed in sol_fee PDA.
+    const solFeeAfterWithdraw = BigInt((await ctx.banksClient.getAccount(solFeePda))!.lamports)
+    const solFeeAcct = (await ctx.banksClient.getAccount(solFeePda))!
+    const rentMin = rent.minimumBalance(BigInt(solFeeAcct.data.length))
+    const collectable = solFeeAfterWithdraw - rentMin
+    assert.ok(collectable > 0n, `Expected collectable > 0, got ${collectable} (fee accrued: ${expectedFee})`)
+
+    // Snapshot authority lamports before collect.
+    const authorityBefore = BigInt((await ctx.banksClient.getAccount(authority.publicKey))!.lamports)
+
+    // collect_fee_sol(0) → drain ALL collectable.
+    await sendIx(ctx, [
+      ixCollectFeeSol(authority.publicKey, 0n),
+    ], [authority])
+
+    // sol_fee must be left at exactly rent_min.
+    const solFeeAfterCollect = BigInt((await ctx.banksClient.getAccount(solFeePda))!.lamports)
+    assert.strictEqual(
+      solFeeAfterCollect,
+      rentMin,
+      `sol_fee after collect: expected ${rentMin} (rent_min), got ${solFeeAfterCollect}`,
+    )
+
+    // Authority must have received exactly collectable lamports (net of tx fee).
+    // We tolerate a small tx-fee window (< 10_000 lamports) in the same way
+    // as the refund_sol tests above.
+    const authorityAfter = BigInt((await ctx.banksClient.getAccount(authority.publicKey))!.lamports)
+    const authorityGain = authorityAfter - authorityBefore
+    // authorityGain = collectable - tx_fees. Tx fees are tiny (< 10_000 lamports).
+    assert.ok(
+      authorityGain >= collectable - 10_000n && authorityGain <= collectable,
+      `authority lamport gain: expected ~+${collectable}, got +${authorityGain}`,
+    )
+  })
+
+  it('collect_fee_sol → wrong authority is rejected with Unauthorized (6001 / 0x1771)', async function () {
+    await ensureFeeCollectorSetup()
+
+    const wrongAuthority = Keypair.generate()
+    await sendIx(ctx, [
+      SystemProgram.transfer({
+        fromPubkey: authority.publicKey,
+        toPubkey: wrongAuthority.publicKey,
+        lamports: 5_000_000,
+      }),
+    ], [authority])
+
+    try {
+      await sendIx(ctx, [
+        ixCollectFeeSol(wrongAuthority.publicKey, 0n),
       ], [wrongAuthority])
       assert.fail('Expected Unauthorized error but transaction succeeded')
     } catch (e: unknown) {

--- a/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
+++ b/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
@@ -550,6 +550,87 @@ export function ixDepositSol(
 }
 
 /**
+ * withdraw_private_sol(
+ *   amount: u64,
+ *   amount_commitment: [u8;33],
+ *   stealth_pubkey: Pubkey,
+ *   ephemeral_pubkey: [u8;33],
+ *   viewing_key_hash: [u8;32],
+ *   encrypted_amount: Vec<u8>,
+ *   proof: Vec<u8>,
+ * )
+ *
+ * Accounts (WithdrawPrivateSol) — mirrors WithdrawPrivate minus all token accounts:
+ *   config               readonly PDA
+ *   deposit_record       mut, PDA  seeds=[…, depositor, NATIVE_SOL_MINT]
+ *   sol_vault            mut, PDA  seeds=[VAULT_SOL_SEED]
+ *   sol_fee              mut, PDA  seeds=[FEE_SOL_SEED]
+ *   stealth              mut (plain writable system account — no ATA, no mint check)
+ *   depositor            mut, signer
+ *   sip_config           mut, CPI PDA
+ *   sip_transfer_record  mut, CPI PDA (new)
+ *   sip_privacy_program  readonly
+ *   system_program
+ *
+ * Arg layout is identical to withdraw_private (the on-chain encoding is shared via
+ * emit_transfer_announcement); only the native track has no token-specific args.
+ */
+export function ixWithdrawPrivateSol(
+  depositor: PublicKey,
+  stealth: PublicKey,
+  sipTransferRecord: PublicKey,
+  amount: bigint,
+  amountCommitment: Buffer,   // 33 bytes
+  stealthPubkey: PublicKey,
+  ephemeralPubkey: Buffer,    // 33 bytes
+  viewingKeyHash: Buffer,     // 32 bytes
+  encryptedAmount: Buffer,
+  proof: Buffer,
+): TransactionInstruction {
+  const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+  const [depositRecordPda] = getDepositRecordPDA(depositor, NATIVE_SOL_MINT, VAULT_PROGRAM_ID)
+  const [solVaultPda] = getSolVaultPDA(VAULT_PROGRAM_ID)
+  const [solFeePda] = getSolFeePDA(VAULT_PROGRAM_ID)
+  const [sipConfigPda] = getSipConfigPDA()
+
+  // Arg layout: disc(8) + amount(8) + commitment(33) + stealth_pk(32) +
+  //             ephemeral(33) + vk_hash(32) + enc_len(4) + enc + proof_len(4) + proof
+  const encLen = Buffer.alloc(4); encLen.writeUInt32LE(encryptedAmount.length)
+  const proofLen = Buffer.alloc(4); proofLen.writeUInt32LE(proof.length)
+
+  const data = Buffer.concat([
+    disc('withdraw_private_sol'),
+    u64le(amount),
+    amountCommitment,
+    stealthPubkey.toBuffer(),
+    ephemeralPubkey,
+    viewingKeyHash,
+    encLen,
+    encryptedAmount,
+    proofLen,
+    proof,
+  ])
+
+  return new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: false },
+      { pubkey: depositRecordPda, isSigner: false, isWritable: true },
+      { pubkey: solVaultPda, isSigner: false, isWritable: true },
+      { pubkey: solFeePda, isSigner: false, isWritable: true },
+      { pubkey: stealth, isSigner: false, isWritable: true },
+      { pubkey: depositor, isSigner: true, isWritable: true },
+      // CPI accounts
+      { pubkey: sipConfigPda, isSigner: false, isWritable: true },
+      { pubkey: sipTransferRecord, isSigner: false, isWritable: true },
+      { pubkey: SIP_PRIVACY_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data,
+  })
+}
+
+/**
  * sip_privacy::initialize(fee_bps: u16) — creates the Config PDA.
  * Must be called once before any CPI from withdraw_private.
  *

--- a/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
+++ b/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
@@ -41,6 +41,13 @@ import {
 
 export const VAULT_PROGRAM_ID = new PublicKey('S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB')
 
+/**
+ * Sentinel mint pubkey for native SOL deposits — all-zero (PublicKey.default()).
+ * Used as the token_mint in DepositRecord and deposit_record PDA derivation
+ * for native SOL. Exported for all test suites in the native-SOL track.
+ */
+export const NATIVE_SOL_MINT = new PublicKey(new Uint8Array(32))
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Core utilities
 // ─────────────────────────────────────────────────────────────────────────────
@@ -524,8 +531,6 @@ export function ixDepositSol(
   amount: bigint,
 ): TransactionInstruction {
   const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
-  // NATIVE_SOL_MINT = all-zero pubkey (PublicKey.default())
-  const NATIVE_SOL_MINT = new PublicKey(new Uint8Array(32))
   const [depositRecordPda] = getDepositRecordPDA(depositor, NATIVE_SOL_MINT, VAULT_PROGRAM_ID)
   const [solVaultPda] = getSolVaultPDA(VAULT_PROGRAM_ID)
 

--- a/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
+++ b/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
@@ -257,10 +257,14 @@ export function ixInitialize(
  *   payer        mut, signer
  *   token_program
  *   system_program
+ *
+ * @param tokenProgram - Defaults to TOKEN_PROGRAM_ID (classic SPL).
+ *   Pass TOKEN_2022_PROGRAM_ID for Token-2022 mints.
  */
 export function ixCreateVaultToken(
   tokenMint: PublicKey,
   payer: PublicKey,
+  tokenProgram: PublicKey = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
   const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
   const [vaultTokenPda] = getVaultTokenPDA(tokenMint, VAULT_PROGRAM_ID)
@@ -272,7 +276,7 @@ export function ixCreateVaultToken(
       { pubkey: vaultTokenPda, isSigner: false, isWritable: true },
       { pubkey: tokenMint, isSigner: false, isWritable: false },
       { pubkey: payer, isSigner: true, isWritable: true },
-      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: tokenProgram, isSigner: false, isWritable: false },
       { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
     ],
     data: disc('create_vault_token'),

--- a/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
+++ b/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
@@ -662,6 +662,70 @@ export function ixSipPrivacyInitialize(
 }
 
 /**
+ * refund_sol() — no args
+ *
+ * Returns the available (unlocked) native-SOL balance to the original depositor.
+ * Depositor is the signer and lamport destination.
+ *
+ * Accounts (RefundSol):
+ *   config          readonly PDA
+ *   deposit_record  mut, PDA  seeds=[DEPOSIT_RECORD_SEED, depositor, NATIVE_SOL_MINT]
+ *   sol_vault       mut, PDA  seeds=[VAULT_SOL_SEED]
+ *   depositor       mut, signer
+ */
+export function ixRefundSol(depositor: PublicKey): TransactionInstruction {
+  const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+  const [depositRecordPda] = getDepositRecordPDA(depositor, NATIVE_SOL_MINT, VAULT_PROGRAM_ID)
+  const [solVaultPda] = getSolVaultPDA(VAULT_PROGRAM_ID)
+
+  return new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: false },
+      { pubkey: depositRecordPda, isSigner: false, isWritable: true },
+      { pubkey: solVaultPda, isSigner: false, isWritable: true },
+      { pubkey: depositor, isSigner: true, isWritable: true },
+    ],
+    data: disc('refund_sol'),
+  })
+}
+
+/**
+ * authority_refund_sol() — no args
+ *
+ * Authority-signed refund: returns the available (unlocked) native-SOL balance
+ * to the original depositor. Depositor is a NON-signer account (lamport destination).
+ * Timeout is still enforced on-chain.
+ *
+ * Accounts (AuthorityRefundSol):
+ *   config          readonly PDA  has_one = authority
+ *   deposit_record  mut, PDA      seeds=[DEPOSIT_RECORD_SEED, depositor, NATIVE_SOL_MINT]
+ *   sol_vault       mut, PDA      seeds=[VAULT_SOL_SEED]
+ *   depositor       mut, SystemAccount (non-signer — lamport destination + seed source)
+ *   authority       mut, signer
+ */
+export function ixAuthorityRefundSol(
+  depositor: PublicKey,
+  authority: PublicKey,
+): TransactionInstruction {
+  const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+  const [depositRecordPda] = getDepositRecordPDA(depositor, NATIVE_SOL_MINT, VAULT_PROGRAM_ID)
+  const [solVaultPda] = getSolVaultPDA(VAULT_PROGRAM_ID)
+
+  return new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: false },
+      { pubkey: depositRecordPda, isSigner: false, isWritable: true },
+      { pubkey: solVaultPda, isSigner: false, isWritable: true },
+      { pubkey: depositor, isSigner: false, isWritable: true },
+      { pubkey: authority, isSigner: true, isWritable: true },
+    ],
+    data: disc('authority_refund_sol'),
+  })
+}
+
+/**
  * collect_fee(amount: u64) — pass 0n to drain all
  *
  * Accounts (CollectFee):

--- a/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
+++ b/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
@@ -443,6 +443,7 @@ export function ixWithdrawPrivate(
  *   deposit_record   mut, PDA
  *   vault_token      mut, PDA
  *   depositor_token  mut
+ *   token_mint       readonly  ← added for transfer_checked
  *   depositor        mut, signer
  *   token_program
  */
@@ -462,6 +463,7 @@ export function ixRefund(
       { pubkey: depositRecordPda, isSigner: false, isWritable: true },
       { pubkey: vaultTokenPda, isSigner: false, isWritable: true },
       { pubkey: depositorToken, isSigner: false, isWritable: true },
+      { pubkey: tokenMint, isSigner: false, isWritable: false },
       { pubkey: depositor, isSigner: true, isWritable: true },
       { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
     ],

--- a/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
+++ b/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
@@ -31,6 +31,8 @@ import {
   getFeeTokenPDA,
   getSipConfigPDA,
   getSipTransferRecordPDA,
+  getSolVaultPDA,
+  getSolFeePDA,
 } from './setup'
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -478,6 +480,34 @@ export function ixRefund(
 // ─────────────────────────────────────────────────────────────────────────────
 // sip_privacy instruction builder (CPI prerequisite)
 // ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * create_sol_vault() — no args
+ *
+ * Accounts (CreateSolVault):
+ *   config      readonly PDA
+ *   sol_vault   mut, PDA (init)
+ *   sol_fee     mut, PDA (init)
+ *   payer       mut, signer
+ *   system_program
+ */
+export function ixCreateSolVault(payer: PublicKey): TransactionInstruction {
+  const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+  const [solVaultPda] = getSolVaultPDA(VAULT_PROGRAM_ID)
+  const [solFeePda] = getSolFeePDA(VAULT_PROGRAM_ID)
+
+  return new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: false },
+      { pubkey: solVaultPda, isSigner: false, isWritable: true },
+      { pubkey: solFeePda, isSigner: false, isWritable: true },
+      { pubkey: payer, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data: disc('create_sol_vault'),
+  })
+}
 
 /**
  * sip_privacy::initialize(fee_bps: u16) — creates the Config PDA.

--- a/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
+++ b/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
@@ -1,0 +1,541 @@
+// tests/sipher-vault/bankrun-helpers.ts
+//
+// IDL-free bankrun harness for sipher-vault tests.
+// All instruction encoding is manual (8-byte Anchor discriminator + Borsh args).
+// Account orders match the #[derive(Accounts)] structs in lib.rs verbatim.
+//
+// Consumed by Task-1 baseline and all downstream tasks in the universal-asset plan.
+
+import { createHash } from 'crypto'
+import {
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+  Keypair,
+  AccountMeta,
+  SystemProgram,
+} from '@solana/web3.js'
+import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
+import { startAnchor, ProgramTestContext } from 'solana-bankrun'
+import {
+  SIP_PRIVACY_PROGRAM_ID,
+  VAULT_CONFIG_SEED,
+  DEPOSIT_RECORD_SEED,
+  VAULT_TOKEN_SEED,
+  FEE_TOKEN_SEED,
+  SIP_CONFIG_SEED,
+  SIP_TRANSFER_RECORD_SEED,
+  getVaultConfigPDA,
+  getDepositRecordPDA,
+  getVaultTokenPDA,
+  getFeeTokenPDA,
+  getSipConfigPDA,
+  getSipTransferRecordPDA,
+} from './setup'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Program ID
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const VAULT_PROGRAM_ID = new PublicKey('S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB')
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Core utilities
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Anchor instruction discriminator: sha256("global:<name>")[..8] */
+export function disc(name: string): Buffer {
+  return createHash('sha256').update(`global:${name}`).digest().subarray(0, 8)
+}
+
+/** Encode a u64 as 8-byte little-endian buffer (Borsh u64). */
+export function u64le(n: bigint): Buffer {
+  const b = Buffer.alloc(8)
+  b.writeBigUInt64LE(n)
+  return b
+}
+
+/** Encode a u16 as 2-byte little-endian buffer (Borsh u16). */
+export function u16le(n: number): Buffer {
+  const b = Buffer.alloc(2)
+  b.writeUInt16LE(n)
+  return b
+}
+
+/** Encode an i64 as 8-byte little-endian buffer (Borsh i64). */
+export function i64le(n: bigint): Buffer {
+  const b = Buffer.alloc(8)
+  b.writeBigInt64LE(n)
+  return b
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test context lifecycle
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Spin up bankrun with sipher_vault (from Anchor workspace target/) and
+ * sip_privacy (from tests/fixtures/sip_privacy.so, resolved by name).
+ *
+ * The Anchor workspace root is '.', which startAnchor resolves relative to
+ * the cwd at runtime (programs/sipher-vault when running with ts-mocha from
+ * the Anchor project root).
+ */
+export async function startVault(): Promise<ProgramTestContext> {
+  return startAnchor(
+    '.',
+    [{ name: 'sip_privacy', programId: SIP_PRIVACY_PROGRAM_ID }],
+    [],
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Transaction helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Send one or more instructions as a single transaction.
+ * The first signer pays fees. Blockhash is taken from ctx.lastBlockhash.
+ */
+export async function sendIx(
+  ctx: ProgramTestContext,
+  ixs: TransactionInstruction[],
+  signers: Keypair[],
+): Promise<void> {
+  const tx = new Transaction()
+  tx.recentBlockhash = ctx.lastBlockhash
+  tx.feePayer = signers[0].publicKey
+  ixs.forEach((ix) => tx.add(ix))
+  tx.sign(...signers)
+  await ctx.banksClient.processTransaction(tx)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Account data helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch raw account bytes. Throws if the account does not exist.
+ * All callers should catch and rethrow with context.
+ */
+export async function getAccountData(ctx: ProgramTestContext, pk: PublicKey): Promise<Buffer> {
+  const acct = await ctx.banksClient.getAccount(pk)
+  if (!acct) throw new Error(`account ${pk.toBase58()} not found`)
+  return Buffer.from(acct.data)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Account parsers (byte-offset, Anchor disc prefix = 8 bytes)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Parse a DepositRecord account.
+ *
+ * Layout (post-discriminator):
+ *   depositor:         Pubkey  (32)
+ *   token_mint:        Pubkey  (32)
+ *   balance:           u64     (8)
+ *   locked_amount:     u64     (8)
+ *   cumulative_volume: u64     (8)
+ *   last_deposit_at:   i64     (8)
+ *   bump:              u8      (1)
+ */
+export function parseDepositRecord(d: Buffer): {
+  depositor: PublicKey
+  tokenMint: PublicKey
+  balance: bigint
+  lockedAmount: bigint
+  cumulativeVolume: bigint
+  lastDepositAt: bigint
+  bump: number
+} {
+  let o = 8 // skip 8-byte Anchor discriminator
+  const depositor = new PublicKey(d.subarray(o, o += 32))
+  const tokenMint = new PublicKey(d.subarray(o, o += 32))
+  const balance = d.readBigUInt64LE(o); o += 8
+  const lockedAmount = d.readBigUInt64LE(o); o += 8
+  const cumulativeVolume = d.readBigUInt64LE(o); o += 8
+  const lastDepositAt = d.readBigInt64LE(o); o += 8
+  const bump = d.readUInt8(o)
+  return { depositor, tokenMint, balance, lockedAmount, cumulativeVolume, lastDepositAt, bump }
+}
+
+/**
+ * Parse a VaultConfig account.
+ *
+ * Layout (post-discriminator):
+ *   authority:         Pubkey  (32)
+ *   fee_bps:           u16     (2)
+ *   refund_timeout:    i64     (8)
+ *   paused:            bool    (1)
+ *   total_deposits:    u64     (8)
+ *   total_depositors:  u64     (8)
+ *   bump:              u8      (1)
+ */
+export function parseVaultConfig(d: Buffer): {
+  authority: PublicKey
+  feeBps: number
+  refundTimeout: bigint
+  paused: boolean
+  totalDeposits: bigint
+  totalDepositors: bigint
+  bump: number
+} {
+  let o = 8 // skip 8-byte Anchor discriminator
+  const authority = new PublicKey(d.subarray(o, o += 32))
+  const feeBps = d.readUInt16LE(o); o += 2
+  const refundTimeout = d.readBigInt64LE(o); o += 8
+  const paused = d.readUInt8(o) !== 0; o += 1
+  const totalDeposits = d.readBigUInt64LE(o); o += 8
+  const totalDepositors = d.readBigUInt64LE(o); o += 8
+  const bump = d.readUInt8(o)
+  return { authority, feeBps, refundTimeout, paused, totalDeposits, totalDepositors, bump }
+}
+
+/**
+ * Parse the sip_privacy Config account to get total_transfers.
+ *
+ * sip_privacy Config layout (post-discriminator):
+ *   authority:       Pubkey  (32)
+ *   fee_bps:         u16     (2)
+ *   paused:          bool    (1)
+ *   total_transfers: u64     (8)
+ *   bump:            u8      (1)
+ */
+export function parseSipConfig(d: Buffer): { totalTransfers: bigint } {
+  let o = 8 // skip discriminator
+  o += 32 // authority
+  o += 2  // fee_bps
+  o += 1  // paused
+  const totalTransfers = d.readBigUInt64LE(o)
+  return { totalTransfers }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Instruction builders — account orders copied verbatim from lib.rs contexts
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * initialize(fee_bps: u16, refund_timeout: i64)
+ *
+ * Accounts (Initialize):
+ *   config         mut, PDA
+ *   authority      mut, signer
+ *   system_program
+ */
+export function ixInitialize(
+  authority: PublicKey,
+  feeBps: number,
+  refundTimeout: bigint,
+): TransactionInstruction {
+  const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+
+  const data = Buffer.concat([
+    disc('initialize'),
+    u16le(feeBps),
+    i64le(refundTimeout),
+  ])
+
+  return new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: true },
+      { pubkey: authority, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data,
+  })
+}
+
+/**
+ * create_vault_token() — no args
+ *
+ * Accounts (CreateVaultToken):
+ *   config       readonly PDA
+ *   vault_token  mut, PDA (init)
+ *   token_mint   readonly
+ *   payer        mut, signer
+ *   token_program
+ *   system_program
+ */
+export function ixCreateVaultToken(
+  tokenMint: PublicKey,
+  payer: PublicKey,
+): TransactionInstruction {
+  const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+  const [vaultTokenPda] = getVaultTokenPDA(tokenMint, VAULT_PROGRAM_ID)
+
+  return new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: false },
+      { pubkey: vaultTokenPda, isSigner: false, isWritable: true },
+      { pubkey: tokenMint, isSigner: false, isWritable: false },
+      { pubkey: payer, isSigner: true, isWritable: true },
+      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data: disc('create_vault_token'),
+  })
+}
+
+/**
+ * create_fee_token() — no args
+ *
+ * Accounts (CreateFeeToken):
+ *   config      readonly PDA
+ *   fee_token   mut, PDA (init)
+ *   token_mint  readonly
+ *   payer       mut, signer
+ *   token_program
+ *   system_program
+ */
+export function ixCreateFeeToken(
+  tokenMint: PublicKey,
+  payer: PublicKey,
+): TransactionInstruction {
+  const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+  const [feeTokenPda] = getFeeTokenPDA(tokenMint, VAULT_PROGRAM_ID)
+
+  return new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: false },
+      { pubkey: feeTokenPda, isSigner: false, isWritable: true },
+      { pubkey: tokenMint, isSigner: false, isWritable: false },
+      { pubkey: payer, isSigner: true, isWritable: true },
+      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data: disc('create_fee_token'),
+  })
+}
+
+/**
+ * deposit(amount: u64)
+ *
+ * Accounts (Deposit):
+ *   config           mut, PDA
+ *   deposit_record   mut, PDA (init_if_needed)
+ *   vault_token      mut, PDA
+ *   depositor_token  mut
+ *   token_mint       readonly
+ *   depositor        mut, signer
+ *   token_program
+ *   system_program
+ */
+export function ixDeposit(
+  depositor: PublicKey,
+  depositorToken: PublicKey,
+  tokenMint: PublicKey,
+  amount: bigint,
+): TransactionInstruction {
+  const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+  const [depositRecordPda] = getDepositRecordPDA(depositor, tokenMint, VAULT_PROGRAM_ID)
+  const [vaultTokenPda] = getVaultTokenPDA(tokenMint, VAULT_PROGRAM_ID)
+
+  const data = Buffer.concat([disc('deposit'), u64le(amount)])
+
+  return new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: true },
+      { pubkey: depositRecordPda, isSigner: false, isWritable: true },
+      { pubkey: vaultTokenPda, isSigner: false, isWritable: true },
+      { pubkey: depositorToken, isSigner: false, isWritable: true },
+      { pubkey: tokenMint, isSigner: false, isWritable: false },
+      { pubkey: depositor, isSigner: true, isWritable: true },
+      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data,
+  })
+}
+
+/**
+ * withdraw_private(
+ *   amount: u64,
+ *   amount_commitment: [u8;33],
+ *   stealth_pubkey: Pubkey,
+ *   ephemeral_pubkey: [u8;33],
+ *   viewing_key_hash: [u8;32],
+ *   encrypted_amount: Vec<u8>,
+ *   proof: Vec<u8>,
+ * )
+ *
+ * Accounts (WithdrawPrivate):
+ *   config               readonly PDA
+ *   deposit_record       mut, PDA
+ *   vault_token          mut, PDA
+ *   fee_token            mut, PDA
+ *   stealth_token        mut (pre-created ATA owned by stealth address)
+ *   token_mint           readonly
+ *   depositor            mut, signer
+ *   token_program
+ *   sip_config           mut, CPI PDA
+ *   sip_transfer_record  mut, CPI PDA (new)
+ *   sip_privacy_program  readonly
+ *   system_program
+ */
+export function ixWithdrawPrivate(
+  depositor: PublicKey,
+  stealthToken: PublicKey,
+  tokenMint: PublicKey,
+  sipTransferRecord: PublicKey,
+  amount: bigint,
+  amountCommitment: Buffer,   // 33 bytes
+  stealthPubkey: PublicKey,
+  ephemeralPubkey: Buffer,    // 33 bytes
+  viewingKeyHash: Buffer,     // 32 bytes
+  encryptedAmount: Buffer,
+  proof: Buffer,
+): TransactionInstruction {
+  const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+  const [depositRecordPda] = getDepositRecordPDA(depositor, tokenMint, VAULT_PROGRAM_ID)
+  const [vaultTokenPda] = getVaultTokenPDA(tokenMint, VAULT_PROGRAM_ID)
+  const [feeTokenPda] = getFeeTokenPDA(tokenMint, VAULT_PROGRAM_ID)
+  const [sipConfigPda] = getSipConfigPDA()
+
+  // Arg layout: disc(8) + amount(8) + commitment(33) + stealth_pk(32) +
+  //             ephemeral(33) + vk_hash(32) + enc_len(4) + enc + proof_len(4) + proof
+  const encLen = Buffer.alloc(4); encLen.writeUInt32LE(encryptedAmount.length)
+  const proofLen = Buffer.alloc(4); proofLen.writeUInt32LE(proof.length)
+
+  const data = Buffer.concat([
+    disc('withdraw_private'),
+    u64le(amount),
+    amountCommitment,
+    stealthPubkey.toBuffer(),
+    ephemeralPubkey,
+    viewingKeyHash,
+    encLen,
+    encryptedAmount,
+    proofLen,
+    proof,
+  ])
+
+  return new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: false },
+      { pubkey: depositRecordPda, isSigner: false, isWritable: true },
+      { pubkey: vaultTokenPda, isSigner: false, isWritable: true },
+      { pubkey: feeTokenPda, isSigner: false, isWritable: true },
+      { pubkey: stealthToken, isSigner: false, isWritable: true },
+      { pubkey: tokenMint, isSigner: false, isWritable: false },
+      { pubkey: depositor, isSigner: true, isWritable: true },
+      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      // CPI accounts
+      { pubkey: sipConfigPda, isSigner: false, isWritable: true },
+      { pubkey: sipTransferRecord, isSigner: false, isWritable: true },
+      { pubkey: SIP_PRIVACY_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data,
+  })
+}
+
+/**
+ * refund() — no args
+ *
+ * Accounts (Refund):
+ *   config           readonly PDA
+ *   deposit_record   mut, PDA
+ *   vault_token      mut, PDA
+ *   depositor_token  mut
+ *   depositor        mut, signer
+ *   token_program
+ */
+export function ixRefund(
+  depositor: PublicKey,
+  depositorToken: PublicKey,
+  tokenMint: PublicKey,
+): TransactionInstruction {
+  const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+  const [depositRecordPda] = getDepositRecordPDA(depositor, tokenMint, VAULT_PROGRAM_ID)
+  const [vaultTokenPda] = getVaultTokenPDA(tokenMint, VAULT_PROGRAM_ID)
+
+  return new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: false },
+      { pubkey: depositRecordPda, isSigner: false, isWritable: true },
+      { pubkey: vaultTokenPda, isSigner: false, isWritable: true },
+      { pubkey: depositorToken, isSigner: false, isWritable: true },
+      { pubkey: depositor, isSigner: true, isWritable: true },
+      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+    ],
+    data: disc('refund'),
+  })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// sip_privacy instruction builder (CPI prerequisite)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * sip_privacy::initialize(fee_bps: u16) — creates the Config PDA.
+ * Must be called once before any CPI from withdraw_private.
+ *
+ * Accounts (Initialize):
+ *   config         mut, PDA   seeds=[b"config"]
+ *   authority      mut, signer
+ *   system_program
+ */
+export function ixSipPrivacyInitialize(
+  authority: PublicKey,
+  feeBps: number,
+): TransactionInstruction {
+  const [sipConfigPda] = getSipConfigPDA()
+
+  const data = Buffer.concat([
+    disc('initialize'),
+    u16le(feeBps),
+  ])
+
+  return new TransactionInstruction({
+    programId: SIP_PRIVACY_PROGRAM_ID,
+    keys: [
+      { pubkey: sipConfigPda, isSigner: false, isWritable: true },
+      { pubkey: authority, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data,
+  })
+}
+
+/**
+ * collect_fee(amount: u64) — pass 0n to drain all
+ *
+ * Accounts (CollectFee):
+ *   config          readonly PDA
+ *   fee_token       mut, PDA
+ *   authority_token mut
+ *   token_mint      readonly
+ *   authority       mut, signer
+ *   token_program
+ */
+export function ixCollectFee(
+  authority: PublicKey,
+  authorityToken: PublicKey,
+  tokenMint: PublicKey,
+  amount: bigint,
+): TransactionInstruction {
+  const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+  const [feeTokenPda] = getFeeTokenPDA(tokenMint, VAULT_PROGRAM_ID)
+
+  const data = Buffer.concat([disc('collect_fee'), u64le(amount)])
+
+  return new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: false },
+      { pubkey: feeTokenPda, isSigner: false, isWritable: true },
+      { pubkey: authorityToken, isSigner: false, isWritable: true },
+      { pubkey: tokenMint, isSigner: false, isWritable: false },
+      { pubkey: authority, isSigner: true, isWritable: true },
+      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+    ],
+    data,
+  })
+}

--- a/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
+++ b/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
@@ -726,6 +726,37 @@ export function ixAuthorityRefundSol(
 }
 
 /**
+ * collect_fee_sol(amount: u64) — pass 0n to drain all collectable lamports
+ *
+ * Drains lamports above the rent-exempt minimum from the SolFee PDA to the
+ * authority. amount=0 or amount > collectable both drain everything available.
+ *
+ * Accounts (CollectFeeSol):
+ *   config    readonly PDA  seeds=[VAULT_CONFIG_SEED], has_one = authority
+ *   sol_fee   mut, PDA      seeds=[FEE_SOL_SEED]
+ *   authority mut, signer
+ */
+export function ixCollectFeeSol(
+  authority: PublicKey,
+  amount: bigint,
+): TransactionInstruction {
+  const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+  const [solFeePda] = getSolFeePDA(VAULT_PROGRAM_ID)
+
+  const data = Buffer.concat([disc('collect_fee_sol'), u64le(amount)])
+
+  return new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: false },
+      { pubkey: solFeePda, isSigner: false, isWritable: true },
+      { pubkey: authority, isSigner: true, isWritable: true },
+    ],
+    data,
+  })
+}
+
+/**
  * collect_fee(amount: u64) — pass 0n to drain all
  *
  * Accounts (CollectFee):

--- a/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
+++ b/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
@@ -510,6 +510,41 @@ export function ixCreateSolVault(payer: PublicKey): TransactionInstruction {
 }
 
 /**
+ * deposit_sol(amount: u64)
+ *
+ * Accounts (DepositSol):
+ *   config         mut, PDA
+ *   deposit_record mut, PDA (init_if_needed)
+ *   sol_vault      mut, PDA
+ *   depositor      mut, signer
+ *   system_program
+ */
+export function ixDepositSol(
+  depositor: PublicKey,
+  amount: bigint,
+): TransactionInstruction {
+  const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+  // NATIVE_SOL_MINT = all-zero pubkey (PublicKey.default())
+  const NATIVE_SOL_MINT = new PublicKey(new Uint8Array(32))
+  const [depositRecordPda] = getDepositRecordPDA(depositor, NATIVE_SOL_MINT, VAULT_PROGRAM_ID)
+  const [solVaultPda] = getSolVaultPDA(VAULT_PROGRAM_ID)
+
+  const data = Buffer.concat([disc('deposit_sol'), u64le(amount)])
+
+  return new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: true },
+      { pubkey: depositRecordPda, isSigner: false, isWritable: true },
+      { pubkey: solVaultPda, isSigner: false, isWritable: true },
+      { pubkey: depositor, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data,
+  })
+}
+
+/**
  * sip_privacy::initialize(fee_bps: u16) — creates the Config PDA.
  * Must be called once before any CPI from withdraw_private.
  *

--- a/programs/sipher-vault/tests/sipher-vault/setup.ts
+++ b/programs/sipher-vault/tests/sipher-vault/setup.ts
@@ -16,6 +16,8 @@ export const VAULT_CONFIG_SEED = Buffer.from('vault_config')
 export const DEPOSIT_RECORD_SEED = Buffer.from('deposit_record')
 export const VAULT_TOKEN_SEED = Buffer.from('vault_token')
 export const FEE_TOKEN_SEED = Buffer.from('fee_token')
+export const VAULT_SOL_SEED = Buffer.from('vault_sol')
+export const FEE_SOL_SEED = Buffer.from('fee_sol')
 
 // SIP Privacy program seeds (must match sip_privacy constants)
 export const SIP_CONFIG_SEED = Buffer.from('config')
@@ -91,6 +93,22 @@ export function getSipConfigPDA(): [PublicKey, number] {
     [SIP_CONFIG_SEED],
     SIP_PRIVACY_PROGRAM_ID,
   )
+}
+
+/**
+ * Derive the native-SOL vault PDA.
+ * Seeds: [b"vault_sol"]
+ */
+export function getSolVaultPDA(programId: PublicKey): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync([VAULT_SOL_SEED], programId)
+}
+
+/**
+ * Derive the native-SOL fee PDA.
+ * Seeds: [b"fee_sol"]
+ */
+export function getSolFeePDA(programId: PublicKey): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync([FEE_SOL_SEED], programId)
 }
 
 /**


### PR DESCRIPTION
## Summary

Extends the `sipher-vault` privacy vault from **classic-SPL-only** custody to a **universal asset vault**: native SOL (lamports) + classic SPL + Token-2022 (with a conservative, fail-closed extension allowlist) — in one pass.

- **Native SOL custody** — deposit / withdraw / refund / fee-collect lamports directly, no wSOL wrapping.
- **Token-2022 support** — the token instructions migrate to the SPL `token_interface` (`transfer_checked`), so one code path serves both token programs, gated by a fail-closed extension allowlist.

**Scope:** on-chain program only (`programs/sipher-vault`). The SDK native-SOL scan / gasless cash-out and the integrator client are separate follow-on specs. Mainnet deploy is gated on the self-audit; **the devnet redeploy is intentionally left as a maintainer step** (see Reviewer action items).

## Architecture (two tracks, shared spine)

One `VaultConfig` / `DepositRecord` / announcement-CPI spine; two custody tracks:
- **Token track** (classic SPL + Token-2022): the existing instructions migrated to `Interface<TokenInterface>` + `transfer_checked` — classic SPL rides the identical path.
- **Native-SOL track**: new `*_sol` instructions custodying lamports in singleton `SolVault` / `SolFee` PDAs.

Native SOL is keyed by the sentinel `NATIVE_SOL_MINT = Pubkey::default()` (the all-zero pubkey — no real mint collides with it). The high-risk lamport handling is isolated in the native track so each track audits independently. The `create_transfer_announcement` CPI was extracted into a shared helper used by both withdrawal paths (only the mint argument differs).

### Instruction inventory (9 → 15)
| | Instructions |
|--|--|
| Unchanged | `initialize`, `set_paused` |
| Migrated to SPL interface (+ allowlist gate on `create_vault_token`) | `create_vault_token`, `create_fee_token`, `deposit`, `withdraw_private`, `refund`, `authority_refund`, `collect_fee` |
| **New (native SOL)** | `create_sol_vault`, `deposit_sol`, `withdraw_private_sol`, `refund_sol`, `authority_refund_sol`, `collect_fee_sol` |

### Token-2022 allowlist (fail-closed)
Enforced at `create_vault_token` (the choke point — `deposit` requires the per-mint vault PDA, and every rejected extension is init-immutable on the mint). Accepts **only**: no extensions, `MetadataPointer`, `TokenMetadata`, `InterestBearingConfig`. Rejects everything else (transfer-fee, transfer-hook, permanent-delegate, confidential, non-transferable, default-account-state) **and any unknown/future extension** (fail-closed even for malformed Token-2022 mint data).

## Safety (native lamport handling)
- Every lamport mutation is **checked-then-assign** — never bare `+=`/`-=` (BPF release wraps `u64` silently; a wrap here is a vault-drain).
- **Rent-reserve guard** on every debit of a SOL PDA (a SOL PDA can never be drained below its rent-exempt minimum).
- **Debit-first** ordering; **conservation** verified (`net + fee == amount`).
- Refund destination is the **original depositor only** (`has_one` + PDA-seed double-bind) — the authority cannot redirect principal, and the refund timeout is not bypassable by the authority.
- The stealth recipient is a `SystemAccount` (stricter than a plain writable account), so a lamport credit can never target a program-owned data account.

## Testing
**Full bankrun suite: 25/25** (classic-SPL 5 + Token-2022 allowlist 8 + native-SOL 12). Tests are **IDL-free solana-bankrun** with raw instructions — the Anchor IDL generator is broken on this toolchain (`rustc 1.94.1` vs `anchor 0.30.1`); the SBF binary is unaffected and is built with `anchor build --no-idl`. Built `.so`: 492,888 bytes.

Each commit passed a spec + code-quality review; the high-risk native withdrawal/refund work and the whole branch each had an additional architecture review — all clean, **no must-fix items**.

## Notable finding (for the SDK/relayer follow-on)
Modern Solana's runtime **rejects** a transaction that would leave a *fresh* (0-data) stealth recipient below the rent-exempt minimum (~890,880 lamports). The on-chain code is correct (no minimum-payout floor, per design) and the failure mode is **fail-closed** (atomic revert — no fund loss, no partial state). The SDK/relayer must therefore pre-fund the stealth recipient to rent-exemption, or ensure `net ≥ rent-exempt minimum`. Documented in `DEPLOYMENT.md`.

## Deferred follow-ups (non-blocking, tracked)
- A bankrun test for the **token** `authority_refund` migrated path (no builder yet; mechanically identical to the tested `refund` / `withdraw_private`, and the native `authority_refund_sol` IS tested). Low-risk coverage item.
- `create_fee_token` carries no allowlist check — confirmed **inert** by review (deposits require the gated `vault_token` PDA, so a disallowed mint can never accrue protocol fees through the program).

## Reviewer action items
1. Review the diff (start with `lib.rs` + the spec).
2. **Devnet redeploy is held for you** — `anchor build --no-idl` → `solana program deploy` (authority = devnet wallet) → run `scripts/create-sol-vault.ts` to init the SOL vault/fee PDAs. `DEPLOYMENT.md` has the procedure and a placeholder for the upgrade TX/slot.
3. Merge decision is yours (not self-merged).

Design spec + implementation plan are included in the diff under `docs/superpowers/`.
