### PR TITLE
chore(deps): add cargo coverage, group solana/langchain, watch program manifests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,47 @@
 version: 2
 updates:
-  # npm dependencies
+  # npm — root pnpm workspace + standalone Anchor program test harnesses
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/"
+      - "/programs/sip-privacy"
+      - "/programs/sipher-vault"
     schedule:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 10
     groups:
+      # Packages that must version together (they fail CI individually)
+      solana:
+        patterns:
+          - "@solana/*"
+      langchain:
+        patterns:
+          - "@langchain/*"
+          - "langchain"
       minor-and-patch:
         update-types:
           - "minor"
           - "patch"
     ignore:
-      # Ignore major version updates for critical crypto libs (review manually)
+      # Critical crypto libs — major bumps reviewed manually
       - dependency-name: "@noble/*"
         update-types: ["version-update:semver-major"]
+
+  # Cargo — deployed on-chain programs (security-critical)
+  - package-ecosystem: "cargo"
+    directories:
+      - "/programs/sip-privacy"
+      - "/programs/sipher-vault"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## What
Enhances the existing Dependabot config:
- Adds **cargo** coverage for the deployed on-chain programs (`/programs/sip-privacy`, `/programs/sipher-vault`).
- Adds **npm** coverage for those programs' test harnesses (only `/` was watched before).
- **Groups `@solana/*` and `@langchain/*`** so interdependent packages version (and test) together.

## Why
The org-wide audit (2026-06-18) found cargo uncovered everywhere — Rust crate advisories were invisible (refs #1161). The recent backlog also showed `@solana/kit`+`@solana/compat` and `@langchain/core`+`@langchain/openai` fail CI when bumped individually; grouping lets each pair move together.

## Notes
- Keeps the existing `@noble/*` major-ignore guard.
- The currently-open partial-bump PRs (#1148, #1149, #1151, #1153, #1154) can be closed after this merges so Dependabot recreates them grouped.