### PR TITLE
chore(sipher-vault): migrate to Anchor 1.0.2

### DIFF
--- a/docs/superpowers/plans/2026-06-20-anchor-1.0-migration.md
+++ b/docs/superpowers/plans/2026-06-20-anchor-1.0-migration.md
@@ -371,3 +371,15 @@ gh pr create --repo sip-protocol/sip-protocol --base main \
 **Placeholder scan:** No TBDs. The duplicate-mutable fixes are audit-driven (the compiler + runtime identify them), so the plan gives the decision criteria + concrete `dup` syntax rather than fabricated diffs — this is correct for a migration, not a placeholder.
 
 **Type/command consistency:** Build command `cargo build-sbf --tools-version v1.52` used consistently; `anchor build` for IDL; `pnpm install --ignore-workspace` + `pnpm test` for sipher-vault (matches the security-sweep finding that sipher-vault is a standalone pnpm project). Fixture path `tests/fixtures/sip_privacy.so` consistent with the harness reference found in `10-bankrun-classic-spl.test.ts`.
+
+---
+
+## Execution Outcome (2026-06-20, T3_32)
+
+Executed inline; shipped as two CI-green PRs (#1190 sipher-vault, #1191 sip-privacy), not self-merged. The migration deviated from the predictions above in three ways — all verified by build + `anchor idl build` + tests + `/code-review`:
+
+- **No `dup` constraints were needed** (Tasks 2 & 5 predicted these as the *primary* work). The duplicate-mutable audit found NO context with a legitimate aliasing pair in either program, so the stricter 1.0 default is left in place as free hardening — the "leave un-`dup`'d" branch the plan allowed.
+- **The dominant source work was two changes the plan listed only as "verify":** (1) `CpiContext::new[_with_signer]` now take `program_id: Pubkey`, not `AccountInfo` → `.key()` at every CPI site; (2) the granular Anchor-1.0 `solana_program` facade DROPPED the `hash` module → the `create_transfer_announcement` discriminator is hardcoded as a documented const. Plus one break the plan did not anticipate: **borsh 1.0 requires `#[borsh(use_discriminant)]`** on enums with explicit discriminants (sip-privacy `ProofType`).
+- **New: a BPF stack-frame regression.** Anchor 1.0's duplicate-mutable-key codegen enlarged `WithdrawPrivate::try_accounts` past the 4 KiB stack (24 → 288 bytes over); fixed by `Box<>`-ing the heavy `InterfaceAccount`s (also resolves sipher-vault self-audit M6). The CPI passthrough fields were converted from deprecated `AccountInfo` to `UncheckedAccount`.
+
+The Task 1 toolchain spike was GO with no `declare_id!`-guard or edition2024 issues. Full playbook: memory `reference_anchor-1.0-migration`.

--- a/docs/superpowers/plans/2026-06-20-anchor-1.0-migration.md
+++ b/docs/superpowers/plans/2026-06-20-anchor-1.0-migration.md
@@ -1,0 +1,373 @@
+# Anchor 0.30.1 → 1.0.2 Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the source of `programs/sip-privacy` and `programs/sipher-vault` from `anchor-lang 0.30.1` to `1.0.2`, get both building and their tests green, and clear Dependabot PRs #1169/#1171/#1172 — without redeploying the mainnet program.
+
+**Architecture:** Spike-first to prove the Anchor 1.0.2 / Agave-3.x / platform-tools-v1.52+ toolchain builds on this host, then migrate sipher-vault (devnet, bankrun-verifiable) end-to-end, then apply the proven pattern to sip-privacy (mainnet source, no redeploy). Two independent PRs.
+
+**Tech Stack:** Rust, Anchor 1.0.2, Solana/Agave CLI 3.0.13, `cargo build-sbf` (platform-tools v1.52+), `avm`, solana-bankrun (TS/mocha) for sipher-vault, `cargo test` for sip-privacy unit tests.
+
+**Spec:** `docs/superpowers/specs/2026-06-20-anchor-1.0-migration-design.md`
+
+## Global Constraints
+
+- Target: `anchor-lang = "1.0.2"` and `anchor-spl = "1.0.2"` in both program crates (keep sipher-vault's `init-if-needed` feature).
+- **No mainnet redeploy.** The deployed sip-privacy program (`S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at`) is untouched; this is source-only.
+- **Do NOT rename any `#[account]` struct or instruction handler** — discriminators are derived from these names and must stay byte-identical so existing on-chain accounts remain readable.
+- Build with explicit `cargo build-sbf --tools-version v1.52` (or newer) — Agave 3.0.13 may default to v1.51 which cannot compile edition2024.
+- GPG-signed commits (key `BF47B9DC1FA320FA`), conventional commit messages, **NO AI attribution**. One program per PR. Do **not** self-merge.
+- Work happens in the `anchor-1.0-migration` git worktree (off origin/main); branch `worktree-anchor-1.0-migration`. (sipher-vault and sip-privacy commits can share this branch; they go out as two PRs — or split into two branches at PR time. Keep commits per-program so they can be cherry-picked if needed.)
+- Breaking-change fix reference (from the spec §3.2): duplicate-mutable-account rejection (add `dup` where aliasing is intended), single `#[error_code]` (already satisfied), CPI-context program-info shape, `discriminator()`→`DISCRIMINATOR`, `#[instruction]` must match handler. Discriminator VALUES unchanged.
+
+---
+
+### Task 1: Toolchain spike on sipher-vault (go/no-go gate)
+
+Install Anchor 1.0.2 and prove the toolchain builds sipher-vault on this host. This task's manifest edits are the real start of the sipher-vault migration; if the gate fails, revert and stop.
+
+**Files:**
+- Modify: `programs/sipher-vault/programs/sipher-vault/Cargo.toml` (crate deps)
+- Modify: `programs/sipher-vault/Cargo.toml` (workspace deps — pin removal)
+- Modify: `programs/sipher-vault/Anchor.toml` (toolchain version)
+
+**Interfaces:**
+- Produces (consumed by all later build steps): the exact working build invocation (whether bare `anchor build` works or `cargo build-sbf --tools-version vX` is required), how the `declare_id!` build-time guard behaves, and the list of 1.0 compile errors to fix in Task 2.
+
+- [ ] **Step 1: Install Anchor 1.0.2 via avm**
+
+```bash
+avm install 1.0.2 && avm use 1.0.2
+anchor --version   # expect: anchor-cli 1.0.2
+```
+If `avm install 1.0.2` fails, refresh avm first: `cargo install --git https://github.com/solana-foundation/anchor avm --force` then retry.
+
+- [ ] **Step 2: Bump sipher-vault crate manifest**
+
+In `programs/sipher-vault/programs/sipher-vault/Cargo.toml`, under `[dependencies]`:
+```toml
+anchor-lang = { version = "1.0.2", features = ["init-if-needed"] }
+anchor-spl = "1.0.2"
+```
+Remove the edition2024 workaround block (the comment + the two pins):
+```toml
+# DELETE these lines:
+# # Pin blake3/constant_time_eq to avoid edition2024 requirement
+# # (Solana platform-tools BPF toolchain uses Cargo 1.84 which doesn't support it)
+# blake3 = "=1.8.5"
+# constant_time_eq = "=0.3.1"
+```
+
+- [ ] **Step 3: Relax the workspace-level pins**
+
+In `programs/sipher-vault/Cargo.toml`, under `[workspace.dependencies]`, remove the `constant_time_eq` exact pin and relax `blake3` (these are unused-in-source defensive pins for the old toolchain):
+```toml
+# Replace the workaround comment + pins with:
+[workspace.dependencies]
+blake3 = "1.8.5"
+# constant_time_eq pin removed — edition2024 builds under platform-tools v1.52+
+```
+If removing `constant_time_eq` from `[workspace.dependencies]` causes a "not found in workspace" error (a member referenced it via `.workspace = true`), instead set `constant_time_eq = "0.4"` there.
+
+- [ ] **Step 4: Bump Anchor.toml toolchain**
+
+In `programs/sipher-vault/Anchor.toml`:
+```toml
+[toolchain]
+anchor_version = "1.0.2"
+```
+
+- [ ] **Step 5: Attempt the build (the spike)**
+
+```bash
+cd programs/sipher-vault
+anchor build 2>&1 | tee /tmp/sv-build.log
+# If anchor build's build-sbf defaults to v1.51 / edition2024 error appears:
+cargo build-sbf --tools-version v1.52 2>&1 | tee /tmp/sv-buildsbf.log
+```
+Expected outcomes to characterize (record in the commit/PR notes):
+- Whether `anchor build` works directly or `--tools-version v1.52` is required.
+- Whether the `declare_id!` guard errors (program-keypair mismatch) — if so, note the workaround (e.g. `anchor build` picks up `target/deploy/sipher_vault-keypair.json`, or pass the keypair; for a CI/local build that isn't deploying, the keypair in the repo/`target` should satisfy it).
+- The list of `anchor-lang 1.0` **compile errors** (these are Task 2's work — most likely duplicate-mutable-account rejections).
+
+- [ ] **Step 6: GO / NO-GO decision**
+
+- **GO** if the toolchain installs and the build progresses to *Anchor-API* compile errors (i.e., the toolchain itself works; remaining errors are source migration). Proceed to Task 2.
+- **NO-GO** if the toolchain fundamentally cannot build (e.g., platform-tools won't fetch, Agave 3.0.13 incompatible with anchor 1.0.2 in a way `--tools-version` can't fix). **Stop, revert the manifest edits (`git checkout -- .`), and report to RECTOR with the logs.** Do not touch sip-privacy.
+
+- [ ] **Step 7: Commit the manifest bump (only if GO)**
+
+```bash
+cd /Users/rector/local-dev/sip-protocol/.claude/worktrees/anchor-1.0-migration
+git add programs/sipher-vault/Cargo.toml programs/sipher-vault/programs/sipher-vault/Cargo.toml programs/sipher-vault/Anchor.toml
+git commit -S -m "chore(sipher-vault): bump anchor-lang/anchor-spl to 1.0.2 + drop edition2024 pins"
+```
+
+---
+
+### Task 2: sipher-vault — fix Anchor 1.0 breaking changes to a clean build
+
+Resolve the compile errors surfaced by Task 1 until sipher-vault builds with IDL. The dominant change is the duplicate-mutable-account rejection.
+
+**Files:**
+- Modify: `programs/sipher-vault/programs/sipher-vault/src/lib.rs` (the `#[derive(Accounts)]` contexts + any CPI calls)
+
+**Interfaces:**
+- Consumes: the working build command from Task 1.
+- Produces: a sipher-vault `.so` + IDL that build cleanly (consumed by Task 3).
+
+- [ ] **Step 1: Audit every multi-writable Accounts context**
+
+For each `#[derive(Accounts)]` struct in `lib.rs`, list the accounts marked `mut` (or `init`/`init_if_needed`). For any pair of writable accounts that *could* be the same pubkey at runtime (e.g. a payout token account and a stealth token account, vault PDA vs fee PDA), Anchor 1.0 now rejects the tx by default.
+
+- [ ] **Step 2: Apply the `dup` constraint where aliasing is legitimate**
+
+For each intentionally-aliasable pair, add the `dup` constraint to the *second* account:
+```rust
+// Before (0.30 silently allowed alias):
+#[account(mut)]
+pub fee_token_account: InterfaceAccount<'info, TokenAccount>,
+
+// After (1.0 — allow the alias explicitly):
+#[account(mut, dup)]
+pub fee_token_account: InterfaceAccount<'info, TokenAccount>,
+// or with a custom error if they must NOT alias in some path:
+#[account(mut, dup @ VaultError::DuplicateAccount)]
+```
+Where two writable accounts must **never** be the same key, leave them un-`dup`'d (the stricter default is the desired behavior — it's a free hardening).
+
+- [ ] **Step 3: Verify CPI context shape (token_interface::transfer_checked)**
+
+Confirm each `token_interface::transfer_checked(CpiContext::new(cpi_program, Accounts{..})...)` call compiles under 1.0 (the invoked program's `AccountInfo` is passed as the first `CpiContext::new` arg, not inside the accounts struct). Fix any that the compiler flags.
+
+- [ ] **Step 4: Build until clean**
+
+```bash
+cd programs/sipher-vault
+cargo build-sbf --tools-version v1.52    # use the exact command Task 1 proved
+anchor build                              # confirm IDL generates too
+```
+Expected: `target/deploy/sipher_vault.so` + `target/idl/sipher_vault.json` produced, zero errors.
+
+- [ ] **Step 5: Commit the source fixes**
+
+```bash
+cd /Users/rector/local-dev/sip-protocol/.claude/worktrees/anchor-1.0-migration
+git add programs/sipher-vault/programs/sipher-vault/src/lib.rs
+git commit -S -m "fix(sipher-vault): migrate Accounts contexts + CPIs to Anchor 1.0"
+```
+
+---
+
+### Task 3: sipher-vault — bankrun verification (26 tests)
+
+The bankrun suite loads both `sipher_vault.so` and `sip_privacy.so` (its `withdraw_private` CPIs into sip-privacy), so build sip-privacy's `.so` as a fixture too.
+
+**Files:**
+- Modify: `programs/sipher-vault/tests/fixtures/` (add `sip_privacy.so` fixture — currently empty except `.gitkeep`)
+
+**Interfaces:**
+- Consumes: `sipher_vault.so` from Task 2; the build command from Task 1.
+
+- [ ] **Step 1: Build the sip_privacy.so fixture**
+
+The bankrun harness loads `tests/fixtures/sip_privacy.so` by name. Build it from sip-privacy source (still on 0.30.1 at this point — that is fine; a `.so` is `.so`):
+```bash
+cd /Users/rector/local-dev/sip-protocol/.claude/worktrees/anchor-1.0-migration/programs/sip-privacy
+cargo build-sbf --tools-version v1.52
+cp target/deploy/sip_privacy.so ../sipher-vault/tests/fixtures/sip_privacy.so
+```
+If sip-privacy (0.30.1) won't `build-sbf` under the new toolchain, build just its `.so` after Task 5's migration instead, and run Task 3 after Task 5. (Record which order worked.)
+
+- [ ] **Step 2: Confirm the sipher_vault workspace binary is discoverable**
+
+Check how `startVault` in `tests/sipher-vault/10-bankrun-classic-spl.test.ts` loads the `sipher_vault` program (workspace binary path or fixture). Ensure `target/deploy/sipher_vault.so` from Task 2 is where the harness expects it.
+
+- [ ] **Step 3: Install test deps + run the bankrun suite**
+
+```bash
+cd /Users/rector/local-dev/sip-protocol/.claude/worktrees/anchor-1.0-migration/programs/sipher-vault
+pnpm install --ignore-workspace
+pnpm test 2>&1 | tail -40
+```
+Expected: the 3 files (`10/11/12-*.test.ts`) pass — 26 tests, 0 failures. (Earlier this failed only with "Program file data not available for sip_privacy" — Step 1 fixes that.)
+
+- [ ] **Step 4: If a test fails on the duplicate-mutable change**
+
+A test that deliberately passes the same key for two writable accounts will now fail unless that path got a `dup` in Task 2. Decide per case: add `dup` (legitimate alias) or fix the test (the alias was a test artifact). Re-run.
+
+---
+
+### Task 4: sipher-vault — commit fixture + open PR (closes #1171, supersedes #1172)
+
+**Files:**
+- Add: `programs/sipher-vault/tests/fixtures/sip_privacy.so` (if the repo tracks fixtures; if `.gitignore` excludes `.so`, skip committing it and note that CI must build it)
+
+- [ ] **Step 1: Decide whether the .so fixture is committed or built in CI**
+
+```bash
+cd /Users/rector/local-dev/sip-protocol/.claude/worktrees/anchor-1.0-migration
+git check-ignore programs/sipher-vault/tests/fixtures/sip_privacy.so && echo "IGNORED — do not commit; CI must build" || echo "tracked — commit it"
+```
+Follow the result. If committing, `git add` it; otherwise document the CI build step in the PR.
+
+- [ ] **Step 2: Final local verification before PR**
+
+```bash
+cd /Users/rector/local-dev/sip-protocol/.claude/worktrees/anchor-1.0-migration/programs/sipher-vault
+cargo build-sbf --tools-version v1.52 && anchor build && pnpm test 2>&1 | tail -15
+```
+Expected: build clean, 26 tests pass.
+
+- [ ] **Step 3: Push branch + open the PR**
+
+```bash
+cd /Users/rector/local-dev/sip-protocol/.claude/worktrees/anchor-1.0-migration
+git push -u origin worktree-anchor-1.0-migration
+gh pr create --repo sip-protocol/sip-protocol --base main --head worktree-anchor-1.0-migration \
+  --title "chore(sipher-vault): migrate to Anchor 1.0.2" \
+  --body "Migrates programs/sipher-vault to anchor-lang/anchor-spl 1.0.2, drops the edition2024 blake3/constant_time_eq pins (now buildable under platform-tools v1.52+/rustc 1.89), and applies the 1.0 duplicate-mutable-account constraints. Builds with cargo build-sbf --tools-version v1.52 + anchor build; 26 bankrun tests pass. No on-chain redeploy. Closes #1171. Supersedes #1172 (the constant_time_eq pin is removed, so it floats to 0.4.x). Spec: docs/superpowers/specs/2026-06-20-anchor-1.0-migration-design.md"
+```
+
+- [ ] **Step 4: Close the superseded Dependabot PR #1172**
+
+```bash
+gh pr close 1172 --repo sip-protocol/sip-protocol --comment "Superseded by the sipher-vault Anchor 1.0.2 migration, which removes the constant_time_eq=0.3.1 pin entirely (it now floats to 0.4.x under the platform-tools v1.52+ toolchain). See the migration PR."
+```
+
+- [ ] **Step 5: Do NOT self-merge. Report the PR URL + CI status to RECTOR.**
+
+---
+
+### Task 5: sip-privacy — bump manifests + Anchor.toml + build & fix
+
+Apply the proven pattern to the mainnet program's source. Extra scrutiny on the duplicate-mutable audit of the claim/co-signer contexts.
+
+**Files:**
+- Modify: `programs/sip-privacy/programs/sip-privacy/Cargo.toml` (crate deps)
+- Modify: `programs/sip-privacy/Cargo.toml` (`[workspace.dependencies]` pins)
+- Modify: `programs/sip-privacy/Anchor.toml`
+- Modify: `programs/sip-privacy/programs/sip-privacy/src/lib.rs` (Accounts contexts, CPIs)
+
+**Interfaces:**
+- Consumes: the working build command + breaking-change fix patterns proven in Tasks 1–2.
+
+- [ ] **Step 1: Bump the crate manifest**
+
+In `programs/sip-privacy/programs/sip-privacy/Cargo.toml`:
+```toml
+anchor-lang = "1.0.2"
+anchor-spl = "1.0.2"
+```
+Update the stale comment on line 24 ("Use Anchor 0.30.1 for compatibility with solana platform-tools v1.51") — remove or replace it.
+
+- [ ] **Step 2: Relax the workspace pins**
+
+In `programs/sip-privacy/Cargo.toml` `[workspace.dependencies]`, mirror Task 1 Step 3: relax `blake3 = "1.8.5"`, remove the `constant_time_eq = "=0.3.1"` pin (or set `"0.4"` if a member references it via `.workspace`), and remove the stale "Workaround" comment.
+
+- [ ] **Step 3: Bump Anchor.toml**
+
+```toml
+[toolchain]
+anchor_version = "1.0.2"
+```
+
+- [ ] **Step 4: Build and fix breaking changes**
+
+```bash
+cd programs/sip-privacy
+cargo build-sbf --tools-version v1.52
+anchor build
+```
+Fix compile errors using the same playbook as Task 2:
+- **Duplicate-mutable audit** — sip-privacy's claim contexts pass the stealth account + recipient as co-signers, and the token contexts have `sender`/`stealth`/`fee` token accounts. Check whether any two writable accounts can be the same key (e.g. fee account == stealth account when fee recipient is the stealth owner). Add `dup` where the alias is legitimate; otherwise leave strict.
+- **CPI shape** — confirm `token::transfer(CpiContext::new(...))` (classic SPL Token) compiles under 1.0.
+- **`#[instruction(nullifier: [u8; 32])]`** (2 sites) — confirm they still match the handler signatures.
+- **`declare_id!` guard** — `declare_id!("S1PMF…")` must match the program keypair at build; use the same handling proven in Task 1.
+
+Expected: `target/deploy/sip_privacy.so` + `target/idl/sip_privacy.json`, zero errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/rector/local-dev/sip-protocol/.claude/worktrees/anchor-1.0-migration
+git add programs/sip-privacy/Cargo.toml programs/sip-privacy/programs/sip-privacy/Cargo.toml programs/sip-privacy/Anchor.toml programs/sip-privacy/programs/sip-privacy/src/lib.rs
+git commit -S -m "chore(sip-privacy): migrate to Anchor 1.0.2 (source only, no redeploy)"
+```
+
+---
+
+### Task 6: sip-privacy — cargo test verification
+
+**Files:**
+- Test: `programs/sip-privacy/programs/sip-privacy/src/commitment/mod.rs` (`#[cfg(test)]`)
+- Test: `programs/sip-privacy/programs/sip-privacy/src/zk_verifier/mod.rs` (`#[cfg(test)]`)
+
+- [ ] **Step 1: Run the Rust unit tests (host target)**
+
+```bash
+cd /Users/rector/local-dev/sip-protocol/.claude/worktrees/anchor-1.0-migration/programs/sip-privacy/programs/sip-privacy
+cargo test 2>&1 | tail -30
+```
+Expected: the `commitment` and `zk_verifier` module tests pass (host-side, no validator needed).
+
+- [ ] **Step 2: Confirm the bankrun fixture still loads (regression)**
+
+If Task 3 built `sip_privacy.so` from 0.30.1 source, rebuild it from the migrated source and re-run the sipher-vault bankrun suite to confirm the migrated sip-privacy still satisfies the CPI contract (TransferRecord PDA created, discriminators unchanged):
+```bash
+cd /Users/rector/local-dev/sip-protocol/.claude/worktrees/anchor-1.0-migration/programs/sip-privacy
+cargo build-sbf --tools-version v1.52
+cp target/deploy/sip_privacy.so ../sipher-vault/tests/fixtures/sip_privacy.so
+cd ../sipher-vault && pnpm test 2>&1 | tail -15
+```
+Expected: 26 bankrun tests still pass (proves the migrated sip-privacy CPI is byte-compatible).
+
+- [ ] **Step 3: The TS mocha file (`tests/sip-privacy.ts`) is best-effort**
+
+It has no npm `test` script and needs a local validator. Do not block on it; if `anchor test` runs trivially under 1.0, note the result, otherwise defer (build + IDL-gen success + cargo test + the bankrun regression are the gate).
+
+---
+
+### Task 7: sip-privacy — commit + open PR (closes #1169)
+
+- [ ] **Step 1: Final local verification**
+
+```bash
+cd /Users/rector/local-dev/sip-protocol/.claude/worktrees/anchor-1.0-migration/programs/sip-privacy
+cargo build-sbf --tools-version v1.52 && anchor build
+cd programs/sip-privacy && cargo test 2>&1 | tail -10
+```
+Expected: clean build + IDL + unit tests pass.
+
+- [ ] **Step 2: Open the PR**
+
+If sharing the branch with sipher-vault, the sip-privacy commits ride the same branch; open a second PR only if the sipher-vault PR has already merged, otherwise note in the PR that it stacks on / follows the sipher-vault PR. Cleanest: open the sip-privacy PR after the sipher-vault PR merges, or use a separate branch cut from the sip-privacy commits. Decide with RECTOR at this point.
+
+```bash
+gh pr create --repo sip-protocol/sip-protocol --base main \
+  --title "chore(sip-privacy): migrate to Anchor 1.0.2 (source only)" \
+  --body "Migrates programs/sip-privacy to anchor-lang/anchor-spl 1.0.2 (source only — the deployed mainnet program is untouched; redeploy stays a separate B5-gated decision). Drops the edition2024 pins, applies 1.0 duplicate-mutable constraints. Discriminators are byte-identical (PR #3098), confirmed by the sipher-vault bankrun CPI regression. cargo test (commitment + zk_verifier) passes; build + IDL clean under cargo build-sbf --tools-version v1.52. Closes #1169. Spec: docs/superpowers/specs/2026-06-20-anchor-1.0-migration-design.md"
+```
+
+- [ ] **Step 3: Do NOT self-merge. Report PR URL + CI to RECTOR.**
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Manifest bumps (both programs) → Tasks 1, 5 ✓
+- Drop edition2024 pins → Tasks 1 (sipher-vault), 5 (sip-privacy) ✓
+- Anchor.toml toolchain bump → Tasks 1, 5 ✓
+- Duplicate-mutable audit → Tasks 2, 5 ✓
+- CPI shape / `#[instruction]` / `declare_id` guard → Tasks 2, 5 ✓
+- Toolchain spike / go-no-go → Task 1 ✓
+- sipher-vault bankrun (with sip_privacy.so fixture) → Tasks 3, 6 ✓
+- sip-privacy cargo test → Task 6 ✓
+- Close #1169/#1171, supersede #1172 → Tasks 4, 7 ✓
+- No redeploy / discriminators unchanged → Global Constraints + Task 6 regression ✓
+- Two PRs, GPG, no self-merge → Tasks 4, 7 + Global Constraints ✓
+
+**Placeholder scan:** No TBDs. The duplicate-mutable fixes are audit-driven (the compiler + runtime identify them), so the plan gives the decision criteria + concrete `dup` syntax rather than fabricated diffs — this is correct for a migration, not a placeholder.
+
+**Type/command consistency:** Build command `cargo build-sbf --tools-version v1.52` used consistently; `anchor build` for IDL; `pnpm install --ignore-workspace` + `pnpm test` for sipher-vault (matches the security-sweep finding that sipher-vault is a standalone pnpm project). Fixture path `tests/fixtures/sip_privacy.so` consistent with the harness reference found in `10-bankrun-classic-spl.test.ts`.

--- a/docs/superpowers/specs/2026-06-20-anchor-1.0-migration-design.md
+++ b/docs/superpowers/specs/2026-06-20-anchor-1.0-migration-design.md
@@ -1,0 +1,111 @@
+# Design: Anchor 0.30.1 → 1.0.2 Migration (sip-privacy + sipher-vault)
+
+**Date:** 2026-06-20
+**Status:** Approved (design) — pending spec review → implementation plan
+**Scope owner:** RECTOR
+**Tracks:** Dependabot PRs #1169 (sip-privacy), #1171 (sipher-vault), #1172 (constant_time_eq); epic #1161 (Anchor cross-program upgrade)
+
+---
+
+## 1. Goal & Scope
+
+Migrate the **source** of the two Anchor programs in this repo from `anchor-lang 0.30.1` to `1.0.2`, get both building and their tests green, and clear the related Dependabot alerts.
+
+**In scope:**
+- `programs/sip-privacy` (mainnet-deployed program `S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at`) — **source only**.
+- `programs/sipher-vault` (devnet program `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB`).
+- Close/supersede Dependabot PRs #1169, #1171, #1172.
+
+**Out of scope (explicit):**
+- **No mainnet redeploy.** The deployed sip-privacy program is left untouched; redeploying from the 1.0 build is a separate, B5-Squads-multisig-gated decision (see `reference_squads-multisig-sip-governance`).
+- **sip-arcium** (separate repo `sip-arcium-program`, Anchor 0.32.1) — deferred to its own follow-up; it needs the `arcup`/`arcium` toolchain (not installed here) and Arcis circuit reconciliation.
+
+**Success criteria:**
+1. Both program crates declare `anchor-lang`/`anchor-spl = "1.0.2"` and compile.
+2. `anchor build` (or `cargo build-sbf --tools-version v1.52`) produces the program `.so` + IDL for each.
+3. sipher-vault bankrun suite (26 tests, from #1162) passes against freshly built `.so` files — note it loads **both** `sipher_vault` and `sip_privacy.so` (as `tests/fixtures/sip_privacy.so`), since `withdraw_private` CPIs into sip-privacy. sip-privacy's **Rust unit tests** (`cargo test` — `commitment/` + `zk_verifier/` modules) pass.
+4. The two Dependabot anchor PRs (#1169/#1171) are closeable; #1172 is superseded.
+5. No change to on-chain account/instruction discriminators (existing accounts remain readable).
+
+---
+
+## 2. Why this is feasible — Anchor 1.0 dissolves the toolchain wall
+
+The "wall" (see `reference_solana-anchor-toolchain-idl-blocker`, `reference_solana-blake3-edition2024-toolchain`) had two causes, **both fixed by moving to 1.0**:
+
+1. **IDL-gen failure** — anchor-0.30.1's proc-macros choke on host rustc 1.94. Anchor 1.0.x has an MSRV of rustc 1.89 and rebuilds the IDL-build path for the modern toolchain, so the IDL generates again. (Anchor PR #4325 also caches `CrateContext` for faster IDL build.)
+2. **edition2024 rejection under `build-sbf`** — platform-tools v1.51 bundles rustc 1.84.1, which cannot compile edition2024 (this forced the `constant_time_eq = "=0.3.1"` pin). Anchor 1.0.x / Agave 3.x build against **platform-tools v1.52+, which bundles rustc 1.89.0** — edition2024 works. Verified: `anza-xyz/rust` branches `solana-tools-v1.52`/`v1.53` report version `1.89.0`.
+
+**Host readiness:** Agave CLI 3.0.13 + rustc 1.94.1 + avm 0.32.1 are installed. anchor 1.0.2 targets Agave 3.x and MSRV rustc 1.89 (1.94 ≥ 1.89 ✓). The documented known-good combo is anchor-cli 1.0.2 + Agave 3.1.10 + rustc 1.85+, `build-sbf` on platform-tools v1.52+.
+
+**One empirical unknown (gates the work):** Agave **3.0.13**'s *default* `build-sbf` tools-version. Agave 3.0.6 defaulted to v1.51 (breaks edition2024). Mitigation is trivial and explicit: pass `--tools-version v1.52` (or upgrade CLI to 3.1.10). The toolchain spike (§5, step 1) resolves this before any mainnet-program work.
+
+**Discriminators are byte-identical 0.30→1.0** (still `sha256("account:<Name>")[0..8]` / `sha256("global:<ix>")[0..8]`; Anchor PR #3098). Only the trait API changed (`discriminator()` method → `DISCRIMINATOR` const, PR #3163). So existing on-chain accounts and clients are not broken — important even though we do not redeploy.
+
+---
+
+## 3. Migration surface
+
+### 3.1 Manifest changes (both programs)
+- Program crate `Cargo.toml`: `anchor-lang`/`anchor-spl` `"0.30.1"` → `"1.0.2"` (keep `init-if-needed` feature on sipher-vault).
+- Drop the edition2024 workaround pins where present: `blake3 = "=1.8.5"` and `constant_time_eq = "=0.3.1"` (let them float; edition2024 now builds). Update the stale "use 0.30.1 for platform-tools v1.51" comments. Pins exist in:
+  - `programs/sip-privacy/Cargo.toml` (workspace)
+  - `programs/sipher-vault/Cargo.toml` (workspace) and `programs/sipher-vault/programs/sipher-vault/Cargo.toml` (crate)
+- `Anchor.toml` (both): `[toolchain] anchor_version = "0.30.1"` → `"1.0.2"`.
+- `idl-build` feature block is already present in both crates — no change needed (just confirm `anchor-spl/idl-build` is listed).
+
+### 3.2 Source changes
+| Change | Applies? | Action |
+|--------|----------|--------|
+| **Duplicate mutable accounts rejected by default** (PR #3946; `init_if_needed` included, #4239; only types that serialize on exit, #4202) | **Yes — primary work** | Audit every multi-writable `#[derive(Accounts)]` context in both programs. Where two writable accounts can legitimately be the same key, add the `dup` constraint (`#[account(mut, dup)]` or `#[account(mut, dup @ Err)]`). Candidates: sip-privacy claim co-signers; sipher-vault payout vs stealth accounts. Otherwise leave as-is (the stricter default is desirable). |
+| **Single `#[error_code]` per program** (PR #4300) | No | Each program already has exactly one (`sip-privacy` lib.rs; `sipher-vault` errors.rs). |
+| **CPI context: invoked-program AccountInfo removed** (PR #2762) | Verify | Confirm `token::transfer(CpiContext::new(program, accts))` (sip-privacy) and `token_interface::transfer_checked(...)` (sipher-vault) match the 1.0 `CpiContext::new(cpi_program, accounts).with_signer(seeds)` shape. |
+| **`discriminator()` method → `DISCRIMINATOR` const** (PR #3163) | Verify | Replace any `T::discriminator()` calls in program code (likely none; mostly client/test). |
+| **`#[instruction(...)]` must match handler** (PR #4000) | Verify | 2 sites in sip-privacy (`#[instruction(nullifier: [u8; 32])]`); existing/working, confirm. |
+| **Token / TokenInterface (Token-2022)** | No | Interface API unchanged since 0.30; sip-privacy uses classic `token::`, sipher-vault uses `token_interface::` — both stable. |
+| **`init_if_needed`** | No | Still a feature flag; keep it. Now included in the duplicate-mutable check above. |
+| **`emit!` / `#[event]`** | No (no evidence of change) | `emit_transfer_announcement` helper unaffected. |
+| **`declare_id!` build-time match guard** (PR #4018) | Build-time | 1.0 checks `declare_id!` against the program keypair at build. sip-privacy may need the program keypair available or a build flag — resolve in the spike. |
+
+---
+
+## 4. Verification strategy
+
+- **Build:** `anchor build` for each program (or `cargo build-sbf --tools-version v1.52` if anchor's default tools-version is still v1.51). Must emit `.so` + IDL.
+- **sipher-vault tests:** build the `sipher_vault` `.so` **and** `sip_privacy.so` (the suite loads `tests/fixtures/sip_privacy.so` because `withdraw_private` CPIs into sip-privacy), then run the 26-test bankrun suite (`10/11/12-*.test.ts`). These are currently un-runnable (empty `tests/fixtures/`, build blocked); the 1.0 toolchain makes them runnable for the first time since the wall appeared. **Consequence:** sip-privacy's `.so` gets built during sipher-vault verification regardless of PR order.
+- **sip-privacy tests:** run its **Rust unit tests** (`cargo test`: `commitment/` + `zk_verifier/` modules). Its Anchor/TS mocha file (`tests/sip-privacy.ts`) has no npm `test` script and needs a local validator — treat as best-effort / defer unless trivially runnable under the 1.0 toolchain (build + IDL-gen success is the hard gate there).
+- **Regression guard:** the SDK/JS suite is unaffected (Rust-only change) but CI runs it anyway.
+- **No on-chain action.** Building the `.so` is local; nothing is deployed.
+
+---
+
+## 5. Approach — A: spike → sipher-vault → sip-privacy (two PRs)
+
+1. **Toolchain spike (go/no-go gate).** `avm install 1.0.2 && avm use 1.0.2`; bump sipher-vault's Cargo + Anchor.toml; attempt `anchor build` / `cargo build-sbf --tools-version v1.52`. Confirm the `.so` + IDL build on this host and resolve the declare_id-guard + default-tools-version unknowns. **If the spike fails, stop and reassess before touching the mainnet program.**
+2. **sipher-vault PR** (devnet, lower stakes, only bankrun-verifiable one). Full migration: manifests, drop pins, dup-mutable audit, build `.so`, run 26 bankrun tests. → closes #1171, supersedes #1172.
+3. **sip-privacy PR** (mainnet *source*, no redeploy). Apply the proven pattern with extra dup-mutable scrutiny on the claim/co-signer contexts; build + run tests. → closes #1169.
+
+**Two PRs** — matches the two Dependabot PRs, independently reviewable/revertible, one-fix-per-PR.
+
+**Rejected alternatives:** B (sip-privacy first) loses early bankrun feedback and shakes out the toolchain on the mainnet program instead of devnet; C (single combined PR) couples two independent programs and violates one-fix-per-PR.
+
+---
+
+## 6. Coordination & risks
+
+- **#1172 (constant_time_eq 0.3.1 → 0.4.2):** superseded — the migration drops the pin, so `constant_time_eq` floats to 0.4.x under the v1.52+ toolchain. Close #1172 with a pointer to the sipher-vault migration PR.
+- **sipher-vault audit-hardening worktree** (`feat+sipher-vault-audit-hardening`): currently only the `SELF-AUDIT.md` doc is committed; the M1/M2 *code* fixes are pending/not-started, so no source conflict today. The 1.0 migration lands first; that work rebases onto 1.0 when it resumes (small, different concern). Flagged for awareness.
+- **declare_id guard:** may require the program keypair locally or a build flag for sip-privacy; resolved in the spike.
+- **Agave 3.0.13 default tools-version:** unknown; mitigated by explicit `--tools-version v1.52`.
+- **bankrun ↔ build target:** bankrun bundles `solana-program-test 1.18.0`; it loads a compiled BPF `.so` regardless of the build toolchain, so an Agave-3.x/Anchor-1.0-built `.so` should load — confirm in the spike.
+- **Isolation:** work happens in the `anchor-1.0-migration` git worktree (off origin/main), separate from the security-sweep worktree.
+
+---
+
+## 7. References
+
+- Anchor CHANGELOG / releases: github.com/solana-foundation/anchor (PRs #3098, #3163, #3946, #4239, #4202, #4300, #2762, #4000, #4018, #4325).
+- Anchor installation + 0.31 release notes: anchor-lang.com/docs/installation, .../updates/release-notes/0-31-0.
+- Agave edition2024 issue: github.com/anza-xyz/agave/issues/8443 (platform-tools v1.51 = rustc 1.84.1, no edition2024).
+- platform-tools rustc version: anza-xyz/rust branches `solana-tools-v1.52`/`v1.53` = 1.89.0.
+- Internal memory: `reference_solana-anchor-toolchain-idl-blocker`, `reference_solana-blake3-edition2024-toolchain`, `reference_squads-multisig-sip-governance`.

--- a/programs/sipher-vault/Anchor.toml
+++ b/programs/sipher-vault/Anchor.toml
@@ -1,5 +1,5 @@
 [toolchain]
-anchor_version = "0.30.1"
+anchor_version = "1.0.2"
 package_manager = "pnpm"
 
 [features]

--- a/programs/sipher-vault/Cargo.lock
+++ b/programs/sipher-vault/Cargo.lock
@@ -4,30 +4,30 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.4.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
+ "crypto-common",
  "generic-array",
 ]
 
 [[package]]
 name = "aes"
-version = "0.7.5"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
- "opaque-debug",
+ "cpufeatures",
 ]
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589c637f0e68c877bbd59a4599bbe849cac8e5f3e4b5a3ebae8f528cd218dcdc"
+checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
 dependencies = [
  "aead",
  "aes",
@@ -36,29 +36,6 @@ dependencies = [
  "polyval",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
 ]
 
 [[package]]
@@ -71,18 +48,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "anchor-attribute-access-control"
-version = "0.30.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47fe28365b33e8334dd70ae2f34a43892363012fe239cf37d2ee91693575b1f8"
+checksum = "0b8cd233e382ea499e3c1e51bf4f0cb367abb37bb64e9e3667a5d618af3fe265"
 dependencies = [
- "anchor-syn",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -90,12 +60,11 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-account"
-version = "0.30.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c288d496168268d198d9b53ee9f4f9d260a55ba4df9877ea1d4486ad6109e0f"
+checksum = "2e12171382e24c5cda6b0f7236a4f6bb9b657da997780c88a0ef794a419298bf"
 dependencies = [
  "anchor-syn",
- "bs58 0.5.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -103,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-constant"
-version = "0.30.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b77b6948d0eeaaa129ce79eea5bbbb9937375a9241d909ca8fb9e006bb6e90"
+checksum = "510f8db71375446405dfabdaf157fb7d3fbf33470c98ed75fad4c467e8ca0080"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -114,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-error"
-version = "0.30.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d20bb569c5a557c86101b944721d865e1fd0a4c67c381d31a44a84f07f84828"
+checksum = "72b203169a49ea74da7782281e740ea8e21017c85f8f3b1ab452712c9796d28f"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -125,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-event"
-version = "0.30.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cebd8d0671a3a9dc3160c48598d652c34c77de6be4d44345b8b514323284d57"
+checksum = "c50a462651e573ec6cc632e8f607e8b1e11f620f6fc26badaeff04fd49f45cc1"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -137,26 +106,24 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-program"
-version = "0.30.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb2a5eb0860e661ab31aff7bb5e0288357b176380e985bade4ccb395981b42d"
+checksum = "84704ee25a7e788afd9d846945cba536cfdcd53b463e8a337cf237cd897ca4d9"
 dependencies = [
  "anchor-lang-idl",
  "anchor-syn",
  "anyhow",
- "bs58 0.5.1",
  "heck",
  "proc-macro2",
  "quote",
- "serde_json",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "anchor-derive-accounts"
-version = "0.30.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04368b5abef4266250ca8d1d12f4dff860242681e4ec22b885dcfe354fd35aa1"
+checksum = "98bf49664527c7bb0ebca04e9b5bfb618d6ceb849ef44a8149241d244bbfb0f6"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -165,12 +132,12 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-serde"
-version = "0.30.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bb0e0911ad4a70cab880cdd6287fe1e880a1a9d8e4e6defa8e9044b9796a6c"
+checksum = "8140a40827bdfd74720f1f3084778fa081262f2f43bd4bdbc350f98ce1b341c6"
 dependencies = [
  "anchor-syn",
- "borsh-derive-internal 0.10.4",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -178,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-space"
-version = "0.30.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef415ff156dc82e9ecb943189b0cb241b3a6bfc26a180234dc21bd3ef3ce0cb"
+checksum = "1ee5b6fa5dde037399d3e0bb322a1c7360ad8adc6b6afdd797d19566c039dcfb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -189,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-lang"
-version = "0.30.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6620c9486d9d36a4389cab5e37dc34a42ed0bfaa62e6a75a2999ce98f8f2e373"
+checksum = "1bac4de7c9a9a69180798af701e22302cc0ebf2ef683b843706a1b7809454735"
 dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
@@ -203,14 +170,33 @@ dependencies = [
  "anchor-derive-serde",
  "anchor-derive-space",
  "anchor-lang-idl",
- "arrayref",
  "base64 0.21.7",
  "bincode",
- "borsh 0.10.4",
+ "borsh",
  "bytemuck",
- "getrandom 0.2.17",
- "solana-program",
- "thiserror",
+ "const-crypto",
+ "solana-account-info",
+ "solana-clock",
+ "solana-cpi",
+ "solana-define-syscall 3.0.0",
+ "solana-feature-gate-interface",
+ "solana-instruction",
+ "solana-instructions-sysvar",
+ "solana-invoke",
+ "solana-loader-v3-interface",
+ "solana-msg",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "solana-stake-interface",
+ "solana-system-interface 2.0.0",
+ "solana-sysvar",
+ "solana-sysvar-id",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -225,7 +211,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -240,36 +226,35 @@ dependencies = [
 
 [[package]]
 name = "anchor-spl"
-version = "0.30.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04bd077c34449319a1e4e0bc21cea572960c9ae0d0fefda0dd7c52fcc3c647a3"
+checksum = "0b8005eef3a48a9a8cb21b126ae3bb252647e353afe6ef7f19e545177801c841"
 dependencies = [
  "anchor-lang",
- "spl-associated-token-account",
+ "spl-associated-token-account-interface",
  "spl-pod",
- "spl-token",
- "spl-token-2022",
+ "spl-token-2022-interface",
  "spl-token-group-interface",
+ "spl-token-interface",
  "spl-token-metadata-interface",
 ]
 
 [[package]]
 name = "anchor-syn"
-version = "0.30.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99daacb53b55cfd37ce14d6c9905929721137fd4c67bbab44a19802aecb622f"
+checksum = "6940253e80acf0f8e83b1ebd9c4772c496aedcce6ad19aa85ce75d0b6b188298"
 dependencies = [
  "anyhow",
- "bs58 0.5.1",
+ "bs58",
  "cargo_toml",
  "heck",
  "proc-macro2",
  "quote",
  "serde",
- "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "syn 1.0.109",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -279,150 +264,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
-name = "ark-bn254"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
-]
-
-[[package]]
-name = "ark-ec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
-dependencies = [
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
- "derivative",
- "hashbrown 0.13.2",
- "itertools",
- "num-traits",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
-dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
- "derivative",
- "digest 0.10.7",
- "itertools",
- "num-bigint",
- "num-traits",
- "paste",
- "rustc_version",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
-dependencies = [
- "num-bigint",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-poly"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
-dependencies = [
- "ark-ff",
- "ark-serialize",
- "ark-std",
- "derivative",
- "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
-dependencies = [
- "ark-serialize-derive",
- "ark-std",
- "digest 0.10.7",
- "num-bigint",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -432,15 +277,15 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bincode"
@@ -456,43 +301,6 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "blake3"
-version = "1.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq 0.4.2",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "block-padding",
- "generic-array",
-]
 
 [[package]]
 name = "block-buffer"
@@ -504,74 +312,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
-
-[[package]]
-name = "borsh"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
-dependencies = [
- "borsh-derive 0.9.3",
- "hashbrown 0.11.2",
-]
-
-[[package]]
-name = "borsh"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
-dependencies = [
- "borsh-derive 0.10.4",
- "hashbrown 0.13.2",
-]
-
-[[package]]
 name = "borsh"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
 dependencies = [
- "borsh-derive 1.6.0",
+ "borsh-derive",
  "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
-dependencies = [
- "borsh-derive-internal 0.9.3",
- "borsh-schema-derive-internal 0.9.3",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831213f80d9423998dd696e2c5345aba6be7a0bd8cd19e31c5243e13df1cef89"
-dependencies = [
- "borsh-derive-internal 0.10.4",
- "borsh-schema-derive-internal 0.10.4",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -581,61 +328,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
 dependencies = [
  "once_cell",
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
 ]
-
-[[package]]
-name = "borsh-derive-internal"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive-internal"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65d6ba50644c98714aa2a70d13d7df3cd75cd2b523a2b452bf010443800976b3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276691d96f063427be83e6692b86148e488ebba9f48f77788724ca027ba3b6d4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "bs58"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bs58"
@@ -695,19 +392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a98356df42a2eb1bd8f1793ae4ee4de48e384dd974ce5eac8eee802edb7492be"
 dependencies = [
  "serde",
- "toml 0.8.23",
-]
-
-[[package]]
-name = "cc"
-version = "1.2.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
-dependencies = [
- "find-msvc-tools",
- "jobserver",
- "libc",
- "shlex",
+ "toml",
 ]
 
 [[package]]
@@ -723,60 +408,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chrono"
-version = "0.4.43"
+name = "cipher"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "num-traits",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
-name = "cipher"
+name = "const-crypto"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+checksum = "1c06f1eb05f06cf2e380fdded278fbf056a38974299d77960555a311dcf91a52"
 dependencies = [
- "generic-array",
+ "keccak-const",
+ "sha2-const-stable",
 ]
-
-[[package]]
-name = "cmov"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
-
-[[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "console_log"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89f72f65e8501878b8a004d5a1afb780987e2ce2b4532c562e367a72c57499f"
-dependencies = [
- "log",
- "web-sys",
-]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "cpufeatures"
@@ -788,111 +437,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
 name = "ctr"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
-name = "ctutils"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
-dependencies = [
- "cmov",
-]
-
-[[package]]
 name = "curve25519-dalek"
-version = "3.2.1"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rand_core",
+ "rustc_version",
  "serde",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "darling"
-version = "0.20.11"
+name = "curve25519-dalek-derive"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -900,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
  "fnv",
  "ident_case",
@@ -914,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
@@ -930,80 +527,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e5c37193a1db1d8ed868c03ec7b152175f26160a5b740e5e484143877e0adf0"
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
+ "block-buffer",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.1",
- "crypto-common 0.2.2",
- "ctutils",
-]
-
-[[package]]
-name = "ed25519"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
-dependencies = [
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand 0.7.3",
- "serde",
- "sha2 0.9.9",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-dalek-bip32"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d2be62a4061b872c8c0873ee4fc6f101ce7b889d039f019c5fa2af471a59908"
-dependencies = [
- "derivation-path",
- "ed25519-dalek",
- "hmac 0.12.1",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1011,19 +542,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
 
 [[package]]
 name = "equivalent"
@@ -1038,10 +556,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.8"
+name = "fiat-crypto"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "five8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
+dependencies = [
+ "five8_core",
+]
+
+[[package]]
+name = "five8_const"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
+dependencies = [
+ "five8_core",
+]
+
+[[package]]
+name = "five8_core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "059c31d7d36c43fe39d89e55711858b4da8be7eb6dabac23c7289b1a19489406"
 
 [[package]]
 name = "fnv"
@@ -1050,33 +592,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
- "serde",
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1088,49 +610,8 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash 0.7.8",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash 0.8.12",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
 ]
 
 [[package]]
@@ -1149,57 +630,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hmac"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
-]
-
-[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "hmac-drbg"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
-dependencies = [
- "digest 0.9.0",
- "generic-array",
- "hmac 0.8.1",
-]
-
-[[package]]
-name = "humantime"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
-dependencies = [
- "typenum",
+ "digest",
 ]
 
 [[package]]
@@ -1209,36 +645,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.4",
- "rand_xoshiro",
- "rayon",
- "serde",
- "sized-chunks",
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -1248,16 +677,6 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -1275,8 +694,14 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
+
+[[package]]
+name = "keccak-const"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d8d8ce877200136358e0bbff3a77965875db3af755a11e1fa6b1b3e2df13ea"
 
 [[package]]
 name = "lazy_static"
@@ -1289,66 +714,6 @@ name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
-
-[[package]]
-name = "libsecp256k1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
-dependencies = [
- "arrayref",
- "base64 0.12.3",
- "digest 0.9.0",
- "hmac-drbg",
- "libsecp256k1-core",
- "libsecp256k1-gen-ecmult",
- "libsecp256k1-gen-genmult",
- "rand 0.7.3",
- "serde",
- "sha2 0.9.9",
- "typenum",
-]
-
-[[package]]
-name = "libsecp256k1-core"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
-dependencies = [
- "crunchy",
- "digest 0.9.0",
- "subtle",
-]
-
-[[package]]
-name = "libsecp256k1-gen-ecmult"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccab96b584d38fac86a83f07e659f0deafd0253dc096dab5a36d53efe653c5c3"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
-name = "libsecp256k1-gen-genmult"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
-name = "light-poseidon"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c9a85a9752c549ceb7578064b4ed891179d20acd85f27318573b64d2d7ee7ee"
-dependencies = [
- "ark-bn254",
- "ark-ff",
- "num-bigint",
- "thiserror",
-]
 
 [[package]]
 name = "lock_api"
@@ -1372,24 +737,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
-name = "memmap2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "merlin"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,18 +744,8 @@ checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core 0.6.4",
+ "rand_core",
  "zeroize",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -1420,15 +757,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -1456,7 +784,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -1498,19 +826,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pbkdf2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
-dependencies = [
- "crypto-mac",
-]
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pbkdf2"
@@ -1518,7 +837,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1529,12 +848,12 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "polyval"
-version = "0.5.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1546,15 +865,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml 0.5.11",
 ]
 
 [[package]]
@@ -1585,17 +895,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "qualifier_attr"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2e25ee72f5b24d773cae88422baddefff7714f97aab68d96fe2b6fc4a28fb2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,43 +904,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1651,16 +921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -1669,45 +930,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
+ "getrandom",
 ]
 
 [[package]]
@@ -1747,12 +970,6 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -1844,62 +1061,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
-dependencies = [
- "serde",
- "serde_with_macros",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
-name = "sha3"
-version = "0.9.1"
+name = "sha2-const-stable"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug",
-]
+checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
 
 [[package]]
 name = "sha3"
@@ -1907,27 +1083,9 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-
-[[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "sipher-vault"
@@ -1935,18 +1093,6 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
- "blake3",
- "constant_time_eq 0.3.1",
-]
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
 ]
 
 [[package]]
@@ -1956,238 +1102,659 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "solana-frozen-abi"
-version = "1.18.26"
+name = "solana-account-info"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ab2c30c15311b511c0d1151e4ab6bc9a3e080a37e7c6e7c2d96f5784cf9434"
+checksum = "a9cf16495d9eb53e3d04e72366a33bb1c20c24e78c171d8b8f5978357b63ae95"
 dependencies = [
- "block-buffer 0.10.4",
- "bs58 0.4.0",
- "bv",
- "either",
- "generic-array",
- "im",
- "lazy_static",
- "log",
- "memmap2",
- "rustc_version",
- "serde",
- "serde_bytes",
- "serde_derive",
- "sha2 0.10.9",
- "solana-frozen-abi-macro",
- "subtle",
- "thiserror",
+ "solana-address 2.3.0",
+ "solana-program-error",
+ "solana-program-memory",
 ]
 
 [[package]]
-name = "solana-frozen-abi-macro"
-version = "1.18.26"
+name = "solana-address"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c142f779c3633ac83c84d04ff06c70e1f558c876f13358bed77ba629c7417932"
+checksum = "a2ecac8e1b7f74c2baa9e774c42817e3e75b20787134b76cc4d45e8a604488f5"
 dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.114",
+ "solana-address 2.3.0",
 ]
 
 [[package]]
-name = "solana-logger"
-version = "1.18.26"
+name = "solana-address"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121d36ffb3c6b958763312cbc697fbccba46ee837d3a0aa4fc0e90fcb3b884f3"
+checksum = "500b83d41bda401b84ebff6033e2e7bc828870ea444805112d15fc0a3e470b9c"
 dependencies = [
- "env_logger",
- "lazy_static",
- "log",
-]
-
-[[package]]
-name = "solana-program"
-version = "1.18.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c10f4588cefd716b24a1a40dd32c278e43a560ab8ce4de6b5805c9d113afdfa1"
-dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "base64 0.21.7",
- "bincode",
- "bitflags",
- "blake3",
- "borsh 0.10.4",
- "borsh 0.9.3",
- "borsh 1.6.0",
- "bs58 0.4.0",
- "bv",
+ "borsh",
  "bytemuck",
- "cc",
- "console_error_panic_hook",
- "console_log",
+ "bytemuck_derive",
  "curve25519-dalek",
- "getrandom 0.2.17",
- "itertools",
- "js-sys",
- "lazy_static",
- "libc",
- "libsecp256k1",
- "light-poseidon",
- "log",
- "memoffset",
- "num-bigint",
- "num-derive",
- "num-traits",
- "parking_lot",
- "rand 0.8.5",
- "rustc_version",
- "rustversion",
+ "five8",
+ "five8_const",
  "serde",
- "serde_bytes",
  "serde_derive",
- "serde_json",
- "sha2 0.10.9",
- "sha3 0.10.8",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-sdk-macro",
- "thiserror",
- "tiny-bip39",
- "wasm-bindgen",
- "zeroize",
+ "sha2-const-stable",
+ "solana-atomic-u64",
+ "solana-define-syscall 5.1.0",
+ "solana-program-error",
+ "solana-sanitize",
+ "solana-sha256-hasher",
+ "wincode",
 ]
 
 [[package]]
-name = "solana-sdk"
-version = "1.18.26"
+name = "solana-atomic-u64"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "580ad66c2f7a4c3cb3244fe21440546bd500f5ecb955ad9826e92a78dded8009"
+checksum = "085db4906d89324cef2a30840d59eaecf3d4231c560ec7c9f6614a93c652f501"
 dependencies = [
- "assert_matches",
- "base64 0.21.7",
- "bincode",
- "bitflags",
- "borsh 1.6.0",
- "bs58 0.4.0",
+ "parking_lot",
+]
+
+[[package]]
+name = "solana-borsh"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c04abbae16f57178a163125805637b8a076175bb5c0002fb04f4792bea901cf7"
+dependencies = [
+ "borsh",
+]
+
+[[package]]
+name = "solana-clock"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ea35d8f69b67daddb921a9da7f78ca591b533cf5e98833cd9ae62fdc2e4652c"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-cpi"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dea26709d867aada85d0d3617db0944215c8bb28d3745b912de7db13a23280c"
+dependencies = [
+ "solana-account-info",
+ "solana-define-syscall 4.0.1",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey 4.2.0",
+ "solana-stable-layout",
+]
+
+[[package]]
+name = "solana-curve25519"
+version = "3.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aff7432cdf2ec6a44ac06b4d64d2ee006f6c0066d6456e032a7fe25be40cd5c"
+dependencies = [
  "bytemuck",
- "byteorder",
- "chrono",
+ "bytemuck_derive",
+ "curve25519-dalek",
+ "solana-define-syscall 3.0.0",
+ "subtle",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "solana-define-syscall"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9697086a4e102d28a156b8d6b521730335d6951bd39a5e766512bbe09007cee"
+
+[[package]]
+name = "solana-define-syscall"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
+
+[[package]]
+name = "solana-define-syscall"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e14a4f604117f379840956a8fc8695e4c84f5b0ebed192f31f60d9b85d581d"
+
+[[package]]
+name = "solana-derivation-path"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff71743072690fdbdfcdc37700ae1cb77485aaad49019473a81aee099b1e0b8c"
+dependencies = [
  "derivation-path",
- "digest 0.10.7",
- "ed25519-dalek",
- "ed25519-dalek-bip32",
- "generic-array",
- "hmac 0.12.1",
- "itertools",
- "js-sys",
- "lazy_static",
- "libsecp256k1",
- "log",
- "memmap2",
- "num-derive",
- "num-traits",
- "num_enum",
- "pbkdf2 0.11.0",
  "qstring",
- "qualifier_attr",
- "rand 0.7.3",
- "rand 0.8.5",
- "rustc_version",
- "rustversion",
+ "uriparse",
+]
+
+[[package]]
+name = "solana-epoch-rewards"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cddf2388b28291210d9aa60690740733cab527531f06ed153c4d388951e407c"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-hash",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-epoch-schedule"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ad280b1ed803853f7b453cb3ea9a57e600ca5599a63e69f7be199b486c0ec93"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-feature-gate-interface"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75ca9b5cbb6f500f7fd73db5bd95640f71a83f04d6121a0e59a43b202dca2731"
+dependencies = [
+ "solana-program-error",
+ "solana-pubkey 4.2.0",
+ "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-fee-calculator"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef67f01cc6a0c72e99a08d0d484683f995de4c80e9568728fa77d1537f9b7e09"
+dependencies = [
+ "log",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "solana-hash"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe51db00ac3aa9f950d1e6201a126acfa26e6d81bc4a183ba64ec02effcad883"
+dependencies = [
+ "bytemuck",
+ "bytemuck_derive",
+ "five8",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "solana-instruction"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ebb0ffd19263051bc3f683fcc086134b8ff23af894dcb63f7563c7137b42f1"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_derive",
+ "solana-define-syscall 5.1.0",
+ "solana-instruction-error",
+ "solana-pubkey 4.2.0",
+]
+
+[[package]]
+name = "solana-instruction-error"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b188842592fdf6cb96f55263ae1bf11713ab5114401d1d5a881ed7cc41bef6"
+dependencies = [
+ "num-traits",
+ "solana-program-error",
+]
+
+[[package]]
+name = "solana-instructions-sysvar"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0732294560e88ecdb2bbc656e67383e9f88c78ec09469cef172f0d28cd1bcd"
+dependencies = [
+ "bitflags",
+ "solana-account-info",
+ "solana-instruction",
+ "solana-instruction-error",
+ "solana-program-error",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-serialize-utils",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-invoke"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4065031f5c7dd29ef5f5003c1a353011eeabbafa6c5a5033da0cedbfca824b94"
+dependencies = [
+ "solana-account-info",
+ "solana-define-syscall 3.0.0",
+ "solana-instruction",
+ "solana-program-entrypoint",
+ "solana-stable-layout",
+]
+
+[[package]]
+name = "solana-last-restart-slot"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "426711c6564b790026e45cabec3c64b971864c48b6b2d83c0ebf52a118bb4cda"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-loader-v3-interface"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e0538d4dbc9022e01616f1c58f2db98ece739c5d5ed4a2ef8737a953e76a2d4"
+dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "serde_json",
- "serde_with",
- "sha2 0.10.9",
- "sha3 0.10.8",
- "siphasher",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-logger",
- "solana-program",
+ "solana-instruction",
+ "solana-pubkey 4.2.0",
+ "solana-sdk-ids",
+ "solana-system-interface 3.1.0",
+]
+
+[[package]]
+name = "solana-msg"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726b7cbbc6be6f1c6f29146ac824343b9415133eee8cce156452ad1db93f8008"
+dependencies = [
+ "solana-define-syscall 5.1.0",
+]
+
+[[package]]
+name = "solana-program-entrypoint"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c9b0a1ff494e05f503a08b3d51150b73aa639544631e510279d6375f290997"
+dependencies = [
+ "solana-account-info",
+ "solana-define-syscall 4.0.1",
+ "solana-program-error",
+ "solana-pubkey 4.2.0",
+]
+
+[[package]]
+name = "solana-program-error"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f04fa578707b3612b095f0c8e19b66a1233f7c42ca8082fcb3b745afcc0add6"
+dependencies = [
+ "borsh",
+]
+
+[[package]]
+name = "solana-program-memory"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4068648649653c2c50546e9a7fb761791b5ab0cda054c771bb5808d3a4b9eb52"
+dependencies = [
+ "solana-define-syscall 4.0.1",
+]
+
+[[package]]
+name = "solana-program-option"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a88006a9b8594088cec9027ab77caaaa258a2aaa2083d3f086c44b42e50aeab"
+
+[[package]]
+name = "solana-program-pack"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7701cb15b90667ae1c89ef4ac35a59c61e66ce58ddee13d729472af7f41d59"
+dependencies = [
+ "solana-program-error",
+]
+
+[[package]]
+name = "solana-pubkey"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8909d399deb0851aa524420beeb5646b115fd253ef446e35fe4504c904da3941"
+dependencies = [
+ "solana-address 1.1.0",
+]
+
+[[package]]
+name = "solana-pubkey"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db719574990de7e8b0f55a8593ac92a5ccb42c8ce67b3e4bf05b139d5d9ee71"
+dependencies = [
+ "solana-address 2.3.0",
+]
+
+[[package]]
+name = "solana-rent"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e860d5499a705369778647e97d760f7670adfb6fc8419dd3d568deccd46d5487"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-ids",
  "solana-sdk-macro",
- "thiserror",
- "uriparse",
- "wasm-bindgen",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-sanitize"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
+
+[[package]]
+name = "solana-sdk-ids"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def234c1956ff616d46c9dd953f251fa7096ddbaa6d52b165218de97882b7280"
+dependencies = [
+ "solana-address 2.3.0",
 ]
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.18.26"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b75d0f193a27719257af19144fdaebec0415d1c9e9226ae4bd29b791be5e9bd"
+checksum = "8765316242300c48242d84a41614cb3388229ec353ba464f6fe62a733e41806f"
 dependencies = [
- "bs58 0.4.0",
+ "bs58",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn 2.0.114",
 ]
 
 [[package]]
-name = "solana-security-txt"
-version = "1.1.2"
+name = "solana-seed-derivable"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "156bb61a96c605fa124e052d630dba2f6fb57e08c7d15b757e1e958b3ed7b3fe"
+checksum = "ff7bdb72758e3bec33ed0e2658a920f1f35dfb9ed576b951d20d63cb61ecd95c"
 dependencies = [
- "hashbrown 0.15.2",
+ "solana-derivation-path",
 ]
 
 [[package]]
-name = "solana-zk-token-sdk"
-version = "1.18.26"
+name = "solana-seed-phrase"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cbdf4249b6dfcbba7d84e2b53313698043f60f8e22ce48286e6fbe8a17c8d16"
+checksum = "dc905b200a95f2ea9146e43f2a7181e3aeb55de6bc12afb36462d00a3c7310de"
+dependencies = [
+ "hmac",
+ "pbkdf2",
+ "sha2",
+]
+
+[[package]]
+name = "solana-serialize-utils"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "761357b0853c9623bf12c1d2314b3d6160a85b087b84c45224fb85766d22616b"
+dependencies = [
+ "solana-instruction-error",
+ "solana-pubkey 4.2.0",
+ "solana-sanitize",
+]
+
+[[package]]
+name = "solana-sha256-hasher"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7dc3011ea4c0334aaaa7e7128cb390ecf546b28d412e9bf2064680f57f588f"
+dependencies = [
+ "sha2",
+ "solana-define-syscall 4.0.1",
+ "solana-hash",
+]
+
+[[package]]
+name = "solana-signature"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0364c7577c3c82a693ce28a1febc8d1b5d1b0a175fdc2114ae6186b69effe1e"
+dependencies = [
+ "five8",
+ "solana-sanitize",
+]
+
+[[package]]
+name = "solana-signer"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520bd6021163ee517f4bdc7ae03ded904f97e11320001ba0b3355f45eb14f558"
+dependencies = [
+ "solana-pubkey 4.2.0",
+ "solana-signature",
+ "solana-transaction-error",
+]
+
+[[package]]
+name = "solana-slot-hashes"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a57c158c35629f9e302ab385f16b15813f4927a31c27dda72f3df828bb08d93"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-hash",
+ "solana-sdk-ids",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-slot-history"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0622d03a823770f7763afd866e012b296d5a3cbbbe51e110b5bd9ab3441efdca"
+dependencies = [
+ "bv",
+ "serde",
+ "serde_derive",
+ "solana-sdk-ids",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-stable-layout"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9f6a291ba063a37780af29e7db14bdd3dc447584d8ba5b3fc4b88e2bbc982fa"
+dependencies = [
+ "solana-instruction",
+ "solana-pubkey 4.2.0",
+]
+
+[[package]]
+name = "solana-stake-interface"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9bc26191b533f9a6e5a14cca05174119819ced680a80febff2f5051a713f0db"
+dependencies = [
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-clock",
+ "solana-cpi",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
+ "solana-system-interface 2.0.0",
+ "solana-sysvar",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-system-interface"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1790547bfc3061f1ee68ea9d8dc6c973c02a163697b24263a8e9f2e6d4afa2"
+dependencies = [
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
+]
+
+[[package]]
+name = "solana-system-interface"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a95a6f2e23ed861d6444ad4a6d6896c418d7d101b960787e65a8e33157cee81b"
+dependencies = [
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-address 2.3.0",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+]
+
+[[package]]
+name = "solana-sysvar"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6690d3dd88f15c21edff68eb391ef8800df7a1f5cec84ee3e8d1abf05affdf74"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "solana-account-info",
+ "solana-clock",
+ "solana-define-syscall 4.0.1",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-fee-calculator",
+ "solana-hash",
+ "solana-instruction",
+ "solana-last-restart-slot",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-pubkey 4.2.0",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-slot-hashes",
+ "solana-slot-history",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-sysvar-id"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17358d1e9a13e5b9c2264d301102126cf11a47fd394cdf3dec174fe7bc96e1de"
+dependencies = [
+ "solana-address 2.3.0",
+ "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-transaction-error"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441d6dcd51100e7d97c3fb3b723e08aa701066ff7afc00026fd8d8e222cb95b"
+dependencies = [
+ "solana-instruction-error",
+ "solana-sanitize",
+]
+
+[[package]]
+name = "solana-zero-copy"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea15126ebdc7e270c50d43884369af9f51d2308156d46a18e351522a164844d"
+dependencies = [
+ "borsh",
+ "bytemuck",
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "solana-zk-sdk"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9602bcb1f7af15caef92b91132ec2347e1c51a72ecdbefdaefa3eac4b8711475"
 dependencies = [
  "aes-gcm-siv",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bincode",
  "bytemuck",
- "byteorder",
+ "bytemuck_derive",
  "curve25519-dalek",
- "getrandom 0.1.16",
+ "getrandom",
  "itertools",
- "lazy_static",
+ "js-sys",
  "merlin",
  "num-derive",
  "num-traits",
- "rand 0.7.3",
+ "rand",
  "serde",
+ "serde_derive",
  "serde_json",
- "sha3 0.9.1",
- "solana-program",
- "solana-sdk",
+ "sha3",
+ "solana-derivation-path",
+ "solana-instruction",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "solana-seed-derivable",
+ "solana-seed-phrase",
+ "solana-signature",
+ "solana-signer",
  "subtle",
- "thiserror",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
  "zeroize",
 ]
 
 [[package]]
-name = "spl-associated-token-account"
-version = "3.0.4"
+name = "spl-associated-token-account-interface"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143109d789171379e6143ef23191786dfaac54289ad6e7917cfb26b36c432b10"
+checksum = "e6433917b60441d68d99a17e121d9db0ea15a9a69c0e5afa34649cf5ba12612f"
 dependencies = [
- "assert_matches",
- "borsh 1.6.0",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-token",
- "spl-token-2022",
- "thiserror",
+ "solana-instruction",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
 name = "spl-discriminator"
-version = "0.2.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "210101376962bb22bb13be6daea34656ea1cbc248fce2164b146e39203b55e03"
+checksum = "e597c5ff9ed7c74a54dbc47bae2f06e4db8c98f4356ad280200dc11878266db1"
 dependencies = [
  "bytemuck",
- "solana-program",
+ "solana-program-error",
+ "solana-sha256-hasher",
  "spl-discriminator-derive",
 ]
 
@@ -2210,165 +1777,162 @@ checksum = "5d1dbc82ab91422345b6df40a79e2b78c7bce1ebb366da323572dd60b7076b67"
 dependencies = [
  "proc-macro2",
  "quote",
- "sha2 0.10.9",
+ "sha2",
  "syn 2.0.114",
- "thiserror",
-]
-
-[[package]]
-name = "spl-memo"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49f49f95f2d02111ded31696ab38a081fab623d4c76bd4cb074286db4560836"
-dependencies = [
- "solana-program",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "spl-pod"
-version = "0.2.5"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52d84c55efeef8edcc226743dc089d7e3888b8e3474569aa3eff152b37b9996"
+checksum = "2f9c6e142cdf1e7e77f480053ec9f0ce989890768ddf91f619b50f39d1b456f5"
 dependencies = [
- "borsh 1.6.0",
+ "borsh",
  "bytemuck",
- "solana-program",
- "solana-zk-token-sdk",
- "spl-program-error",
-]
-
-[[package]]
-name = "spl-program-error"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45a49acb925db68aa501b926096b2164adbdcade7a0c24152af9f0742d0a602"
-dependencies = [
+ "bytemuck_derive",
  "num-derive",
  "num-traits",
- "solana-program",
- "spl-program-error-derive",
- "thiserror",
+ "num_enum",
+ "solana-program-error",
+ "solana-program-option",
+ "solana-pubkey 3.0.0",
+ "solana-zero-copy",
+ "solana-zk-sdk",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
-name = "spl-program-error-derive"
-version = "0.4.1"
+name = "spl-token-2022-interface"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d375dd76c517836353e093c2dbb490938ff72821ab568b545fd30ab3256b3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2 0.10.9",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fab8edfd37be5fa17c9e42c1bff86abbbaf0494b031b37957f2728ad2ff842ba"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-type-length-value",
-]
-
-[[package]]
-name = "spl-token"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9eb465e4bf5ce1d498f05204c8089378c1ba34ef2777ea95852fc53a1fd4fb2"
+checksum = "2fcd81188211f4b3c8a5eba7fd534c7142f9dd026123b3472492782cc72f4dc6"
 dependencies = [
  "arrayref",
  "bytemuck",
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token-2022"
-version = "3.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c39e416aeb1ea0b22f3b2bbecaf7e38a92a1aa8f4a0c5785c94179694e846a0"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-program",
- "solana-security-txt",
- "solana-zk-token-sdk",
- "spl-memo",
+ "solana-account-info",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "solana-zk-sdk",
  "spl-pod",
- "spl-token",
+ "spl-token-confidential-transfer-proof-extraction",
+ "spl-token-confidential-transfer-proof-generation",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
- "spl-transfer-hook-interface",
  "spl-type-length-value",
- "thiserror",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "spl-token-confidential-transfer-proof-extraction"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879a9ebad0d77383d3ea71e7de50503554961ff0f4ef6cbca39ad126e6f6da3a"
+dependencies = [
+ "bytemuck",
+ "solana-account-info",
+ "solana-curve25519",
+ "solana-instruction",
+ "solana-instructions-sysvar",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "solana-zk-sdk",
+ "spl-pod",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "spl-token-confidential-transfer-proof-generation"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0cd59fce3dc00f563c6fa364d67c3f200d278eae681f4dc250240afcfe044b1"
+dependencies = [
+ "curve25519-dalek",
+ "solana-zk-sdk",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "spl-token-group-interface"
-version = "0.2.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "014817d6324b1e20c4bbc883e8ee30a5faa13e59d91d1b2b95df98b920150c17"
+checksum = "452d0f758af20caaa10d9a6f7608232e000d4c74462f248540b3d2ddfa419776"
 dependencies = [
  "bytemuck",
- "solana-program",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
  "spl-discriminator",
  "spl-pod",
- "spl-program-error",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "spl-token-interface"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c564ac05a7c8d8b12e988a37d82695b5ba4db376d07ea98bc4882c81f96c7f3"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "spl-token-metadata-interface"
-version = "0.3.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3da00495b602ebcf5d8ba8b3ecff1ee454ce4c125c9077747be49c2d62335ba"
+checksum = "9c467c7c3bd056f8fe60119e7ec34ddd6f23052c2fa8f1f51999098063b72676"
 dependencies = [
- "borsh 1.6.0",
- "solana-program",
+ "borsh",
+ "num-derive",
+ "num-traits",
+ "solana-borsh",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
  "spl-discriminator",
  "spl-pod",
- "spl-program-error",
  "spl-type-length-value",
-]
-
-[[package]]
-name = "spl-transfer-hook-interface"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b5c08a89838e5a2931f79b17f611857f281a14a2100968a3ccef352cb7414b"
-dependencies = [
- "arrayref",
- "bytemuck",
- "solana-program",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-tlv-account-resolution",
- "spl-type-length-value",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "spl-type-length-value"
-version = "0.4.6"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c872f93d0600e743116501eba2d53460e73a12c9a496875a42a7d70e034fe06d"
+checksum = "2504631748c48d2a937414d64a12dcac4588d34bd07d355d648619c189d29435"
 dependencies = [
  "bytemuck",
- "solana-program",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-account-info",
+ "solana-program-error",
+ "solana-zero-copy",
  "spl-discriminator",
- "spl-pod",
- "spl-program-error",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2379,9 +1943,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2406,21 +1970,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2435,22 +1999,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-bip39"
-version = "0.8.2"
+name = "thiserror-impl"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc59cb9dfc85bb312c3a78fd6aa8a8582e310b0fa885d5bb877f6dcc601839d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
- "anyhow",
- "hmac 0.8.1",
- "once_cell",
- "pbkdf2 0.4.0",
- "rand 0.7.3",
- "rustc-hash",
- "sha2 0.9.9",
- "thiserror",
- "unicode-normalization",
- "wasm-bindgen",
- "zeroize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2467,15 +2023,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "toml"
@@ -2561,15 +2108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2577,11 +2115,11 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "generic-array",
+ "crypto-common",
  "subtle",
 ]
 
@@ -2603,24 +2141,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2668,60 +2191,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.85"
+name = "wincode"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "466e67917609b2d40a838a5b972d1a6237c9749600cb8de8f65559b90d48485b"
 dependencies = [
- "js-sys",
- "wasm-bindgen",
+ "pastey",
+ "proc-macro2",
+ "quote",
+ "thiserror 2.0.18",
+ "wincode-derive",
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
+name = "wincode-derive"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+checksum = "26a7a568eda854acc9945ed136a9d50b8c6d31911584624958808ae96eee3912"
 dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "winnow"
@@ -2731,12 +2229,6 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "zerocopy"
@@ -2760,18 +2252,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/programs/sipher-vault/Cargo.toml
+++ b/programs/sipher-vault/Cargo.toml
@@ -12,10 +12,3 @@ codegen-units = 1
 opt-level = 3
 incremental = false
 codegen-units = 1
-
-# Workaround: Pin blake3 to 1.5.5 to avoid constant_time_eq 0.4.x
-# which requires Rust edition2024 (not supported by Solana platform-tools v1.52)
-# See: https://github.com/sip-protocol/sip-protocol/issues/780
-[workspace.dependencies]
-blake3 = "=1.8.5"
-constant_time_eq = "=0.3.1"

--- a/programs/sipher-vault/programs/sipher-vault/Cargo.toml
+++ b/programs/sipher-vault/programs/sipher-vault/Cargo.toml
@@ -20,13 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = { version = "0.30.1", features = ["init-if-needed"] }
-anchor-spl = "0.30.1"
-
-# Pin blake3/constant_time_eq to avoid edition2024 requirement
-# (Solana platform-tools BPF toolchain uses Cargo 1.84 which doesn't support it)
-blake3 = "=1.8.5"
-constant_time_eq = "=0.3.1"
+anchor-lang = { version = "1.0.2", features = ["init-if-needed"] }
+anchor-spl = "1.0.2"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"))'] }

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -41,6 +41,16 @@ pub const SIP_PRIVACY_PROGRAM_ID: Pubkey = Pubkey::new_from_array([
 pub const SIP_CONFIG_SEED: &[u8] = b"config";
 pub const SIP_TRANSFER_RECORD_SEED: &[u8] = b"transfer_record";
 
+/// Anchor instruction discriminator for `sip_privacy::create_transfer_announcement`
+/// = `sha256("global:create_transfer_announcement")[..8]`.
+///
+/// Hardcoded as a constant — like `SIP_PRIVACY_PROGRAM_ID` above — because Anchor 1.0's
+/// granular `solana_program` facade no longer re-exports a `hash` module. The value is
+/// verified end-to-end by the `withdraw_private` / `withdraw_private_sol` bankrun CPI
+/// tests: a wrong discriminator makes the announcement CPI fail.
+pub const CREATE_TRANSFER_ANNOUNCEMENT_DISC: [u8; 8] =
+  [0x9b, 0x34, 0xb1, 0x8f, 0xd3, 0x5b, 0xcd, 0x66];
+
 declare_id!("S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB");
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -131,7 +141,7 @@ pub mod sipher_vault {
 
     // Transfer SOL from depositor to sol_vault PDA via system_program::transfer
     let cpi = CpiContext::new(
-      ctx.accounts.system_program.to_account_info(),
+      ctx.accounts.system_program.key(),
       anchor_lang::system_program::Transfer {
         from: ctx.accounts.depositor.to_account_info(),
         to: ctx.accounts.sol_vault.to_account_info(),
@@ -184,7 +194,7 @@ pub mod sipher_vault {
 
     // Transfer tokens from depositor to vault
     let transfer_ctx = CpiContext::new(
-      ctx.accounts.token_program.to_account_info(),
+      ctx.accounts.token_program.key(),
       TransferChecked {
         from: ctx.accounts.depositor_token.to_account_info(),
         mint: ctx.accounts.token_mint.to_account_info(),
@@ -268,7 +278,7 @@ pub mod sipher_vault {
     let signer_seeds: &[&[&[u8]]] = &[&[VAULT_CONFIG_SEED, &[config_bump]]];
 
     let transfer_to_stealth = CpiContext::new_with_signer(
-      ctx.accounts.token_program.to_account_info(),
+      ctx.accounts.token_program.key(),
       TransferChecked {
         from: ctx.accounts.vault_token.to_account_info(),
         mint: ctx.accounts.token_mint.to_account_info(),
@@ -282,7 +292,7 @@ pub mod sipher_vault {
     // 4. Transfer fee to fee token account (PDA signs)
     if fee > 0 {
       let transfer_fee = CpiContext::new_with_signer(
-        ctx.accounts.token_program.to_account_info(),
+        ctx.accounts.token_program.key(),
         TransferChecked {
           from: ctx.accounts.vault_token.to_account_info(),
           mint: ctx.accounts.token_mint.to_account_info(),
@@ -462,7 +472,7 @@ pub mod sipher_vault {
     let signer_seeds: &[&[&[u8]]] = &[&[VAULT_CONFIG_SEED, &[config_bump]]];
 
     let transfer_ctx = CpiContext::new_with_signer(
-      ctx.accounts.token_program.to_account_info(),
+      ctx.accounts.token_program.key(),
       TransferChecked {
         from: ctx.accounts.vault_token.to_account_info(),
         mint: ctx.accounts.token_mint.to_account_info(),
@@ -508,7 +518,7 @@ pub mod sipher_vault {
     let signer_seeds: &[&[&[u8]]] = &[&[VAULT_CONFIG_SEED, &[config_bump]]];
 
     let transfer_ctx = CpiContext::new_with_signer(
-      ctx.accounts.token_program.to_account_info(),
+      ctx.accounts.token_program.key(),
       TransferChecked {
         from: ctx.accounts.vault_token.to_account_info(),
         mint: ctx.accounts.token_mint.to_account_info(),
@@ -632,7 +642,7 @@ pub mod sipher_vault {
     let signer_seeds: &[&[&[u8]]] = &[&[VAULT_CONFIG_SEED, &[config_bump]]];
 
     let transfer_ctx = CpiContext::new_with_signer(
-      ctx.accounts.token_program.to_account_info(),
+      ctx.accounts.token_program.key(),
       TransferChecked {
         from: ctx.accounts.fee_token.to_account_info(),
         mint: ctx.accounts.token_mint.to_account_info(),
@@ -736,11 +746,8 @@ fn emit_transfer_announcement<'info>(
   viewing_key_hash: &[u8; 32],
   encrypted_amount: &[u8],
 ) -> Result<()> {
-  // Anchor discriminator: sha256("global:create_transfer_announcement")[..8]
-  let disc = solana_program::hash::hash(b"global:create_transfer_announcement").to_bytes();
-
   let mut cpi_data = Vec::with_capacity(8 + 33 + 32 + 33 + 32 + 4 + encrypted_amount.len() + 32);
-  cpi_data.extend_from_slice(&disc[..8]);
+  cpi_data.extend_from_slice(&CREATE_TRANSFER_ANNOUNCEMENT_DISC);
   // amount_commitment: [u8; 33]
   cpi_data.extend_from_slice(amount_commitment);
   // stealth_pubkey: Pubkey (32 bytes)
@@ -975,6 +982,12 @@ pub struct WithdrawPrivate<'info> {
   )]
   pub deposit_record: Account<'info, DepositRecord>,
 
+  // The heavy `InterfaceAccount`s below are boxed to keep `WithdrawPrivate::try_accounts`
+  // under the 4 KiB BPF stack-frame limit. Anchor 1.0's duplicate-mutable-key check
+  // enlarged the generated account-validation frame for this account-heavy context;
+  // boxing moves the deserialized token/mint state to the heap. Box is wire-identical
+  // (account order + discriminators unchanged) and transparent to the handler via
+  // Deref. (Resolves self-audit M6.)
   #[account(
     mut,
     seeds = [VAULT_TOKEN_SEED, token_mint.key().as_ref()],
@@ -982,7 +995,7 @@ pub struct WithdrawPrivate<'info> {
     token::mint = token_mint,
     token::authority = config,
   )]
-  pub vault_token: InterfaceAccount<'info, TokenAccount>,
+  pub vault_token: Box<InterfaceAccount<'info, TokenAccount>>,
 
   #[account(
     mut,
@@ -991,7 +1004,7 @@ pub struct WithdrawPrivate<'info> {
     token::mint = token_mint,
     token::authority = config,
   )]
-  pub fee_token: InterfaceAccount<'info, TokenAccount>,
+  pub fee_token: Box<InterfaceAccount<'info, TokenAccount>>,
 
   /// The stealth token account to receive the net amount.
   /// Owned by any pubkey (the stealth address), we just verify the mint.
@@ -999,9 +1012,9 @@ pub struct WithdrawPrivate<'info> {
     mut,
     constraint = stealth_token.mint == token_mint.key() @ VaultError::InvalidMint,
   )]
-  pub stealth_token: InterfaceAccount<'info, TokenAccount>,
+  pub stealth_token: Box<InterfaceAccount<'info, TokenAccount>>,
 
-  pub token_mint: InterfaceAccount<'info, Mint>,
+  pub token_mint: Box<InterfaceAccount<'info, Mint>>,
 
   #[account(mut)]
   pub depositor: Signer<'info>,

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -1031,17 +1031,17 @@ pub struct WithdrawPrivate<'info> {
     bump,
     seeds::program = SIP_PRIVACY_PROGRAM_ID,
   )]
-  pub sip_config: AccountInfo<'info>,
+  pub sip_config: UncheckedAccount<'info>,
 
   /// Transfer record PDA — will be initialized by CPI to sip_privacy
   /// CHECK: Initialized and validated by the CPI call to sip_privacy
   #[account(mut)]
-  pub sip_transfer_record: AccountInfo<'info>,
+  pub sip_transfer_record: UncheckedAccount<'info>,
 
   /// SIP Privacy program for CPI
   /// CHECK: Validated by address constraint
   #[account(address = SIP_PRIVACY_PROGRAM_ID)]
-  pub sip_privacy_program: AccountInfo<'info>,
+  pub sip_privacy_program: UncheckedAccount<'info>,
 
   /// System program (needed by sip_privacy to init the transfer record)
   pub system_program: Program<'info, System>,
@@ -1101,17 +1101,17 @@ pub struct WithdrawPrivateSol<'info> {
     bump,
     seeds::program = SIP_PRIVACY_PROGRAM_ID,
   )]
-  pub sip_config: AccountInfo<'info>,
+  pub sip_config: UncheckedAccount<'info>,
 
   /// Transfer record PDA — will be initialized by CPI to sip_privacy
   /// CHECK: Initialized and validated by the CPI call to sip_privacy
   #[account(mut)]
-  pub sip_transfer_record: AccountInfo<'info>,
+  pub sip_transfer_record: UncheckedAccount<'info>,
 
   /// SIP Privacy program for CPI
   /// CHECK: Validated by address constraint
   #[account(address = SIP_PRIVACY_PROGRAM_ID)]
-  pub sip_privacy_program: AccountInfo<'info>,
+  pub sip_privacy_program: UncheckedAccount<'info>,
 
   /// System program (needed by sip_privacy to init the transfer record)
   pub system_program: Program<'info, System>,
@@ -1203,7 +1203,7 @@ pub struct AuthorityRefund<'info> {
   /// CHECK: Not a signer — validated by deposit_record.has_one. Used for PDA
   /// derivation and token account ownership check. The authority (not depositor)
   /// is the signer for this instruction.
-  pub depositor: AccountInfo<'info>,
+  pub depositor: UncheckedAccount<'info>,
 
   #[account(mut)]
   pub authority: Signer<'info>,


### PR DESCRIPTION
Migrates `programs/sipher-vault` from `anchor-lang`/`anchor-spl` **0.30.1 → 1.0.2** (source only — no on-chain redeploy). Also lands the migration design spec + implementation plan (epic #1161).

## Why now
Anchor 1.0 dissolves the toolchain wall that blocked these programs:
- **IDL-gen blocker** — 0.30.1's proc-macros choke on host rustc 1.94; 1.0.2 (MSRV 1.89) generates the IDL again.
- **edition2024 wall** — platform-tools v1.51 (rustc 1.84.1) rejected edition2024, forcing the `constant_time_eq` pin; 1.0.x builds against platform-tools v1.52+ (rustc 1.89), so the pins are obsolete.

## Changes
**Manifests**
- Bump `anchor-lang`/`anchor-spl` to `1.0.2` (keep `init-if-needed`); bump `Anchor.toml` toolchain.
- Drop the edition2024 workaround pins (`blake3`/`constant_time_eq`) — unused in source; remove the now-vestigial `[workspace.dependencies]` block (no member referenced it).

**Source (Anchor 1.0 breaking changes)**
- `CpiContext::new[_with_signer]` now take `program_id: Pubkey` (not `AccountInfo`) → pass `.key()` at all 7 CPI sites. The modern Agave runtime resolves the callee from the program cache.
- The granular `solana_program` facade no longer re-exports `hash` → hardcode the `create_transfer_announcement` discriminator as a documented const (`sha256("global:create_transfer_announcement")[..8]`), consistent with the already-hardcoded `SIP_PRIVACY_PROGRAM_ID`.
- `Box<>` the heavy `InterfaceAccount`s in `WithdrawPrivate` to keep `try_accounts` under the 4 KiB BPF stack frame. Anchor 1.0's duplicate-mutable-key check enlarged the validation frame (24 → 288 bytes over); boxing clears it. Wire-identical (account order + discriminators unchanged), handler-transparent. **Resolves self-audit M6.**

## Verification (local — there is no CI workflow for sipher-vault, a standalone `--ignore-workspace` project)
- ✅ Builds: `cargo build-sbf --tools-version v1.52` (Agave 3.0.13 may default to v1.51, which can't compile edition2024 — pass v1.52).
- ✅ IDL generates: `anchor idl build` (proves the rustc-1.94 IDL-gen blocker is gone).
- ✅ **26/26 bankrun tests pass** (`pnpm install --ignore-workspace && pnpm test`) — loads `sipher_vault.so` + the `sip_privacy.so` fixture; the CPI announcement path confirms the hardcoded discriminator end-to-end.
- ✅ `/code-review high` — 3 independent angles, zero findings.

## Notes
- **No on-chain redeploy.** Discriminators are byte-identical 0.30→1.0 (Anchor PR #3098), so existing accounts stay readable. Redeploy remains a separate B5-multisig-gated decision.
- `tests/fixtures/sip_privacy.so` is git-ignored → it must be built locally (or in CI) from `programs/sip-privacy` via `cargo build-sbf --tools-version v1.52`.
- Leaves 7 `AccountInfo` → `UncheckedAccount` deprecation warnings — cosmetic only (each account is `/// CHECK:`-documented and validated by `seeds`/`address`/`has_one`); a clean follow-up.

Closes #1171. Supersedes #1172 (the `constant_time_eq=0.3.1` pin is removed, so it floats to 0.4.x under platform-tools v1.52+). Refs #1161.

Spec: `docs/superpowers/specs/2026-06-20-anchor-1.0-migration-design.md`
Plan: `docs/superpowers/plans/2026-06-20-anchor-1.0-migration.md`