### PR TITLE
sipher-vault: B6 self-audit hardening (M1/M2/M6/L3/I1–I4 + deploy caveat)

### DIFF
--- a/programs/sipher-vault/DEPLOYMENT.md
+++ b/programs/sipher-vault/DEPLOYMENT.md
@@ -121,6 +121,11 @@ emergency lever works before mainnet (PR-B1 Risk B2/B3).
 Universal-asset feature branch adds native SOL support (6 new instructions, 9 → 15 total).
 Binary: `492536` bytes (Δ from `383144` — ~107 KB for two new account structs + 6 instruction handlers).
 
+> **⚠️ If the B6 audit-hardening (M1/M2) is included in this redeploy, the
+> account layouts change and an in-place upgrade is NOT safe — see the breaking-change
+> warning under "Devnet Upgrade" below. Fresh accounts (new program ID or recreate)
+> are required.**
+
 - **Upgrade TX:** `[TODO — run scripts/upgrade-devnet.ts and paste TX signature here]`
 - **New deployed slot:** `[TODO — paste slot from upgrade-devnet.ts output]`
 - **SOL vault init TX:** `[TODO — run scripts/create-sol-vault.ts after redeploy and paste TX here]`
@@ -163,7 +168,29 @@ Expected: **25 passing**, 0 failing.
 
 ### Devnet Upgrade
 
-Use the atomic upgrade script:
+> **⚠️ BREAKING ACCOUNT-LAYOUT CHANGE in the B6 audit-hardening — an in-place upgrade across this boundary will BRICK the existing vault.**
+> The hardening adds `VaultConfig.pending_authority` (M1, +33 bytes) and removes
+> `DepositRecord.locked_amount` (M2, −8 bytes mid-struct), changing both struct
+> layouts. The existing devnet `VaultConfig` PDA
+> (`CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u`, initialized 2026-03-31 at the
+> old layout) and any existing `DepositRecord` accounts are **byte-incompatible**:
+> - `VaultConfig` is now too short for the trailing `Option<Pubkey>` → every
+>   instruction that loads `config` reverts with `AccountDidNotDeserialize`
+>   (fully bricked, including the `refund`/`refund_sol` self-recovery paths).
+> - old `DepositRecord` accounts deserialize **shifted** (garbage
+>   `last_deposit_at`/`bump`); the corrupted `bump` then fails the
+>   `bump = deposit_record.bump` seeds check → that depositor's funds become
+>   unwithdrawable.
+>
+> There is **no migration/`realloc` instruction**, so `upgrade-devnet.ts`
+> (in-place `BPFLoaderUpgradeable`) is unsafe here. Bring the new-layout program
+> up against **fresh** accounts — deploy to a **new program ID** + fresh
+> `initialize`, or close/recreate the config + records first. **This is RECTOR's
+> deploy decision.** (Mainnet B7 is a fresh deploy with no pre-existing accounts
+> → unaffected. Verified against live devnet account sizes by the post-hardening
+> independent review.)
+
+Use the atomic upgrade script (only safe for layout-compatible upgrades):
 
 ```bash
 cd programs/sipher-vault

--- a/programs/sipher-vault/DEPLOYMENT.md
+++ b/programs/sipher-vault/DEPLOYMENT.md
@@ -16,15 +16,16 @@ Deployment records and procedures for the `sipher_vault` Anchor program — a pr
 
 | Tool | Version |
 |------|---------|
-| Anchor CLI | `0.30.1` |
+| Anchor CLI | `1.0.2` |
 | Solana CLI | `3.0.13` (Agave) |
-| platform-tools | `v1.51` (rustc `1.84.1`, target SBF) |
-| Host rustc | `1.94.1` (build only — IDL gen requires `--no-idl`) |
+| platform-tools | `v1.52` (rustc `1.89.0`, target SBF) |
+| Host rustc | `1.94.1` |
 
-> **Build note:** anchor 0.30.1's IDL generator depends on `proc_macro2::Span::source_file()`,
-> a nightly-only proc-macro API removed from current host rustc. Use `anchor build --no-idl`;
-> the on-chain SBF binary is unaffected. The IDL artifact at `target/idl/sipher_vault.json`
-> is regenerated from earlier compatible host toolchains.
+> **Build note:** build the SBF binary with an explicit platform-tools version —
+> `cargo build-sbf --tools-version v1.52` — because Agave 3.0.13 may default to
+> v1.51 (rustc 1.84.1), below Anchor 1.0.2's MSRV. Under Anchor 1.0.2 the IDL
+> generator works on the host toolchain (`anchor idl build`); the `--no-idl`
+> workaround that Anchor 0.30.1 required is no longer needed.
 
 ## Instruction Inventory
 
@@ -147,7 +148,7 @@ The test suite is IDL-free (solana-bankrun raw-ix). It requires the `sip_privacy
 ```bash
 # Step 1: Build sip_privacy to get its .so (from the repo root or programs/sip-privacy)
 cd programs/sip-privacy
-anchor build --no-idl
+cargo build-sbf --tools-version v1.52
 cp target/deploy/sip_privacy.so ../sipher-vault/tests/fixtures/sip_privacy.so
 cd ../sipher-vault
 ```
@@ -155,16 +156,18 @@ cd ../sipher-vault
 Then run the suite:
 
 ```bash
-# All three test files (10 = token-track, 11 = SOL-track, 12 = cross-track)
-pnpm exec ts-mocha -p tsconfig.json -t 60000 'tests/sipher-vault/{10,11,12}-*.ts'
+# All four test files (10 = classic SPL, 11 = Token-2022 allowlist,
+# 12 = native SOL, 13 = authority management)
+pnpm exec ts-mocha -p tsconfig.json -t 60000 'tests/sipher-vault/{10,11,12,13}-*.ts'
 
 # Or individually:
 pnpm exec ts-mocha -p tsconfig.json -t 60000 'tests/sipher-vault/10-*.ts'
 pnpm exec ts-mocha -p tsconfig.json -t 60000 'tests/sipher-vault/11-*.ts'
 pnpm exec ts-mocha -p tsconfig.json -t 60000 'tests/sipher-vault/12-*.ts'
+pnpm exec ts-mocha -p tsconfig.json -t 60000 'tests/sipher-vault/13-*.ts'
 ```
 
-Expected: **25 passing**, 0 failing.
+Expected: **39 passing**, 0 failing.
 
 ### Devnet Upgrade
 
@@ -189,6 +192,13 @@ Expected: **25 passing**, 0 failing.
 > deploy decision.** (Mainnet B7 is a fresh deploy with no pre-existing accounts
 > → unaffected. Verified against live devnet account sizes by the post-hardening
 > independent review.)
+
+> **Downstream error-code sync (B6 M2):** removing the inert `BalanceLocked`
+> variant renumbers the later `VaultError` codes (`UnsupportedMintExtension`
+> 6012→6011, `RentReserveViolation` 6013→6012). On redeploy, regenerate the
+> consuming `sipher` repo's committed IDL (`packages/sdk/src/idl/sipher_vault.json`)
+> and update any hardcoded error numbers (e.g. `scripts/devnet-beta-gate-check.ts`)
+> in lockstep — otherwise off-chain tooling will mislabel on-chain errors.
 
 Use the atomic upgrade script (only safe for layout-compatible upgrades):
 

--- a/programs/sipher-vault/SELF-AUDIT.md
+++ b/programs/sipher-vault/SELF-AUDIT.md
@@ -3,7 +3,7 @@
 | | |
 |---|---|
 | **Date** | 2026-06-19 |
-| **Program** | `sipher_vault` · Anchor 0.30.1 · `programs/sipher-vault/programs/sipher-vault/src/` |
+| **Program** | `sipher_vault` · Anchor 1.0.2 · `programs/sipher-vault/programs/sipher-vault/src/` |
 | **Deployment** | devnet `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB` (this audit gates the mainnet deploy) |
 | **Audit type** | Internal self-audit (the decided milestone approach). **Not** an independent external review — see §9. |
 | **Method** | Static source review across 6 adversarial dimensions + targeted empirical verification |
@@ -52,7 +52,7 @@ Six independent reviewers, one per threat dimension, each instructed to red-team
 
 **Empirical checks beyond static review:** the CPI's manual Borsh encoding and discriminator were re-derived independently and matched byte-for-byte; the stealth scalar signer was reimplemented and verified against a standard ed25519 verifier on 200 random raw scalars (200/200 pass; non-canonical `S` rejected).
 
-**Test harness.** The Anchor IDL generator is broken on the build host (host `rustc` vs `anchor-cli 0.30.1`), so the program is tested with the **solana-bankrun raw-instruction** harness rather than the Anchor TS client. Building the `.so` currently requires platform-tools **v1.52** (see Appendix B for the toolchain regression that this audit also surfaced).
+**Test harness.** The program is tested with the **solana-bankrun raw-instruction** harness (the suite predates an Anchor TS-client setup). Building the `.so` uses platform-tools **v1.52** (rustc 1.89) — the toolchain Anchor 1.0.2 targets (see Appendix B).
 
 ---
 
@@ -199,4 +199,4 @@ Before the mainnet deploy (B7):
 
 ## Appendix B — Build toolchain note
 
-The committed lockfile resolves `blake3 1.8.5 → constant_time_eq 0.4.2`, which requires Rust `edition2024` (rustc ≥ 1.85). The Anchor-0.30.1-pinned platform-tools **v1.51** (rustc 1.84.1) cannot build it, so `anchor build` fails; building with **platform-tools v1.52** (rustc 1.89.0) succeeds. The original workaround pinned `blake3 = "=1.5.5"` to keep the dependency graph on an edition2021 `constant_time_eq 0.3.x`; a dependabot bump (`501db63`) raised it to `=1.8.5` and defeated that pin (the stale comment still reads "1.5.5"). Reverting `blake3` to `=1.5.5` in both `sipher-vault` and `sip_privacy` restores `anchor build` on v1.51 (and unblocks the devnet redeploy). Tracked alongside the Anchor/cargo toolchain alignment work.
+The program builds with **platform-tools v1.52** (rustc 1.89.0), the toolchain Anchor 1.0.2 targets: `cd programs/sipher-vault && cargo build-sbf --tools-version v1.52`. Pass the flag explicitly — Agave 3.0.13 may default to platform-tools v1.51 (rustc 1.84.1), which is below Anchor 1.0.2's MSRV. The Anchor 1.0.2 migration this PR is rebased onto also dissolved an earlier `blake3 → constant_time_eq 0.4.2` (edition2024) regression that had broken the build on the 0.30.1-era v1.51, by dropping the explicit `blake3` pins entirely.

--- a/programs/sipher-vault/SELF-AUDIT.md
+++ b/programs/sipher-vault/SELF-AUDIT.md
@@ -22,7 +22,7 @@
 5. **The cross-program announcement CPI is byte-exact** (Borsh layout + discriminator independently re-derived), makes no re-entrant call, and degrades to an atomic revert under any account substitution — never theft or corruption.
 6. **The SDK gasless relayer leaks no recipient secret**, its fee math cannot over-take or underflow, the ed25519 stealth scalar signer is cryptographically correct (verified on 200 random scalars, with malleated signatures rejected), and no failure mode strands funds.
 
-The findings below — **6 Medium, 5 Low, 4 Info** — are pre-mainnet hardening, latent-footgun prevention, and honest-disclosure items. **None is an active exploit on the deployed program.** Remediation lands in the accompanying hardening PR; the disclosure items live in this report and the deploy runbook.
+The findings below — **6 Medium, 5 Low, 4 Info** — are pre-mainnet hardening, latent-footgun prevention, and honest-disclosure items. **None is a fund-theft exploit.** One was an *active functional defect* rather than a latent one: M6 (the withdrawal-path stack overflow) aborted `withdraw_private` at runtime under the platform-tools v1.52 build — now fixed. **All code findings are resolved in the accompanying hardening PR (M1, M2, M3, M6, L3, I1–I4 — see Appendix A);** the disclosure items (M4, M5, L1) live in this report and the deploy runbook.
 
 ---
 
@@ -103,8 +103,8 @@ Each was an explicit hypothesis the reviewers tried to break and could not:
 **M5 — No native-SOL gasless cash-out path in the SDK.** `buildGaslessCashout` is SPL-token-only; native SOL goes through the self-paid `sol-transfer` path (which already enforces the recipient rent floor). Safe today. But the universal-asset vault now supports native-SOL withdrawals on-chain, so **if** a native-SOL gasless cash-out is built on top, it MUST guarantee `net ≥ rent-exempt-min` for a fresh stealth recipient or the runtime fails the tx closed.
 **Remediation:** documented as a forward integration requirement; gate any native-gasless work on the rent pre-funding check.
 
-**M6 — `WithdrawPrivate` account-validation stack frame exceeds the BPF limit.** The SBF build reports `WithdrawPrivate::try_accounts` at an estimated 4416-byte frame, exceeding the 4096-byte BPF stack limit ("Stack offset of 4120 exceeded max offset of 4096 by 24 bytes … may cause undefined behavior during execution"). The context is account-heavy (`vault_token`, `fee_token`, `stealth_token`, `token_mint`, plus the four `sip_privacy` CPI accounts). The program builds and the bankrun suite passes — so it functions today — but a known stack overflow on the **fund-withdrawal path** is a latent corruption risk and leaves no headroom for future account additions. Pre-existing on `main` (introduced with the universal-asset context); surfaced by this audit's build. *(`WithdrawPrivate` context, lib.rs:962–1035; verify `WithdrawPrivateSol` 1042–1105 too.)*
-**Remediation:** `Box<>` the heavy `InterfaceAccount`/`Account` fields in `WithdrawPrivate` to move them off the validation stack frame; rebuild and confirm the warning clears with the suite still green.
+**M6 — `WithdrawPrivate` account-validation stack frame exceeds the BPF limit.** The SBF build reports `WithdrawPrivate::try_accounts` at an estimated 4416-byte frame, exceeding the 4096-byte BPF stack limit ("Stack offset of 4120 exceeded max offset of 4096 by 24 bytes … may cause undefined behavior during execution"). The context is account-heavy (`vault_token`, `fee_token`, `stealth_token`, `token_mint`, plus the four `sip_privacy` CPI accounts). **This was not merely latent:** the remediation pass confirmed that under the platform-tools v1.52 build `withdraw_private` aborts at runtime with "Access violation in unknown section at address 0x8 of size 8", taking the token-withdrawal path (and the dependent fee collection) down with it — only the lighter native-SOL `WithdrawPrivateSol` context was unaffected. It is a functional break of the token-withdrawal path, not a fund-theft exploit (the transaction reverts atomically). Pre-existing on `main` (introduced with the universal-asset context); surfaced by this audit's build. *(`WithdrawPrivate` context, lib.rs:962–1035; `WithdrawPrivateSol` verified within the limit.)*
+**Remediation: Resolved (`cc800a7`).** `Box<>`-ed the four heavy `InterfaceAccount` fields in `WithdrawPrivate`, moving them off the validation stack frame. The SBF build now emits no stack-offset warning, `withdraw_private` completes, and the bankrun suite is green.
 
 ### Low
 
@@ -153,11 +153,11 @@ This is a **self-audit, not an independent external review.** For a fund-custody
 
 Before the mainnet deploy (B7):
 
-- [ ] **M1 landed** — `update_authority` (two-step) + `update_fee` present and tested.
-- [ ] **M2/M3 landed** — `locked_amount` removed; refund zeroes balance.
-- [ ] **L3 landed** — `encrypted_amount` length guard.
-- [ ] **M6 landed** — `WithdrawPrivate` stack frame back under 4096 B (Box accounts); build warning cleared.
-- [ ] **I1/I2/I3 landed** — dead constant removed; token-program bindings; fee-token allowlist.
+- [x] **M1 landed** (`de065b4`) — `update_authority` (two-step) + `update_fee` present and tested.
+- [x] **M2/M3 landed** (`d740287`) — `locked_amount` removed; refund zeroes balance.
+- [x] **L3 landed** (`871f3e2`) — `encrypted_amount` length guard.
+- [x] **M6 landed** (`cc800a7`) — `WithdrawPrivate` stack frame back under 4096 B (Box accounts); build warning cleared, `withdraw_private` completes.
+- [x] **I1/I2/I3/I4 landed** (`8a047d3`, `399fa33`) — dead constant removed; token-program bindings; fee-token allowlist; init_if_needed invariant comment.
 - [ ] **Authority = Squads v4 2-of-3 multisig** set at (or handed off immediately after) `initialize`; both the BPF upgrade authority and the in-program `config.authority` point at the multisig.
 - [ ] **`sip_privacy` and `sipher_vault` pause authorities governed coherently** under the same multisig (L1).
 - [ ] **Deploy runbook** documents: the privacy boundary (§7), the `sip_privacy` liveness coupling (L1), the SDK rent pre-funding obligation for native payouts (M5), and the build toolchain requirement (Appendix B).
@@ -169,21 +169,21 @@ Before the mainnet deploy (B7):
 
 | ID | Severity | Title | Disposition |
 |----|----------|-------|-------------|
-| M1 | Medium | No `update_authority` / `update_fee` | Fix (this PR) |
-| M2 | Medium | `locked_amount` inert dead state | Fix — remove (this PR) |
-| M3 | Medium | `refund` assigns `= locked_amount` | Fix — subsumed by M2 |
-| M4 | Medium | Privacy disclosure (depositor + amount public) | Document (§7) |
-| M5 | Medium | No native-SOL gasless path (rent pre-funding) | Document — forward gate |
-| M6 | Medium | `WithdrawPrivate::try_accounts` stack frame > 4096 B | Fix — Box accounts (this PR) |
-| L1 | Low | `sip_privacy` liveness coupling | Document — runbook |
-| L2 | Low | `initialize` permissionless | Resolved by M1 |
-| L3 | Low | `encrypted_amount` unbounded | Fix (this PR) |
+| M1 | Medium | No `update_authority` / `update_fee` | ✅ Resolved `de065b4` |
+| M2 | Medium | `locked_amount` inert dead state | ✅ Resolved `d740287` |
+| M3 | Medium | `refund` assigns `= locked_amount` | ✅ Resolved `d740287` (subsumed by M2) |
+| M4 | Medium | Privacy disclosure (depositor + amount public) | Documented (§7) — no code change |
+| M5 | Medium | No native-SOL gasless path (rent pre-funding) | Documented — forward integration gate |
+| M6 | Medium | `WithdrawPrivate::try_accounts` stack frame > 4096 B | ✅ Resolved `cc800a7` |
+| L1 | Low | `sip_privacy` liveness coupling | Documented — runbook |
+| L2 | Low | `initialize` permissionless | ✅ Resolved `de065b4` (via M1) |
+| L3 | Low | `encrypted_amount` unbounded | ✅ Resolved `871f3e2` |
 | L4 | Low | `getStealthBalance` swallows RPC errors | Deferred (SDK) |
 | L5 | Low | counter saturating vs checked | Accepted |
-| I1 | Info | dead `SIP_TRANSFER_RECORD_SEED` | Fix (this PR) |
-| I2 | Info | `token::token_program` not bound | Fix (this PR) |
-| I3 | Info | `create_fee_token` no allowlist | Fix (this PR) |
-| I4 | Info | `init_if_needed` invariant comment | Fix (this PR) |
+| I1 | Info | dead `SIP_TRANSFER_RECORD_SEED` | ✅ Resolved `8a047d3` |
+| I2 | Info | `token::token_program` not bound | ✅ Resolved `8a047d3` |
+| I3 | Info | `create_fee_token` no allowlist | ✅ Resolved `399fa33` |
+| I4 | Info | `init_if_needed` invariant comment | ✅ Resolved `8a047d3` |
 
 ## Appendix B — Build toolchain note
 

--- a/programs/sipher-vault/SELF-AUDIT.md
+++ b/programs/sipher-vault/SELF-AUDIT.md
@@ -1,0 +1,190 @@
+# Sipher Vault — Internal Security Self-Audit
+
+| | |
+|---|---|
+| **Date** | 2026-06-19 |
+| **Program** | `sipher_vault` · Anchor 0.30.1 · `programs/sipher-vault/programs/sipher-vault/src/` |
+| **Deployment** | devnet `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB` (this audit gates the mainnet deploy) |
+| **Audit type** | Internal self-audit (the decided milestone approach). **Not** an independent external review — see §9. |
+| **Method** | Static source review across 6 adversarial dimensions + targeted empirical verification |
+| **Scope** | `sipher_vault` (15 instructions, ~1360 LOC) + the SDK gasless cash-out relayer |
+
+---
+
+## 1. Executive Summary
+
+**Zero Critical, zero High.** Six independent adversarial review passes — each tasked with stealing, draining, freezing, or bypassing the vault — instead *proved* the core fund-custody properties hold from source:
+
+1. **A bounded-but-malicious authority cannot touch depositor principal.** Authority refunds are `has_one = depositor` + timeout-gated; fee collection only drains the separate fee sinks. Proven exhaustively over every authority-gated instruction.
+2. **Per-mint and native-SOL solvency hold.** Debit-first ordering + checked arithmetic + a rent-reserve fail-safe; cross-mint and cross-depositor isolation are enforced by PDA seeds + `has_one`.
+3. **No silent-overflow drain surface.** Every lamport/balance/fee operation is `checked_*`; the native-SOL lamport mutations are aliasing-free with a rent guard on every debit.
+4. **The Token-2022 extension allowlist is genuinely fail-closed.** It rejects transfer-fee / transfer-hook / permanent-delegate / non-transferable / and *unknown/future* extensions; the three allowed extensions are transfer-neutral for raw-amount accounting.
+5. **The cross-program announcement CPI is byte-exact** (Borsh layout + discriminator independently re-derived), makes no re-entrant call, and degrades to an atomic revert under any account substitution — never theft or corruption.
+6. **The SDK gasless relayer leaks no recipient secret**, its fee math cannot over-take or underflow, the ed25519 stealth scalar signer is cryptographically correct (verified on 200 random scalars, with malleated signatures rejected), and no failure mode strands funds.
+
+The findings below — **6 Medium, 5 Low, 4 Info** — are pre-mainnet hardening, latent-footgun prevention, and honest-disclosure items. **None is an active exploit on the deployed program.** Remediation lands in the accompanying hardening PR; the disclosure items live in this report and the deploy runbook.
+
+---
+
+## 2. Scope
+
+**In scope (reviewed line-by-line):**
+- `programs/sipher-vault/programs/sipher-vault/src/{lib.rs, state.rs, errors.rs, constants.rs}`
+- SDK gasless cash-out: `packages/sdk/src/chains/solana/{gasless-cashout,relayer-fee,stealth-signer,scan,sol-transfer}.ts` and `packages/sdk/src/solana/jito-relayer.ts`
+
+**Out of scope (reviewed only at the boundary):**
+- The `sip_privacy` program internals — examined only at the `create_transfer_announcement` CPI surface (§8).
+- The Squads v4 multisig program — adopted as the mainnet authority; separately audited by 4 firms + 2 formal-verification engagements (governance decision record).
+- The off-chain agent / SENTINEL orchestration layer.
+
+---
+
+## 3. Methodology
+
+Six independent reviewers, one per threat dimension, each instructed to red-team — *find a way to break it; if you cannot, prove why it is safe* — and to cite source `file:line` for every claim:
+
+1. Authority model, signer enforcement, PDA/account validation
+2. Accounting correctness and the solvency invariant
+3. Arithmetic, lamport-mutation, and rent safety
+4. Token-2022 / SPL-interface safety
+5. The `sip_privacy` CPI (correctness, account validation, liveness coupling, disclosure)
+6. The SDK gasless relayer (trust boundary, fee math, key handling, failure modes)
+
+**Empirical checks beyond static review:** the CPI's manual Borsh encoding and discriminator were re-derived independently and matched byte-for-byte; the stealth scalar signer was reimplemented and verified against a standard ed25519 verifier on 200 random raw scalars (200/200 pass; non-canonical `S` rejected).
+
+**Test harness.** The Anchor IDL generator is broken on the build host (host `rustc` vs `anchor-cli 0.30.1`), so the program is tested with the **solana-bankrun raw-instruction** harness rather than the Anchor TS client. Building the `.so` currently requires platform-tools **v1.52** (see Appendix B for the toolchain regression that this audit also surfaced).
+
+---
+
+## 4. System & Threat Model
+
+`sipher_vault` is a **deposit-first commingling vault**. Depositors move SPL tokens, Token-2022 tokens, or native SOL into shared, program-owned PDAs; the per-`(depositor, mint)` `DepositRecord` tracks each depositor's balance. Withdrawals are **debit-first and depositor-signed**: the depositor signs, their record is debited, the net is sent to a one-time stealth recipient and the fee to a fee sink, then a metadata-only CPI announces the payment for scannability.
+
+- **Vault holdings:** per-mint `vault_token` PDA (`token::authority = config`); singleton `sol_vault` PDA for native SOL; fee sinks `fee_token(mint)` and `sol_fee`.
+- **Authority** (`config.authority`): may pause, collect fees, and authority-refund (to the original depositor only, timeout-enforced). At mainnet the authority becomes a **Squads v4 2-of-3 multisig**.
+- **Privacy model:** *commingling, not cryptographic hiding* (see §7). Unlinkability comes from a shared, aggregating depositor batching many users — the deposit↔stealth link and the net amount are public on-chain.
+
+**Adversaries assumed:** (a) an external attacker, (b) a malicious depositor, (c) a malicious-but-bounded authority. **Goals attempted:** steal/redirect another depositor's principal, break per-mint or native solvency, freeze funds, bypass a signer/authority check, abuse a Token-2022 mint, or abuse the CPI.
+
+---
+
+## 5. Proven-Safe Invariants
+
+Each was an explicit hypothesis the reviewers tried to break and could not:
+
+- **Authority is bounded — cannot reach principal.** The only authority-gated fund instructions are `authority_refund[_sol]` (destination forced to the seed-bound original depositor via `has_one = depositor`; amount capped at that depositor's balance; timeout enforced) and `collect_fee[_sol]` (source is the `fee_token` / `sol_fee` sink — the contexts have no `vault_token` / `sol_vault` field, so principal is structurally unreachable). `set_paused` moves nothing. *(lib.rs:487–527, 580–618, 622–648, 658–677; contexts 1151–1325.)*
+- **Per-mint token solvency.** For every mint, `Σ DepositRecord.balance ≤ vault_token.amount`. `deposit` credits the record by exactly the transferred amount; `withdraw_private` debits by `amount` and moves out `net + fee = amount`; `refund`/`authority_refund` move out `available` and zero it. *(lib.rs:181–223, 232–330, 443–527.)*
+- **Native-SOL solvency + rent fail-safe.** `Σ native balance ≤ sol_vault.lamports − rent_min`, enforced both by accounting and, independently, by a `checked_sub` + `require!(new_vault ≥ rent_min)` on every `sol_vault` debit — so even corrupted accounting cannot drain below the rent floor. *(lib.rs:390–397, 554–558, 601–605.)*
+- **Checked arithmetic, no wrap, aliasing-free.** No raw `+=`/`-=` on any lamport/balance/fee (BPF release wraps silently); all 9 native lamport writes are full-value assignments after checked computation. The three accounts mutated in `withdraw_private_sol` cannot alias (program-owned `SolVault`/`SolFee` PDAs with distinct seeds vs a System-owned `SystemAccount` recipient). *(lib.rs:381–408.)*
+- **Token-2022 allowlist is fail-closed.** Gated on the mint's real program owner; a malformed TLV → reject; only `MetadataPointer`, `TokenMetadata`, `InterestBearingConfig` allowed (all transfer-neutral for raw amounts); every other / unknown / future extension is rejected, so a fee/hook/permanent-delegate/non-transferable mint can never obtain a `vault_token` and thus can never be deposited or withdrawn. *(lib.rs:83–114.)*
+- **CPI is byte-exact, non-re-entrant, substitution-safe.** The manual Borsh encoding matches `create_transfer_announcement` exactly; the callee makes no CPI (no re-entrancy) and the vault debits before the CPI regardless; `sip_config` (seeds), `sip_privacy_program` (address) are pinned, and a substituted `sip_transfer_record` can only fail the callee's `init` → atomic revert, never theft. *(lib.rs:726–782, 1011–1035.)*
+- **SDK relayer.** Recipient secrets never reach the relayer (it receives only the already-signed serialized tx); `fee + net = gross` with `net` strictly positive; the scalar signer is correct and never logs/persists the scalar; a self-paid `claimStealthPayment` fallback guarantees funds are never stranded.
+
+---
+
+## 6. Findings
+
+> Severity reflects custody impact. **None of these is an active exploit on the live program** — they are hardening, latent-footgun, disclosure, and forward-integration items. `file:line` references are to `programs/sipher-vault/programs/sipher-vault/src/lib.rs` unless noted.
+
+### Medium
+
+**M1 — No authority-rotation / fee-update instruction.** `config.authority` and `fee_bps` are set once at `initialize` and have no setter (only `paused` is mutable). The mainnet plan makes the authority a Squads 2-of-3 multisig; with no `update_authority` the authority can never be rotated without a full redeploy of a live custody program, and there is no recovery from a compromised key. *(whole `#[program]` mod; state.rs:5–13.)*
+**Remediation:** add a two-step `update_authority` (propose / accept via a `pending_authority` field) + `update_fee` (cap-checked), both `has_one = authority`. This also lets the program deploy with a deploy key and hand off to the multisig in a controlled tx (subsumes L2).
+
+**M2 — `locked_amount` is inert dead state.** `DepositRecord.locked_amount` is never written to a non-zero value by any instruction, and `BalanceLocked` is dead. `available == balance` always. Safe for solvency, but a custody struct shipping a load-bearing-looking field that is never enforced is an audit smell and an integration footgun: an SDK scheduler (drip/recurring/split) that treats `balance − reserved` as authoritative will be wrong, because the chain honors a full-`balance` withdraw/refund. *(state.rs:21; reads at lib.rs:248/363/446/492/536/585; errors.rs:26.)*
+**Remediation (decided):** remove `locked_amount` + `BalanceLocked`; scheduled-send reservations are tracked off-chain with an explicit "the chain does not enforce this" contract.
+
+**M3 — `refund` assigns `balance = locked_amount` (`=`, not `−= available`).** Safe today (the preceding `checked_sub` guard + `locked_amount ≡ 0`), but the assignment form means that if a future edit ever let `locked_amount > balance` and reordered the guard, a depositor's balance would *inflate* → insolvency. *(lib.rs:477, 523, 567, 614.)*
+**Remediation:** subsumed by M2 (with `locked_amount` removed, refund becomes `balance = 0`).
+
+**M4 — Privacy disclosure: the depositor↔stealth link and net amount are public.** `create_transfer_announcement` stores `TransferRecord.sender = depositor` (and the depositor is in the PDA seeds and in two emitted events), and `VaultWithdrawEvent.transfer_amount` is plaintext. This is the documented commingling model, but it must be stated plainly so it is never mis-sold: **a direct end-user deposit→withdraw provides essentially no privacy.** Unlinkability requires the depositor to be a shared aggregating wallet. *(lib.rs:301–326, 411–436; sip_privacy `TransferRecord.sender`.)* — see §7.
+**Remediation:** documented here + in the integration notes; not a code change. A trustless (nullifier-based) withdrawal that breaks the on-chain sender link is future work (M19).
+
+**M5 — No native-SOL gasless cash-out path in the SDK.** `buildGaslessCashout` is SPL-token-only; native SOL goes through the self-paid `sol-transfer` path (which already enforces the recipient rent floor). Safe today. But the universal-asset vault now supports native-SOL withdrawals on-chain, so **if** a native-SOL gasless cash-out is built on top, it MUST guarantee `net ≥ rent-exempt-min` for a fresh stealth recipient or the runtime fails the tx closed.
+**Remediation:** documented as a forward integration requirement; gate any native-gasless work on the rent pre-funding check.
+
+**M6 — `WithdrawPrivate` account-validation stack frame exceeds the BPF limit.** The SBF build reports `WithdrawPrivate::try_accounts` at an estimated 4416-byte frame, exceeding the 4096-byte BPF stack limit ("Stack offset of 4120 exceeded max offset of 4096 by 24 bytes … may cause undefined behavior during execution"). The context is account-heavy (`vault_token`, `fee_token`, `stealth_token`, `token_mint`, plus the four `sip_privacy` CPI accounts). The program builds and the bankrun suite passes — so it functions today — but a known stack overflow on the **fund-withdrawal path** is a latent corruption risk and leaves no headroom for future account additions. Pre-existing on `main` (introduced with the universal-asset context); surfaced by this audit's build. *(`WithdrawPrivate` context, lib.rs:962–1035; verify `WithdrawPrivateSol` 1042–1105 too.)*
+**Remediation:** `Box<>` the heavy `InterfaceAccount`/`Account` fields in `WithdrawPrivate` to move them off the validation stack frame; rebuild and confirm the warning clears with the suite still green.
+
+### Low
+
+**L1 — Cross-program liveness coupling to `sip_privacy`.** `withdraw_private[_sol]` reverts if `sip_privacy` is paused or uninitialized (the announcement CPI is mandatory and the tx is atomic). Funds are **never trapped** — `refund`/`refund_sol` make no CPI and let depositors self-recover after the timeout. *(lib.rs:301, 411; refund paths 443–571.)*
+**Remediation:** document the dependency in the deploy runbook; govern both programs' pause authorities coherently under the same multisig.
+
+**L2 — `initialize` is permissionless (first-caller becomes authority).** A deploy-time front-runner could become `config.authority`, gaining pause + fee-skim (not principal). *(lib.rs:55–73.)*
+**Remediation:** resolved operationally by M1 (deploy with a key, hand off to the multisig) and by initializing atomically at deploy.
+
+**L3 — `encrypted_amount` is unbounded in the vault.** The callee caps it at 64 bytes; an over-long blob reverts the whole withdrawal (depositor self-grief only — honest callers send ~48 bytes). *(lib.rs:239, 354.)*
+**Remediation:** add an early `require!(encrypted_amount.len() ≤ 64)` guard before the debit (fail-fast, vault-native error).
+
+**L4 — `getStealthBalance` returns `0n` on any RPC error.** A transient RPC failure is indistinguishable from "empty." Not used by the cash-out builder. *(scan.ts.)*
+**Remediation:** distinguish not-found from RPC error, or document the best-effort semantics. Deferred (SDK robustness).
+
+**L5 — `total_deposits` saturating vs `total_depositors` checked.** Cosmetic metric inconsistency; both unreachable at `u64::MAX`; no fund impact. *(lib.rs:159/214 vs 161/216.)* Accepted.
+
+### Info / cleanup
+
+- **I1 — Dead constant `SIP_TRANSFER_RECORD_SEED`** (lib.rs:42), never used — remove to avoid implying a validation that isn't there.
+- **I2 — `token::token_program` not bound** on non-init token constraints. The runtime's own ownership check backstops it (a mismatch reverts with `IncorrectProgramId`), so no exploit; adding the binding yields a clearer Anchor error. Defense-in-depth.
+- **I3 — `create_fee_token` lacks the Token-2022 allowlist.** Inert (a mint must clear the allowlist at `create_vault_token` before any withdrawal can route fees), but mirror it for defense-in-depth and to keep the two paths from diverging.
+- **I4 — `init_if_needed` on `deposit_record`** is safe here (accumulate-not-reset, `is_new` derived from `cumulative_volume`), but pin the invariant with a comment so a future field-reset edit doesn't reintroduce a bug.
+
+---
+
+## 7. Privacy Boundary (M4 — read this verbatim)
+
+> `sipher_vault`'s `withdraw_private[_sol]` records the **depositor public key on-chain** — in `TransferRecord.sender`, in the `TransferRecord` PDA seeds, and in both `ShieldedTransferEvent` and `VaultWithdrawEvent` — and the **net transfer amount is plaintext**. The depositor↔stealth link and the amount are **PUBLIC**. Unlinkability is achieved by **commingling** and requires the depositor to be a **shared aggregating wallet** batching many users. It is **not** cryptographic amount-hiding and **not** a trustless nullifier mixer. A direct end-user deposit→withdraw provides essentially no privacy. The Pedersen commitment and viewing key are for scannability and selective-disclosure compliance, not for hiding the settlement amount.
+
+This boundary is intrinsic to the current design and must appear in any integration-facing material.
+
+---
+
+## 8. Cross-Program & Operational Dependencies
+
+- **Announcement CPI is mandatory.** Every private withdrawal CPIs `sip_privacy::create_transfer_announcement` (metadata-only, no funds moved). The encoding is byte-exact and the accounts are pinned; a failure reverts the whole atomic tx. The vault debits the record *before* the CPI (debit-first), so there is no double-withdraw even under hypothetical re-entrancy.
+- **Liveness coupling (L1).** A paused/uninitialized `sip_privacy` halts vault withdrawals — but never traps funds (`refund` self-recovery has no CPI). Govern both programs under the same authority.
+- **Native-gasless gap (M5).** Gasless cash-out is SPL-only today; native-SOL recipients use the self-paid path that already enforces the rent floor.
+
+---
+
+## 9. Residual Risk & Mainnet (B7) Gate Checklist
+
+This is a **self-audit, not an independent external review.** For a fund-custody program, an external audit is recommended **before scaling real user funds**; a devnet pilot and a limited-value mainnet launch on the strength of this self-audit + the hardening PR is the planned, accepted posture.
+
+Before the mainnet deploy (B7):
+
+- [ ] **M1 landed** — `update_authority` (two-step) + `update_fee` present and tested.
+- [ ] **M2/M3 landed** — `locked_amount` removed; refund zeroes balance.
+- [ ] **L3 landed** — `encrypted_amount` length guard.
+- [ ] **M6 landed** — `WithdrawPrivate` stack frame back under 4096 B (Box accounts); build warning cleared.
+- [ ] **I1/I2/I3 landed** — dead constant removed; token-program bindings; fee-token allowlist.
+- [ ] **Authority = Squads v4 2-of-3 multisig** set at (or handed off immediately after) `initialize`; both the BPF upgrade authority and the in-program `config.authority` point at the multisig.
+- [ ] **`sip_privacy` and `sipher_vault` pause authorities governed coherently** under the same multisig (L1).
+- [ ] **Deploy runbook** documents: the privacy boundary (§7), the `sip_privacy` liveness coupling (L1), the SDK rent pre-funding obligation for native payouts (M5), and the build toolchain requirement (Appendix B).
+- [ ] **External audit** scheduled before scaling beyond limited mainnet value.
+
+---
+
+## Appendix A — Findings table
+
+| ID | Severity | Title | Disposition |
+|----|----------|-------|-------------|
+| M1 | Medium | No `update_authority` / `update_fee` | Fix (this PR) |
+| M2 | Medium | `locked_amount` inert dead state | Fix — remove (this PR) |
+| M3 | Medium | `refund` assigns `= locked_amount` | Fix — subsumed by M2 |
+| M4 | Medium | Privacy disclosure (depositor + amount public) | Document (§7) |
+| M5 | Medium | No native-SOL gasless path (rent pre-funding) | Document — forward gate |
+| M6 | Medium | `WithdrawPrivate::try_accounts` stack frame > 4096 B | Fix — Box accounts (this PR) |
+| L1 | Low | `sip_privacy` liveness coupling | Document — runbook |
+| L2 | Low | `initialize` permissionless | Resolved by M1 |
+| L3 | Low | `encrypted_amount` unbounded | Fix (this PR) |
+| L4 | Low | `getStealthBalance` swallows RPC errors | Deferred (SDK) |
+| L5 | Low | counter saturating vs checked | Accepted |
+| I1 | Info | dead `SIP_TRANSFER_RECORD_SEED` | Fix (this PR) |
+| I2 | Info | `token::token_program` not bound | Fix (this PR) |
+| I3 | Info | `create_fee_token` no allowlist | Fix (this PR) |
+| I4 | Info | `init_if_needed` invariant comment | Fix (this PR) |
+
+## Appendix B — Build toolchain note
+
+The committed lockfile resolves `blake3 1.8.5 → constant_time_eq 0.4.2`, which requires Rust `edition2024` (rustc ≥ 1.85). The Anchor-0.30.1-pinned platform-tools **v1.51** (rustc 1.84.1) cannot build it, so `anchor build` fails; building with **platform-tools v1.52** (rustc 1.89.0) succeeds. The original workaround pinned `blake3 = "=1.5.5"` to keep the dependency graph on an edition2021 `constant_time_eq 0.3.x`; a dependabot bump (`501db63`) raised it to `=1.8.5` and defeated that pin (the stale comment still reads "1.5.5"). Reverting `blake3` to `=1.5.5` in both `sipher-vault` and `sip_privacy` restores `anchor build` on v1.51 (and unblocks the devnet redeploy). Tracked alongside the Anchor/cargo toolchain alignment work.

--- a/programs/sipher-vault/SELF-AUDIT.md
+++ b/programs/sipher-vault/SELF-AUDIT.md
@@ -151,6 +151,18 @@ This boundary is intrinsic to the current design and must appear in any integrat
 
 This is a **self-audit, not an independent external review.** For a fund-custody program, an external audit is recommended **before scaling real user funds**; a devnet pilot and a limited-value mainnet launch on the strength of this self-audit + the hardening PR is the planned, accepted posture.
 
+> **⚠️ Breaking account-layout change (this hardening PR).** M1 adds
+> `VaultConfig.pending_authority` and M2 removes `DepositRecord.locked_amount`,
+> changing both struct layouts. There is no migration/`realloc` instruction, so
+> the new-layout program is **not a safe in-place upgrade** over any program
+> holding old-layout accounts — the existing devnet config/records would be
+> bricked (`AccountDidNotDeserialize` on `config`; shifted/corrupt deposit
+> records → unwithdrawable). The **held devnet redeploy** must use fresh accounts
+> (new program ID + fresh `initialize`, or close/recreate). Mainnet B7 is a fresh
+> deploy → unaffected. Surfaced + verified against live devnet account sizes by
+> the post-hardening independent review; full runbook detail in `DEPLOYMENT.md` →
+> "Devnet Upgrade".
+
 Before the mainnet deploy (B7):
 
 - [x] **M1 landed** (`de065b4`) — `update_authority` (two-step) + `update_fee` present and tested.
@@ -160,7 +172,7 @@ Before the mainnet deploy (B7):
 - [x] **I1/I2/I3/I4 landed** (`8a047d3`, `399fa33`) — dead constant removed; token-program bindings; fee-token allowlist; init_if_needed invariant comment.
 - [ ] **Authority = Squads v4 2-of-3 multisig** set at (or handed off immediately after) `initialize`; both the BPF upgrade authority and the in-program `config.authority` point at the multisig.
 - [ ] **`sip_privacy` and `sipher_vault` pause authorities governed coherently** under the same multisig (L1).
-- [ ] **Deploy runbook** documents: the privacy boundary (§7), the `sip_privacy` liveness coupling (L1), the SDK rent pre-funding obligation for native payouts (M5), and the build toolchain requirement (Appendix B).
+- [ ] **Deploy runbook** documents: the privacy boundary (§7), the `sip_privacy` liveness coupling (L1), the SDK rent pre-funding obligation for native payouts (M5), the build toolchain requirement (Appendix B), and the **breaking account-layout change** (M1/M2 — no safe in-place upgrade; fresh accounts required; see `DEPLOYMENT.md`).
 - [ ] **External audit** scheduled before scaling beyond limited mainnet value.
 
 ---

--- a/programs/sipher-vault/SELF-AUDIT.md
+++ b/programs/sipher-vault/SELF-AUDIT.md
@@ -22,7 +22,7 @@
 5. **The cross-program announcement CPI is byte-exact** (Borsh layout + discriminator independently re-derived), makes no re-entrant call, and degrades to an atomic revert under any account substitution — never theft or corruption.
 6. **The SDK gasless relayer leaks no recipient secret**, its fee math cannot over-take or underflow, the ed25519 stealth scalar signer is cryptographically correct (verified on 200 random scalars, with malleated signatures rejected), and no failure mode strands funds.
 
-The findings below — **6 Medium, 5 Low, 4 Info** — are pre-mainnet hardening, latent-footgun prevention, and honest-disclosure items. **None is a fund-theft exploit.** One was an *active functional defect* rather than a latent one: M6 (the withdrawal-path stack overflow) aborted `withdraw_private` at runtime under the platform-tools v1.52 build — now fixed. **All code findings are resolved in the accompanying hardening PR (M1, M2, M3, M6, L3, I1–I4 — see Appendix A);** the disclosure items (M4, M5, L1) live in this report and the deploy runbook.
+The findings below — **6 Medium, 5 Low, 4 Info** — are pre-mainnet hardening, latent-footgun prevention, and honest-disclosure items. **None is a fund-theft exploit.** One was an *active functional defect* rather than a latent one: M6 (the withdrawal-path stack overflow) aborted `withdraw_private` at runtime under the platform-tools v1.52 build — now resolved by the Anchor 1.0.2 migration (`8c79a33`), which `Box`-es the heavy `WithdrawPrivate` accounts off the validation stack frame. **The remaining code findings are resolved in the accompanying hardening PR (M1, M2, M3, L3, I1–I4 — see Appendix A);** the disclosure items (M4, M5, L1) live in this report and the deploy runbook.
 
 ---
 
@@ -104,7 +104,7 @@ Each was an explicit hypothesis the reviewers tried to break and could not:
 **Remediation:** documented as a forward integration requirement; gate any native-gasless work on the rent pre-funding check.
 
 **M6 — `WithdrawPrivate` account-validation stack frame exceeds the BPF limit.** The SBF build reports `WithdrawPrivate::try_accounts` at an estimated 4416-byte frame, exceeding the 4096-byte BPF stack limit ("Stack offset of 4120 exceeded max offset of 4096 by 24 bytes … may cause undefined behavior during execution"). The context is account-heavy (`vault_token`, `fee_token`, `stealth_token`, `token_mint`, plus the four `sip_privacy` CPI accounts). **This was not merely latent:** the remediation pass confirmed that under the platform-tools v1.52 build `withdraw_private` aborts at runtime with "Access violation in unknown section at address 0x8 of size 8", taking the token-withdrawal path (and the dependent fee collection) down with it — only the lighter native-SOL `WithdrawPrivateSol` context was unaffected. It is a functional break of the token-withdrawal path, not a fund-theft exploit (the transaction reverts atomically). Pre-existing on `main` (introduced with the universal-asset context); surfaced by this audit's build. *(`WithdrawPrivate` context, lib.rs:962–1035; `WithdrawPrivateSol` verified within the limit.)*
-**Remediation: Resolved (`cc800a7`).** `Box<>`-ed the four heavy `InterfaceAccount` fields in `WithdrawPrivate`, moving them off the validation stack frame. The SBF build now emits no stack-offset warning, `withdraw_private` completes, and the bankrun suite is green.
+**Remediation: Resolved by the Anchor 1.0.2 migration (`8c79a33`).** The 1.0 dup-check codegen enlarges the `try_accounts` frame, which forced the migration to `Box<>` the four heavy `InterfaceAccount` fields in `WithdrawPrivate` — the same fix this finding called for — moving them off the validation stack frame. The SBF build now emits no stack-offset warning, `withdraw_private` completes, and the bankrun suite is green. *(This hardening PR is rebased onto the migrated 1.0.2 base, so it carries no separate M6 commit.)*
 
 ### Low
 
@@ -165,11 +165,11 @@ This is a **self-audit, not an independent external review.** For a fund-custody
 
 Before the mainnet deploy (B7):
 
-- [x] **M1 landed** (`de065b4`) — `update_authority` (two-step) + `update_fee` present and tested.
-- [x] **M2/M3 landed** (`d740287`) — `locked_amount` removed; refund zeroes balance.
-- [x] **L3 landed** (`871f3e2`) — `encrypted_amount` length guard.
-- [x] **M6 landed** (`cc800a7`) — `WithdrawPrivate` stack frame back under 4096 B (Box accounts); build warning cleared, `withdraw_private` completes.
-- [x] **I1/I2/I3/I4 landed** (`8a047d3`, `399fa33`) — dead constant removed; token-program bindings; fee-token allowlist; init_if_needed invariant comment.
+- [x] **M1 landed** (`0528d49`) — `update_authority` (two-step) + `update_fee` present and tested.
+- [x] **M2/M3 landed** (`3dbc44f`) — `locked_amount` removed; refund zeroes balance.
+- [x] **L3 landed** (`d915b5f`) — `encrypted_amount` length guard.
+- [x] **M6 resolved by the Anchor 1.0.2 migration** (`8c79a33`) — `WithdrawPrivate` stack frame back under 4096 B (Box accounts); build warning cleared, `withdraw_private` completes.
+- [x] **I1/I2/I3/I4 landed** (`1b540a8`, `b4668e6`) — dead constant removed; token-program bindings; fee-token allowlist; init_if_needed invariant comment.
 - [ ] **Authority = Squads v4 2-of-3 multisig** set at (or handed off immediately after) `initialize`; both the BPF upgrade authority and the in-program `config.authority` point at the multisig.
 - [ ] **`sip_privacy` and `sipher_vault` pause authorities governed coherently** under the same multisig (L1).
 - [ ] **Deploy runbook** documents: the privacy boundary (§7), the `sip_privacy` liveness coupling (L1), the SDK rent pre-funding obligation for native payouts (M5), the build toolchain requirement (Appendix B), and the **breaking account-layout change** (M1/M2 — no safe in-place upgrade; fresh accounts required; see `DEPLOYMENT.md`).
@@ -181,21 +181,21 @@ Before the mainnet deploy (B7):
 
 | ID | Severity | Title | Disposition |
 |----|----------|-------|-------------|
-| M1 | Medium | No `update_authority` / `update_fee` | ✅ Resolved `de065b4` |
-| M2 | Medium | `locked_amount` inert dead state | ✅ Resolved `d740287` |
-| M3 | Medium | `refund` assigns `= locked_amount` | ✅ Resolved `d740287` (subsumed by M2) |
+| M1 | Medium | No `update_authority` / `update_fee` | ✅ Resolved `0528d49` |
+| M2 | Medium | `locked_amount` inert dead state | ✅ Resolved `3dbc44f` |
+| M3 | Medium | `refund` assigns `= locked_amount` | ✅ Resolved `3dbc44f` (subsumed by M2) |
 | M4 | Medium | Privacy disclosure (depositor + amount public) | Documented (§7) — no code change |
 | M5 | Medium | No native-SOL gasless path (rent pre-funding) | Documented — forward integration gate |
-| M6 | Medium | `WithdrawPrivate::try_accounts` stack frame > 4096 B | ✅ Resolved `cc800a7` |
+| M6 | Medium | `WithdrawPrivate::try_accounts` stack frame > 4096 B | ✅ Resolved `8c79a33` (Anchor 1.0.2 migration) |
 | L1 | Low | `sip_privacy` liveness coupling | Documented — runbook |
-| L2 | Low | `initialize` permissionless | ✅ Resolved `de065b4` (via M1) |
-| L3 | Low | `encrypted_amount` unbounded | ✅ Resolved `871f3e2` |
+| L2 | Low | `initialize` permissionless | ✅ Resolved `0528d49` (via M1) |
+| L3 | Low | `encrypted_amount` unbounded | ✅ Resolved `d915b5f` |
 | L4 | Low | `getStealthBalance` swallows RPC errors | Deferred (SDK) |
 | L5 | Low | counter saturating vs checked | Accepted |
-| I1 | Info | dead `SIP_TRANSFER_RECORD_SEED` | ✅ Resolved `8a047d3` |
-| I2 | Info | `token::token_program` not bound | ✅ Resolved `8a047d3` |
-| I3 | Info | `create_fee_token` no allowlist | ✅ Resolved `399fa33` |
-| I4 | Info | `init_if_needed` invariant comment | ✅ Resolved `8a047d3` |
+| I1 | Info | dead `SIP_TRANSFER_RECORD_SEED` | ✅ Resolved `1b540a8` |
+| I2 | Info | `token::token_program` not bound | ✅ Resolved `1b540a8` |
+| I3 | Info | `create_fee_token` no allowlist | ✅ Resolved `b4668e6` |
+| I4 | Info | `init_if_needed` invariant comment | ✅ Resolved `1b540a8` |
 
 ## Appendix B — Build toolchain note
 

--- a/programs/sipher-vault/package.json
+++ b/programs/sipher-vault/package.json
@@ -2,7 +2,7 @@
   "name": "sipher-vault-tests",
   "private": true,
   "scripts": {
-    "test": "ts-mocha -p ./tsconfig.json -t 1000000 \"tests/sipher-vault/{10,11,12}-*.ts\""
+    "test": "ts-mocha -p ./tsconfig.json -t 1000000 \"tests/sipher-vault/{10,11,12,13}-*.ts\""
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.32.1",

--- a/programs/sipher-vault/programs/sipher-vault/src/errors.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/errors.rs
@@ -28,4 +28,6 @@ pub enum VaultError {
   UnsupportedMintExtension,
   #[msg("Operation would drain a SOL PDA below its rent-exempt minimum")]
   RentReserveViolation,
+  #[msg("Encrypted amount exceeds the 64-byte maximum")]
+  EncryptedAmountTooLong,
 }

--- a/programs/sipher-vault/programs/sipher-vault/src/errors.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/errors.rs
@@ -22,8 +22,6 @@ pub enum VaultError {
   NoFeesToCollect,
   #[msg("Invalid token mint")]
   InvalidMint,
-  #[msg("Balance locked by scheduled operations")]
-  BalanceLocked,
   #[msg("CPI to SIP Privacy program failed")]
   AnnouncementCpiFailed,
   #[msg("Mint carries an unsupported Token-2022 extension")]

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -41,7 +41,6 @@ pub const SIP_PRIVACY_PROGRAM_ID: Pubkey = Pubkey::new_from_array([
 
 /// Seeds used by the sip_privacy program
 pub const SIP_CONFIG_SEED: &[u8] = b"config";
-pub const SIP_TRANSFER_RECORD_SEED: &[u8] = b"transfer_record";
 
 /// Anchor instruction discriminator for `sip_privacy::create_transfer_announcement`
 /// = `sha256("global:create_transfer_announcement")[..8]`.
@@ -935,6 +934,10 @@ pub struct DepositSol<'info> {
   )]
   pub config: Account<'info, VaultConfig>,
 
+  // init_if_needed is safe ONLY because `deposit_sol` accumulates: `is_new` is
+  // derived from cumulative_volume, and balance/cumulative_volume are added to,
+  // never reset. A future edit that zeroes a field on re-init would reintroduce
+  // a double-credit/overwrite bug — preserve the accumulate-not-reset invariant.
   #[account(
     init_if_needed,
     payer = depositor,
@@ -966,6 +969,10 @@ pub struct Deposit<'info> {
   )]
   pub config: Account<'info, VaultConfig>,
 
+  // init_if_needed is safe ONLY because `deposit` accumulates: `is_new` is
+  // derived from cumulative_volume, and balance/cumulative_volume are added to,
+  // never reset. A future edit that zeroes a field on re-init would reintroduce
+  // a double-credit/overwrite bug — preserve the accumulate-not-reset invariant.
   #[account(
     init_if_needed,
     payer = depositor,
@@ -981,6 +988,7 @@ pub struct Deposit<'info> {
     bump,
     token::mint = token_mint,
     token::authority = config,
+    token::token_program = token_program,
   )]
   pub vault_token: InterfaceAccount<'info, TokenAccount>,
 
@@ -1028,6 +1036,7 @@ pub struct WithdrawPrivate<'info> {
     bump,
     token::mint = token_mint,
     token::authority = config,
+    token::token_program = token_program,
   )]
   pub vault_token: Box<InterfaceAccount<'info, TokenAccount>>,
 
@@ -1037,6 +1046,7 @@ pub struct WithdrawPrivate<'info> {
     bump,
     token::mint = token_mint,
     token::authority = config,
+    token::token_program = token_program,
   )]
   pub fee_token: Box<InterfaceAccount<'info, TokenAccount>>,
 
@@ -1173,6 +1183,7 @@ pub struct Refund<'info> {
     bump,
     token::mint = deposit_record.token_mint,
     token::authority = config,
+    token::token_program = token_program,
   )]
   pub vault_token: InterfaceAccount<'info, TokenAccount>,
 
@@ -1218,6 +1229,7 @@ pub struct AuthorityRefund<'info> {
     bump,
     token::mint = deposit_record.token_mint,
     token::authority = config,
+    token::token_program = token_program,
   )]
   pub vault_token: InterfaceAccount<'info, TokenAccount>,
 
@@ -1330,6 +1342,7 @@ pub struct CollectFee<'info> {
     bump,
     token::mint = token_mint,
     token::authority = config,
+    token::token_program = token_program,
   )]
   pub fee_token: InterfaceAccount<'info, TokenAccount>,
 

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -696,6 +696,11 @@ pub mod sipher_vault {
   pub fn update_authority(ctx: Context<UpdateAuthority>, new_authority: Pubkey) -> Result<()> {
     ctx.accounts.config.pending_authority = Some(new_authority);
     msg!("Authority transfer proposed: {}", new_authority);
+    emit!(AuthorityTransferProposedEvent {
+      current_authority: ctx.accounts.authority.key(),
+      pending_authority: new_authority,
+      timestamp: Clock::get()?.unix_timestamp,
+    });
     Ok(())
   }
 
@@ -709,9 +714,15 @@ pub mod sipher_vault {
       config.pending_authority == Some(ctx.accounts.new_authority.key()),
       VaultError::Unauthorized
     );
+    let old_authority = config.authority;
     config.authority = ctx.accounts.new_authority.key();
     config.pending_authority = None;
     msg!("Authority transfer accepted: {}", config.authority);
+    emit!(AuthorityUpdatedEvent {
+      old_authority,
+      new_authority: config.authority,
+      timestamp: Clock::get()?.unix_timestamp,
+    });
     Ok(())
   }
 
@@ -719,8 +730,15 @@ pub mod sipher_vault {
   /// MAX_FEE_BPS. Lets the authority adjust the fee without a redeploy.
   pub fn update_fee(ctx: Context<UpdateFee>, new_fee_bps: u16) -> Result<()> {
     require!(new_fee_bps <= MAX_FEE_BPS, VaultError::FeeTooHigh);
+    let old_fee_bps = ctx.accounts.config.fee_bps;
     ctx.accounts.config.fee_bps = new_fee_bps;
     msg!("Fee updated: {} bps", new_fee_bps);
+    emit!(FeeUpdatedEvent {
+      authority: ctx.accounts.authority.key(),
+      old_fee_bps,
+      new_fee_bps,
+      timestamp: Clock::get()?.unix_timestamp,
+    });
     Ok(())
   }
 }
@@ -1466,5 +1484,34 @@ pub struct VaultWithdrawEvent {
 pub struct VaultPausedEvent {
   pub authority: Pubkey,
   pub paused: bool,
+  pub timestamp: i64,
+}
+
+/// Emitted when the current authority proposes a transfer (step 1). Lets
+/// off-chain monitoring (SENTINEL, indexers) react to a pending authority
+/// change without log-parsing — the same rationale as `VaultPausedEvent`.
+#[event]
+pub struct AuthorityTransferProposedEvent {
+  pub current_authority: Pubkey,
+  pub pending_authority: Pubkey,
+  pub timestamp: i64,
+}
+
+/// Emitted when a pending authority transfer is accepted (step 2) and
+/// `config.authority` actually changes — the single most alarm-worthy custody
+/// event, especially once the authority is a mainnet multisig.
+#[event]
+pub struct AuthorityUpdatedEvent {
+  pub old_authority: Pubkey,
+  pub new_authority: Pubkey,
+  pub timestamp: i64,
+}
+
+/// Emitted when the authority updates the protocol fee.
+#[event]
+pub struct FeeUpdatedEvent {
+  pub authority: Pubkey,
+  pub old_fee_bps: u16,
+  pub new_fee_bps: u16,
   pub timestamp: i64,
 }

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -13,6 +13,8 @@
 //! - `refund` — Return available balance to depositor
 //! - `collect_fee` — Authority-only token-fee withdrawal
 //! - `collect_fee_sol` — Authority-only native-SOL fee withdrawal (above rent floor)
+//! - `update_authority` / `accept_authority` — Two-step authority transfer
+//! - `update_fee` — Authority-only fee update (capped at MAX_FEE_BPS)
 
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program;
@@ -77,6 +79,7 @@ pub mod sipher_vault {
     config.total_deposits = 0;
     config.total_depositors = 0;
     config.bump = ctx.bumps.config;
+    config.pending_authority = None;
 
     msg!("Vault initialized: fee={}bps, timeout={}s", fee_bps, refund_timeout);
     Ok(())
@@ -702,6 +705,43 @@ pub mod sipher_vault {
       paused,
       timestamp: Clock::get()?.unix_timestamp,
     });
+    Ok(())
+  }
+
+  /// Propose a new authority (step 1 of a two-step transfer). The current
+  /// authority signs; the proposed key is recorded in `pending_authority` but
+  /// does not take effect until it calls `accept_authority`. This lets the
+  /// program hand control to e.g. a multisig without a redeploy, and lets a
+  /// fat-fingered or compromised proposal be overwritten by another
+  /// `update_authority` before it is ever accepted.
+  pub fn update_authority(ctx: Context<UpdateAuthority>, new_authority: Pubkey) -> Result<()> {
+    ctx.accounts.config.pending_authority = Some(new_authority);
+    msg!("Authority transfer proposed: {}", new_authority);
+    Ok(())
+  }
+
+  /// Accept a pending authority transfer (step 2). The proposed authority must
+  /// sign — proving control of the key — before `config.authority` changes, so
+  /// the authority can never be handed to a key nobody controls. Clears the
+  /// pending slot on success.
+  pub fn accept_authority(ctx: Context<AcceptAuthority>) -> Result<()> {
+    let config = &mut ctx.accounts.config;
+    require!(
+      config.pending_authority == Some(ctx.accounts.new_authority.key()),
+      VaultError::Unauthorized
+    );
+    config.authority = ctx.accounts.new_authority.key();
+    config.pending_authority = None;
+    msg!("Authority transfer accepted: {}", config.authority);
+    Ok(())
+  }
+
+  /// Update the protocol fee (basis points). Authority-only, capped at
+  /// MAX_FEE_BPS. Lets the authority adjust the fee without a redeploy.
+  pub fn update_fee(ctx: Context<UpdateFee>, new_fee_bps: u16) -> Result<()> {
+    require!(new_fee_bps <= MAX_FEE_BPS, VaultError::FeeTooHigh);
+    ctx.accounts.config.fee_bps = new_fee_bps;
+    msg!("Fee updated: {} bps", new_fee_bps);
     Ok(())
   }
 }
@@ -1333,6 +1373,47 @@ pub struct CollectFeeSol<'info> {
 
 #[derive(Accounts)]
 pub struct SetPaused<'info> {
+  #[account(
+    mut,
+    seeds = [VAULT_CONFIG_SEED],
+    bump = config.bump,
+    has_one = authority @ VaultError::Unauthorized,
+  )]
+  pub config: Account<'info, VaultConfig>,
+
+  pub authority: Signer<'info>,
+}
+
+#[derive(Accounts)]
+pub struct UpdateAuthority<'info> {
+  #[account(
+    mut,
+    seeds = [VAULT_CONFIG_SEED],
+    bump = config.bump,
+    has_one = authority @ VaultError::Unauthorized,
+  )]
+  pub config: Account<'info, VaultConfig>,
+
+  pub authority: Signer<'info>,
+}
+
+/// Accept context — the *proposed* authority signs. No `has_one`: the new
+/// authority is, by definition, not yet the current authority. The match
+/// against `pending_authority` is enforced in the instruction body.
+#[derive(Accounts)]
+pub struct AcceptAuthority<'info> {
+  #[account(
+    mut,
+    seeds = [VAULT_CONFIG_SEED],
+    bump = config.bump,
+  )]
+  pub config: Account<'info, VaultConfig>,
+
+  pub new_authority: Signer<'info>,
+}
+
+#[derive(Accounts)]
+pub struct UpdateFee<'info> {
   #[account(
     mut,
     seeds = [VAULT_CONFIG_SEED],

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -93,30 +93,7 @@ pub mod sipher_vault {
   /// NonTransferable, DefaultAccountState, MintCloseAuthority, etc.) is rejected
   /// with UnsupportedMintExtension to protect the vault's transfer invariants.
   pub fn create_vault_token(ctx: Context<CreateVaultToken>) -> Result<()> {
-    // ── Token-2022 extension allowlist (fail-closed) ──────────────────────
-    // Gate on the mint's program owner so the allowlist is truly fail-closed:
-    // - Classic SPL mints (owned by TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA)
-    //   have no TLV extension area — skip the check entirely.
-    // - Token-2022 mints (owned by anchor_spl::token_2022::ID) MUST unpack
-    //   successfully; a malformed TLV that causes Err is treated as a rejected
-    //   mint (fail-closed), not silently accepted (fail-open).
-    {
-      let mint_ai = ctx.accounts.token_mint.to_account_info();
-      if *mint_ai.owner == anchor_spl::token_2022::ID {
-        let data = mint_ai.try_borrow_data()?;
-        let state = StateWithExtensions::<Token2022Mint>::unpack(&data)
-          .map_err(|_| VaultError::UnsupportedMintExtension)?;
-        for ext in state.get_extension_types()? {
-          let allowed = matches!(
-            ext,
-            ExtensionType::MetadataPointer
-              | ExtensionType::TokenMetadata
-              | ExtensionType::InterestBearingConfig
-          );
-          require!(allowed, VaultError::UnsupportedMintExtension);
-        }
-      }
-    }
+    enforce_token2022_allowlist(&ctx.accounts.token_mint.to_account_info())?;
 
     msg!(
       "Vault token PDA created for mint {}",
@@ -128,6 +105,9 @@ pub mod sipher_vault {
   /// Create the fee token PDA for a given mint.
   /// Anyone can call this. Must exist before withdraw_private.
   pub fn create_fee_token(ctx: Context<CreateFeeToken>) -> Result<()> {
+    // Mirror the create_vault_token allowlist (shared helper) so the two
+    // token-PDA creation paths can never diverge on extension safety.
+    enforce_token2022_allowlist(&ctx.accounts.token_mint.to_account_info())?;
     msg!(
       "Fee token PDA created for mint {}",
       ctx.accounts.token_mint.key()
@@ -748,6 +728,33 @@ pub mod sipher_vault {
 // ─────────────────────────────────────────────────────────────────────────────
 // Shared helpers
 // ─────────────────────────────────────────────────────────────────────────────
+
+/// Fail-closed Token-2022 extension allowlist. Classic SPL mints (no TLV
+/// extension area) pass untouched; Token-2022 mints MUST unpack and may carry
+/// ONLY transfer-neutral extensions (MetadataPointer, TokenMetadata,
+/// InterestBearingConfig). A malformed TLV (Err on unpack) or ANY other /
+/// unknown / future extension is rejected with `UnsupportedMintExtension`, to
+/// protect the vault's raw-amount transfer invariants.
+///
+/// Shared by `create_vault_token` and `create_fee_token` so the two token-PDA
+/// creation paths can never diverge on extension safety.
+fn enforce_token2022_allowlist(mint_ai: &AccountInfo) -> Result<()> {
+  if *mint_ai.owner == anchor_spl::token_2022::ID {
+    let data = mint_ai.try_borrow_data()?;
+    let state = StateWithExtensions::<Token2022Mint>::unpack(&data)
+      .map_err(|_| VaultError::UnsupportedMintExtension)?;
+    for ext in state.get_extension_types()? {
+      let allowed = matches!(
+        ext,
+        ExtensionType::MetadataPointer
+          | ExtensionType::TokenMetadata
+          | ExtensionType::InterestBearingConfig
+      );
+      require!(allowed, VaultError::UnsupportedMintExtension);
+    }
+  }
+  Ok(())
+}
 
 /// Emit a `sip_privacy::create_transfer_announcement` CPI so a vault withdrawal
 /// becomes a scannable, Pedersen-committed announcement (a `TransferRecord` PDA).

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -52,6 +52,13 @@ pub const SIP_CONFIG_SEED: &[u8] = b"config";
 pub const CREATE_TRANSFER_ANNOUNCEMENT_DISC: [u8; 8] =
   [0x9b, 0x34, 0xb1, 0x8f, 0xd3, 0x5b, 0xcd, 0x66];
 
+/// Maximum byte length of the opaque `encrypted_amount` blob the withdrawal
+/// paths accept. Mirrors the callee `sip_privacy`'s own cap (its
+/// `TransferRecord.encrypted_amount` is `#[max_len(64)]`); the vault re-checks
+/// it so an over-long blob fails fast with a vault-native error before the
+/// debit. Keep in sync with sip_privacy if that cap ever changes.
+pub const MAX_ENCRYPTED_AMOUNT_LEN: usize = 64;
+
 declare_id!("S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB");
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -233,14 +240,13 @@ pub mod sipher_vault {
   ) -> Result<()> {
     require!(!ctx.accounts.config.paused, VaultError::ProgramPaused);
     require!(amount > 0, VaultError::ZeroDeposit);
-    // Fail-fast before the debit: the callee caps encrypted_amount at 64 bytes,
-    // so reject an over-long blob early with a vault-native error.
-    require!(_encrypted_amount.len() <= 64, VaultError::EncryptedAmountTooLong);
+    // Fail-fast before the debit: reject an over-long blob early with a
+    // vault-native error. Mirrors the callee's cap (see MAX_ENCRYPTED_AMOUNT_LEN).
+    require!(_encrypted_amount.len() <= MAX_ENCRYPTED_AMOUNT_LEN, VaultError::EncryptedAmountTooLong);
 
     // 1. Debit-first: reduce balance before any transfers
     let record = &mut ctx.accounts.deposit_record;
-    let available = record.balance;
-    require!(available >= amount, VaultError::InsufficientBalance);
+    require!(record.balance >= amount, VaultError::InsufficientBalance);
 
     record.balance = record.balance
       .checked_sub(amount)
@@ -349,14 +355,13 @@ pub mod sipher_vault {
   ) -> Result<()> {
     require!(!ctx.accounts.config.paused, VaultError::ProgramPaused);
     require!(amount > 0, VaultError::ZeroDeposit);
-    // Fail-fast before the debit: the callee caps encrypted_amount at 64 bytes,
-    // so reject an over-long blob early with a vault-native error.
-    require!(_encrypted_amount.len() <= 64, VaultError::EncryptedAmountTooLong);
+    // Fail-fast before the debit: reject an over-long blob early with a
+    // vault-native error. Mirrors the callee's cap (see MAX_ENCRYPTED_AMOUNT_LEN).
+    require!(_encrypted_amount.len() <= MAX_ENCRYPTED_AMOUNT_LEN, VaultError::EncryptedAmountTooLong);
 
     // 1. Debit-first: reduce balance before any lamport movement.
     let record = &mut ctx.accounts.deposit_record;
-    let available = record.balance;
-    require!(available >= amount, VaultError::InsufficientBalance);
+    require!(record.balance >= amount, VaultError::InsufficientBalance);
 
     record.balance = record.balance
       .checked_sub(amount)

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -10,7 +10,7 @@
 //! - `create_fee_token` — Create fee token PDA for a given mint
 //! - `deposit` — Transfer tokens from user to vault PDA, create/update DepositRecord
 //! - `withdraw_private` — Debit-first withdrawal to stealth address + fee split
-//! - `refund` — Return available (unlocked) balance to depositor
+//! - `refund` — Return available balance to depositor
 //! - `collect_fee` — Authority-only token-fee withdrawal
 //! - `collect_fee_sol` — Authority-only native-SOL fee withdrawal (above rent floor)
 
@@ -254,9 +254,7 @@ pub mod sipher_vault {
 
     // 1. Debit-first: reduce balance before any transfers
     let record = &mut ctx.accounts.deposit_record;
-    let available = record.balance
-      .checked_sub(record.locked_amount)
-      .ok_or(VaultError::MathOverflow)?;
+    let available = record.balance;
     require!(available >= amount, VaultError::InsufficientBalance);
 
     record.balance = record.balance
@@ -369,9 +367,7 @@ pub mod sipher_vault {
 
     // 1. Debit-first: reduce balance before any lamport movement.
     let record = &mut ctx.accounts.deposit_record;
-    let available = record.balance
-      .checked_sub(record.locked_amount)
-      .ok_or(VaultError::MathOverflow)?;
+    let available = record.balance;
     require!(available >= amount, VaultError::InsufficientBalance);
 
     record.balance = record.balance
@@ -449,12 +445,10 @@ pub mod sipher_vault {
     Ok(())
   }
 
-  /// Refund available (unlocked) balance back to depositor.
+  /// Refund available balance back to depositor.
   pub fn refund(ctx: Context<Refund>) -> Result<()> {
     let record = &mut ctx.accounts.deposit_record;
-    let available = record.balance
-      .checked_sub(record.locked_amount)
-      .ok_or(VaultError::MathOverflow)?;
+    let available = record.balance;
     require!(available > 0, VaultError::NothingToRefund);
 
     // Check refund timeout
@@ -484,13 +478,13 @@ pub mod sipher_vault {
     token_interface::transfer_checked(transfer_ctx, available, ctx.accounts.token_mint.decimals)?;
 
     // Zero out refunded balance
-    record.balance = record.locked_amount;
+    record.balance = 0;
 
     msg!("Refunded {} tokens", available);
     Ok(())
   }
 
-  /// Authority-signed refund: return available (unlocked) balance to depositor.
+  /// Authority-signed refund: return available balance to depositor.
   /// Mirrors `refund` exactly except the authority signs instead of the depositor.
   /// Used by SENTINEL for autonomous refunds of expired deposits.
   /// Timeout is still enforced on-chain — authority does NOT bypass the cooldown.
@@ -498,9 +492,7 @@ pub mod sipher_vault {
     require!(!ctx.accounts.config.paused, VaultError::ProgramPaused);
 
     let record = &mut ctx.accounts.deposit_record;
-    let available = record.balance
-      .checked_sub(record.locked_amount)
-      .ok_or(VaultError::MathOverflow)?;
+    let available = record.balance;
     require!(available > 0, VaultError::NothingToRefund);
 
     // Enforce refund timeout — authority does NOT bypass the cooldown
@@ -529,22 +521,20 @@ pub mod sipher_vault {
     );
     token_interface::transfer_checked(transfer_ctx, available, ctx.accounts.token_mint.decimals)?;
 
-    // Zero out refunded balance (locked_amount preserved)
-    record.balance = record.locked_amount;
+    // Zero out refunded balance
+    record.balance = 0;
 
     msg!("Authority refunded {} tokens to {}", available, ctx.accounts.depositor.key());
     Ok(())
   }
 
-  /// Refund available (unlocked) native SOL balance back to the depositor.
+  /// Refund available native SOL balance back to the depositor.
   /// Depositor is the signer and the lamport destination.
   /// Timeout is enforced on-chain — the depositor must wait `refund_timeout` seconds
   /// since their last deposit before reclaiming funds.
   pub fn refund_sol(ctx: Context<RefundSol>) -> Result<()> {
     let record = &mut ctx.accounts.deposit_record;
-    let available = record.balance
-      .checked_sub(record.locked_amount)
-      .ok_or(VaultError::MathOverflow)?;
+    let available = record.balance;
     require!(available > 0, VaultError::NothingToRefund);
 
     // Enforce refund timeout
@@ -573,14 +563,14 @@ pub mod sipher_vault {
     **vault_ai.try_borrow_mut_lamports()? = new_vault;
     **dep_ai.try_borrow_mut_lamports()? = new_dep;
 
-    // Zero out the refunded (unlocked) portion; locked_amount is preserved.
-    record.balance = record.locked_amount;
+    // Zero out the refunded balance.
+    record.balance = 0;
 
     msg!("Refunded {} lamports (native SOL)", available);
     Ok(())
   }
 
-  /// Authority-signed refund of available (unlocked) native SOL to the original depositor.
+  /// Authority-signed refund of available native SOL to the original depositor.
   /// Mirrors `refund_sol` exactly except:
   ///   - the authority signs instead of the depositor,
   ///   - `config` carries `has_one = authority` (so wrong authority → Unauthorized),
@@ -591,9 +581,7 @@ pub mod sipher_vault {
     require!(!ctx.accounts.config.paused, VaultError::ProgramPaused);
 
     let record = &mut ctx.accounts.deposit_record;
-    let available = record.balance
-      .checked_sub(record.locked_amount)
-      .ok_or(VaultError::MathOverflow)?;
+    let available = record.balance;
     require!(available > 0, VaultError::NothingToRefund);
 
     // Enforce refund timeout — authority does NOT bypass the cooldown
@@ -620,8 +608,8 @@ pub mod sipher_vault {
     **vault_ai.try_borrow_mut_lamports()? = new_vault;
     **dep_ai.try_borrow_mut_lamports()? = new_dep;
 
-    // Zero out the refunded (unlocked) portion; locked_amount is preserved.
-    record.balance = record.locked_amount;
+    // Zero out the refunded balance.
+    record.balance = 0;
 
     msg!("Authority refunded {} lamports (native SOL) to {}", available, ctx.accounts.depositor.key());
     Ok(())

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -251,6 +251,9 @@ pub mod sipher_vault {
   ) -> Result<()> {
     require!(!ctx.accounts.config.paused, VaultError::ProgramPaused);
     require!(amount > 0, VaultError::ZeroDeposit);
+    // Fail-fast before the debit: the callee caps encrypted_amount at 64 bytes,
+    // so reject an over-long blob early with a vault-native error.
+    require!(_encrypted_amount.len() <= 64, VaultError::EncryptedAmountTooLong);
 
     // 1. Debit-first: reduce balance before any transfers
     let record = &mut ctx.accounts.deposit_record;
@@ -364,6 +367,9 @@ pub mod sipher_vault {
   ) -> Result<()> {
     require!(!ctx.accounts.config.paused, VaultError::ProgramPaused);
     require!(amount > 0, VaultError::ZeroDeposit);
+    // Fail-fast before the debit: the callee caps encrypted_amount at 64 bytes,
+    // so reject an over-long blob early with a vault-native error.
+    require!(_encrypted_amount.len() <= 64, VaultError::EncryptedAmountTooLong);
 
     // 1. Debit-first: reduce balance before any lamport movement.
     let record = &mut ctx.accounts.deposit_record;

--- a/programs/sipher-vault/programs/sipher-vault/src/state.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/state.rs
@@ -10,6 +10,10 @@ pub struct VaultConfig {
   pub total_deposits: u64,
   pub total_depositors: u64,
   pub bump: u8,
+  /// Pending authority for the two-step authority transfer (None = no transfer
+  /// in flight). Set by `update_authority`, promoted/cleared by `accept_authority`.
+  /// Trailing field so the fixed-offset fields above keep their byte positions.
+  pub pending_authority: Option<Pubkey>,
 }
 
 #[account]

--- a/programs/sipher-vault/programs/sipher-vault/src/state.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/state.rs
@@ -18,7 +18,6 @@ pub struct DepositRecord {
   pub depositor: Pubkey,
   pub token_mint: Pubkey,
   pub balance: u64,
-  pub locked_amount: u64,
   pub cumulative_volume: u64,
   pub last_deposit_at: i64,
   pub bump: u8,

--- a/programs/sipher-vault/tests/sipher-vault/02-deposit.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/02-deposit.test.ts
@@ -80,7 +80,6 @@ describe('sipher-vault: deposit', () => {
     expect(record.depositor.toString()).to.equal(authority.publicKey.toString())
     expect(record.tokenMint.toString()).to.equal(mint.toString())
     expect(record.balance.toNumber()).to.equal(DEPOSIT_AMOUNT_1)
-    expect(record.lockedAmount.toNumber()).to.equal(0)
     expect(record.cumulativeVolume.toNumber()).to.equal(DEPOSIT_AMOUNT_1)
     expect(record.lastDepositAt.toNumber()).to.be.greaterThan(0)
     expect(record.bump).to.be.a('number')

--- a/programs/sipher-vault/tests/sipher-vault/03-refund.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/03-refund.test.ts
@@ -154,7 +154,6 @@ describe('sipher-vault: refund', () => {
     // Sanity: verify deposits landed
     const record = await program.account.depositRecord.fetch(depositRecordPDA)
     expect(record.balance.toNumber()).to.equal(TOTAL_DEPOSITED)
-    expect(record.lockedAmount.toNumber()).to.equal(0)
   })
 
   // ── Test 1: RefundNotExpired fires before timeout elapses ──────────────
@@ -199,8 +198,7 @@ describe('sipher-vault: refund', () => {
       depositorAta,
     )
     const vaultBalanceBefore = await getTokenBalance(provider, vaultTokenPDA)
-    const availableToRefund =
-      recordBefore.balance.toNumber() - recordBefore.lockedAmount.toNumber()
+    const availableToRefund = recordBefore.balance.toNumber()
 
     expect(availableToRefund).to.equal(TOTAL_DEPOSITED)
     expect(vaultBalanceBefore).to.equal(TOTAL_DEPOSITED)
@@ -238,12 +236,9 @@ describe('sipher-vault: refund', () => {
       })
       .rpc()
 
-    // Verify deposit record: balance should drop to locked_amount (0)
+    // Verify deposit record: balance should drop to 0
     const recordAfter = await program.account.depositRecord.fetch(
       depositRecordPDA,
-    )
-    expect(recordAfter.balance.toNumber()).to.equal(
-      recordAfter.lockedAmount.toNumber(),
     )
     expect(recordAfter.balance.toNumber()).to.equal(0)
 
@@ -273,7 +268,7 @@ describe('sipher-vault: refund', () => {
     const clock = await provider.context.banksClient.getClock()
     provider.context.warpToSlot(clock.slot + 2n)
 
-    // Post-refund: balance=0, locked_amount=0 -> available=0
+    // Post-refund: balance=0 -> available=0
     const record = await program.account.depositRecord.fetch(depositRecordPDA)
     expect(record.balance.toNumber()).to.equal(0)
 
@@ -414,7 +409,7 @@ describe('sipher-vault: refund', () => {
       const depositorBalanceBefore = await getTokenBalance(provider, depositorAta)
       const vaultBalanceBefore = await getTokenBalance(provider, vaultTokenPDA)
       const record = await program.account.depositRecord.fetch(depositRecordPDA)
-      const availableToRefund = record.balance.toNumber() - record.lockedAmount.toNumber()
+      const availableToRefund = record.balance.toNumber()
 
       expect(availableToRefund).to.equal(DEPOSIT_AMOUNT_1)
 
@@ -432,7 +427,6 @@ describe('sipher-vault: refund', () => {
 
       // Verify: deposit record balance zeroed
       const recordAfter = await program.account.depositRecord.fetch(depositRecordPDA)
-      expect(recordAfter.balance.toNumber()).to.equal(recordAfter.lockedAmount.toNumber())
       expect(recordAfter.balance.toNumber()).to.equal(0)
 
       // Verify: depositor received tokens

--- a/programs/sipher-vault/tests/sipher-vault/10-bankrun-classic-spl.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/10-bankrun-classic-spl.test.ts
@@ -281,6 +281,56 @@ describe('10 · bankrun classic-SPL regression baseline', function () {
     )
   })
 
+  // ── it: withdraw_private rejects an over-long encrypted_amount (L3 guard) ──
+
+  it('withdraw_private → rejects encrypted_amount longer than 64 bytes (EncryptedAmountTooLong 6013 / 0x177d)', async function () {
+    const ENCRYPTED_AMOUNT_TOO_LONG_CODE = 6013
+    const ENCRYPTED_AMOUNT_TOO_LONG_HEX = ENCRYPTED_AMOUNT_TOO_LONG_CODE.toString(16) // '177d'
+
+    const [depositRecordPda] = getDepositRecordPDA(authority.publicKey, mint, VAULT_PROGRAM_ID)
+    const balanceBefore = parseDepositRecord(await getAccountData(ctx, depositRecordPda)).balance
+    assert.ok(balanceBefore > 0n, 'precondition: depositor has a balance to attempt withdrawing')
+
+    const [sipConfigPda] = getSipConfigPDA()
+    const { totalTransfers } = parseSipConfig(await getAccountData(ctx, sipConfigPda))
+    const [sipTransferRecordPda] = getSipTransferRecordPDA(authority.publicKey, totalTransfers)
+
+    const amountCommitment = Buffer.concat([Buffer.from([0x02]), randomBytes(32)])
+    const ephemeralPubkey = Buffer.concat([Buffer.from([0x02]), randomBytes(32)])
+    const viewingKeyHash = randomBytes(32)
+    const tooLong = randomBytes(65) // 65 > the 64-byte cap
+    const proof = Buffer.from([])
+
+    try {
+      await sendIx(ctx, [
+        ixWithdrawPrivate(
+          authority.publicKey, stealthAta, mint, sipTransferRecordPda,
+          1n, amountCommitment, stealthKp.publicKey, ephemeralPubkey,
+          viewingKeyHash, tooLong, proof,
+        ),
+      ], [authority])
+      assert.fail('Expected EncryptedAmountTooLong error but transaction succeeded')
+    } catch (e: unknown) {
+      const err = e as Error
+      if (err.message && err.message.includes('Expected EncryptedAmountTooLong error but transaction succeeded')) {
+        throw err
+      }
+      const msg = (err?.message ?? String(err)).toLowerCase()
+      const matchesCode =
+        msg.includes(String(ENCRYPTED_AMOUNT_TOO_LONG_CODE)) ||
+        msg.includes(ENCRYPTED_AMOUNT_TOO_LONG_HEX) ||
+        msg.includes('encryptedamounttoolong')
+      assert.ok(
+        matchesCode,
+        `Expected EncryptedAmountTooLong (${ENCRYPTED_AMOUNT_TOO_LONG_CODE} / 0x${ENCRYPTED_AMOUNT_TOO_LONG_HEX}), got: ${err?.message ?? String(err)}`,
+      )
+    }
+
+    // Fail-fast: the guard rejects before the debit — balance is unchanged.
+    const balanceAfter = parseDepositRecord(await getAccountData(ctx, depositRecordPda)).balance
+    assert.strictEqual(balanceAfter, balanceBefore, 'balance must be unchanged (guard rejects before debit)')
+  })
+
   // ── it: refund after timeout ─────────────────────────────────────────────
 
   it('refund after timeout → depositor receives remaining balance', async function () {

--- a/programs/sipher-vault/tests/sipher-vault/10-bankrun-classic-spl.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/10-bankrun-classic-spl.test.ts
@@ -171,7 +171,6 @@ describe('10 · bankrun classic-SPL regression baseline', function () {
     const rec = parseDepositRecord(recData)
 
     assert.strictEqual(rec.balance, DEPOSIT_AMOUNT, 'deposit_record.balance mismatch')
-    assert.strictEqual(rec.lockedAmount, 0n, 'locked_amount should be 0 after deposit')
     assert.strictEqual(rec.cumulativeVolume, DEPOSIT_AMOUNT, 'cumulative_volume mismatch')
     assert.ok(rec.depositor.equals(authority.publicKey), 'depositor pubkey mismatch')
     assert.ok(rec.tokenMint.equals(mint), 'token_mint mismatch')
@@ -290,7 +289,7 @@ describe('10 · bankrun classic-SPL regression baseline', function () {
 
     // Read current deposit record to know what's available
     const recBefore = parseDepositRecord(await getAccountData(ctx, depositRecordPda))
-    const available = recBefore.balance - recBefore.lockedAmount
+    const available = recBefore.balance
     assert.ok(available > 0n, 'nothing to refund — test state error')
 
     // Snapshot depositor ATA before refund
@@ -322,7 +321,7 @@ describe('10 · bankrun classic-SPL regression baseline', function () {
       `depositor did not receive correct refund amount`,
     )
 
-    // ── Assert: DepositRecord.balance is now 0 (locked_amount was 0) ──
+    // ── Assert: DepositRecord.balance is now 0 after full refund ──
     const recAfter = parseDepositRecord(await getAccountData(ctx, depositRecordPda))
     assert.strictEqual(recAfter.balance, 0n, 'deposit_record.balance should be 0 after full refund')
 

--- a/programs/sipher-vault/tests/sipher-vault/11-token2022-allowlist.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/11-token2022-allowlist.test.ts
@@ -8,7 +8,7 @@
 //             NonTransferable, DefaultAccountState, MintCloseAuthority
 //
 // All tests use fresh mints per case. The vault config is shared (initialized
-// once in before()). Error code for UnsupportedMintExtension: 6012 (0x177c).
+// once in before()). Error code for UnsupportedMintExtension: 6011 (0x177b).
 
 import { assert } from 'chai'
 import { Keypair, SystemProgram } from '@solana/web3.js'
@@ -36,10 +36,10 @@ import { getVaultTokenPDA } from './setup'
 // Constants
 // ─────────────────────────────────────────────────────────────────────────────
 
-// Anchor custom errors start at 6000. UnsupportedMintExtension is index 12.
-const UNSUPPORTED_MINT_EXTENSION_CODE = 6012
+// Anchor custom errors start at 6000. UnsupportedMintExtension is index 11.
+const UNSUPPORTED_MINT_EXTENSION_CODE = 6011
 // Hex representation for log/message matching
-const UNSUPPORTED_MINT_EXTENSION_HEX = (UNSUPPORTED_MINT_EXTENSION_CODE).toString(16) // '177c'
+const UNSUPPORTED_MINT_EXTENSION_HEX = (UNSUPPORTED_MINT_EXTENSION_CODE).toString(16) // '177b'
 
 const FEE_BPS = 10
 const REFUND_TIMEOUT = 86400n // 24h — not relevant for these tests
@@ -49,7 +49,7 @@ const REFUND_TIMEOUT = 86400n // 24h — not relevant for these tests
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Assert a promise rejects with UnsupportedMintExtension (6012 / 0x177c).
+ * Assert a promise rejects with UnsupportedMintExtension (6011 / 0x177b).
  * Bankrun embeds the error code in the transaction failure message.
  */
 async function assertUnsupportedMintExtension(fn: () => Promise<void>): Promise<void> {

--- a/programs/sipher-vault/tests/sipher-vault/11-token2022-allowlist.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/11-token2022-allowlist.test.ts
@@ -29,7 +29,7 @@ import {
 } from '@solana/spl-token'
 import { ProgramTestContext } from 'solana-bankrun'
 
-import { ixInitialize, ixCreateVaultToken, sendIx, startVault, VAULT_PROGRAM_ID } from './bankrun-helpers'
+import { ixInitialize, ixCreateVaultToken, ixCreateFeeToken, sendIx, startVault, VAULT_PROGRAM_ID } from './bankrun-helpers'
 import { getVaultTokenPDA } from './setup'
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -458,6 +458,44 @@ describe('11 · Token-2022 extension allowlist (fail-closed)', function () {
     await assertUnsupportedMintExtension(async () => {
       await sendIx(ctx, [
         ixCreateVaultToken(mintKp.publicKey, authority.publicKey, TOKEN_2022_PROGRAM_ID),
+      ], [authority])
+    })
+  })
+
+  // ── REJECT: create_fee_token mirrors the same allowlist (I3) ────────────
+
+  it('REJECT: PermanentDelegate mint → create_fee_token fails with UnsupportedMintExtension', async function () {
+    const mintKp = Keypair.generate()
+    const extTypes = [ExtensionType.PermanentDelegate]
+    const space = getMintLen(extTypes)
+    const rent = await ctx.banksClient.getRent()
+    const mintLamports = Number(rent.minimumBalance(BigInt(space)))
+
+    await sendIx(ctx, [
+      SystemProgram.createAccount({
+        fromPubkey: authority.publicKey,
+        newAccountPubkey: mintKp.publicKey,
+        lamports: mintLamports,
+        space,
+        programId: TOKEN_2022_PROGRAM_ID,
+      }),
+      createInitializePermanentDelegateInstruction(
+        mintKp.publicKey,
+        authority.publicKey, // permanent delegate
+        TOKEN_2022_PROGRAM_ID,
+      ),
+      createInitializeMintInstruction(
+        mintKp.publicKey,
+        6,
+        authority.publicKey,
+        null,
+        TOKEN_2022_PROGRAM_ID,
+      ),
+    ], [authority, mintKp])
+
+    await assertUnsupportedMintExtension(async () => {
+      await sendIx(ctx, [
+        ixCreateFeeToken(mintKp.publicKey, authority.publicKey, TOKEN_2022_PROGRAM_ID),
       ], [authority])
     })
   })

--- a/programs/sipher-vault/tests/sipher-vault/12-native-sol.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/12-native-sol.test.ts
@@ -211,6 +211,8 @@ describe('12 · native SOL vault track', function () {
   const INSUFFICIENT_BALANCE_HEX = INSUFFICIENT_BALANCE_CODE.toString(16) // '1772'
   const RENT_RESERVE_CODE = 6012
   const RENT_RESERVE_HEX = RENT_RESERVE_CODE.toString(16) // '177c'
+  const ENCRYPTED_AMOUNT_TOO_LONG_CODE = 6013
+  const ENCRYPTED_AMOUNT_TOO_LONG_HEX = ENCRYPTED_AMOUNT_TOO_LONG_CODE.toString(16) // '177d'
 
   const FEE_DENOM = 10_000n
 
@@ -388,6 +390,54 @@ describe('12 · native SOL vault track', function () {
         `Expected InsufficientBalance (${INSUFFICIENT_BALANCE_CODE} / 0x${INSUFFICIENT_BALANCE_HEX}), got: ${err?.message ?? String(err)}`,
       )
     }
+  })
+
+  it('withdraw_private_sol → rejects encrypted_amount longer than 64 bytes (EncryptedAmountTooLong 6013 / 0x177d)', async function () {
+    await ensureWithdrawSetup()
+
+    // Fund the record so the guard provably fires BEFORE the debit (balance unchanged).
+    // Unique amount → distinct tx signature (bankrun reuses one blockhash, so a
+    // byte-identical deposit from a prior test would be rejected as a duplicate).
+    await sendIx(ctx, [ixDepositSol(wd.publicKey, 1_111_111n)], [wd])
+    const [recordPda] = getDepositRecordPDA(wd.publicKey, NATIVE_SOL_MINT, VAULT_PROGRAM_ID)
+    const balanceBefore = parseDepositRecord(await getAccountData(ctx, recordPda)).balance
+
+    const [sipConfigPda] = getSipConfigPDA()
+    const { totalTransfers } = parseSipConfig(await getAccountData(ctx, sipConfigPda))
+    const [sipTransferRecordPda] = getSipTransferRecordPDA(wd.publicKey, totalTransfers)
+
+    const stealth = Keypair.generate().publicKey
+    const p = announceParams()
+    const tooLong = randomBytes(65) // 65 > the 64-byte cap
+
+    try {
+      await sendIx(ctx, [
+        ixWithdrawPrivateSol(
+          wd.publicKey, stealth, sipTransferRecordPda, 100_000n,
+          p.amountCommitment, stealth, p.ephemeralPubkey, p.viewingKeyHash,
+          tooLong, p.proof,
+        ),
+      ], [wd])
+      assert.fail('Expected EncryptedAmountTooLong error but transaction succeeded')
+    } catch (e: unknown) {
+      const err = e as Error
+      if (err.message && err.message.includes('Expected EncryptedAmountTooLong error but transaction succeeded')) {
+        throw err
+      }
+      const msg = (err?.message ?? String(err)).toLowerCase()
+      const matchesCode =
+        msg.includes(String(ENCRYPTED_AMOUNT_TOO_LONG_CODE)) ||
+        msg.includes(ENCRYPTED_AMOUNT_TOO_LONG_HEX) ||
+        msg.includes('encryptedamounttoolong')
+      assert.ok(
+        matchesCode,
+        `Expected EncryptedAmountTooLong (${ENCRYPTED_AMOUNT_TOO_LONG_CODE} / 0x${ENCRYPTED_AMOUNT_TOO_LONG_HEX}), got: ${err?.message ?? String(err)}`,
+      )
+    }
+
+    // Fail-fast: the guard rejects before the debit — balance is unchanged.
+    const balanceAfter = parseDepositRecord(await getAccountData(ctx, recordPda)).balance
+    assert.strictEqual(balanceAfter, balanceBefore, 'balance must be unchanged (guard rejects before debit)')
   })
 
   it('withdraw_private_sol → rent guard fires when vault lamports are desynced below backing (RentReserveViolation 6012 / 0x177c)', async function () {

--- a/programs/sipher-vault/tests/sipher-vault/12-native-sol.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/12-native-sol.test.ts
@@ -206,11 +206,11 @@ describe('12 · native SOL vault track', function () {
 
   // Anchor custom errors start at 6000. Enum order in errors.rs:
   //   ProgramPaused=6000, Unauthorized=6001, InsufficientBalance=6002,
-  //   MathOverflow=6003, ZeroDeposit=6004, … , RentReserveViolation=6013.
+  //   MathOverflow=6003, ZeroDeposit=6004, … , RentReserveViolation=6012.
   const INSUFFICIENT_BALANCE_CODE = 6002
   const INSUFFICIENT_BALANCE_HEX = INSUFFICIENT_BALANCE_CODE.toString(16) // '1772'
-  const RENT_RESERVE_CODE = 6013
-  const RENT_RESERVE_HEX = RENT_RESERVE_CODE.toString(16) // '177d'
+  const RENT_RESERVE_CODE = 6012
+  const RENT_RESERVE_HEX = RENT_RESERVE_CODE.toString(16) // '177c'
 
   const FEE_DENOM = 10_000n
 
@@ -390,7 +390,7 @@ describe('12 · native SOL vault track', function () {
     }
   })
 
-  it('withdraw_private_sol → rent guard fires when vault lamports are desynced below backing (RentReserveViolation 6013 / 0x177d)', async function () {
+  it('withdraw_private_sol → rent guard fires when vault lamports are desynced below backing (RentReserveViolation 6012 / 0x177c)', async function () {
     await ensureWithdrawSetup()
 
     // Use a FRESH depositor so `available` is large and unrelated to wd's balance.
@@ -510,7 +510,7 @@ describe('12 · native SOL vault track', function () {
     }
   }
 
-  it('refund_sol → depositor receives unlocked lamports and record.balance equals locked_amount', async function () {
+  it('refund_sol → depositor receives available lamports and record.balance is zeroed', async function () {
     await ensureRefunderSetup()
 
     const depositAmount = 2_000_000n
@@ -521,7 +521,7 @@ describe('12 · native SOL vault track', function () {
     // Confirm the record before the refund.
     const [recordPda] = getDepositRecordPDA(refunder.publicKey, NATIVE_SOL_MINT, VAULT_PROGRAM_ID)
     const recBefore = parseDepositRecord(await getAccountData(ctx, recordPda))
-    const available = recBefore.balance - recBefore.lockedAmount
+    const available = recBefore.balance
     assert.ok(available > 0n, 'no available balance to refund — test state error')
 
     // Snapshot depositor lamports before refund (lamports live on the system account).
@@ -565,15 +565,9 @@ describe('12 · native SOL vault track', function () {
       `sol_vault lamport delta: expected -${available}, got -${solVaultBefore - solVaultAfter}`,
     )
 
-    // ── record.balance == locked_amount (available portion zeroed) ──
+    // ── record.balance == 0 (available portion zeroed) ──
     const recAfter = parseDepositRecord(await getAccountData(ctx, recordPda))
-    assert.strictEqual(
-      recAfter.balance,
-      recAfter.lockedAmount,
-      `record.balance should equal locked_amount after refund_sol`,
-    )
-    // Since locked_amount was 0, balance should also be 0.
-    assert.strictEqual(recAfter.balance, 0n, 'balance should be 0 when locked_amount is 0')
+    assert.strictEqual(recAfter.balance, 0n, 'record.balance should be 0 after refund_sol')
   })
 
   it('refund_sol → rejects before timeout with RefundNotExpired (6005 / 0x1775)', async function () {
@@ -641,7 +635,7 @@ describe('12 · native SOL vault track', function () {
 
     const [recordPda3] = getDepositRecordPDA(authorityRefundDepositor.publicKey, NATIVE_SOL_MINT, VAULT_PROGRAM_ID)
     const rec3 = parseDepositRecord(await getAccountData(ctx, recordPda3))
-    const available3 = rec3.balance - rec3.lockedAmount
+    const available3 = rec3.balance
     assert.ok(available3 > 0n, 'no available balance — test state error')
 
     // Snapshot depositor lamports before the authority refund.
@@ -682,13 +676,9 @@ describe('12 · native SOL vault track', function () {
       `sol_vault lamport delta: expected -${available3}, got -${solVaultBefore - solVaultAfter}`,
     )
 
-    // ── record.balance == locked_amount ──
+    // ── record.balance == 0 ──
     const rec3After = parseDepositRecord(await getAccountData(ctx, recordPda3))
-    assert.strictEqual(
-      rec3After.balance,
-      rec3After.lockedAmount,
-      'record.balance should equal locked_amount after authority_refund_sol',
-    )
+    assert.strictEqual(rec3After.balance, 0n, 'record.balance should be 0 after authority_refund_sol')
   })
 
   it('authority_refund_sol → wrong authority is rejected with Unauthorized (6001 / 0x1771)', async function () {

--- a/programs/sipher-vault/tests/sipher-vault/13-authority-management.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/13-authority-management.test.ts
@@ -21,6 +21,7 @@ import {
   startVault,
   getAccountData,
   parseVaultConfig,
+  assertFails,
   VAULT_PROGRAM_ID,
 } from './bankrun-helpers'
 import { getVaultConfigPDA, MAX_FEE_BPS } from './setup'
@@ -52,23 +53,6 @@ describe('13 · authority management (M1: two-step transfer + update_fee)', () =
     await sendIx(ctx, [
       SystemProgram.transfer({ fromPubkey: authority.publicKey, toPubkey: kp.publicKey, lamports }),
     ], [authority])
-  }
-
-  async function assertFails(fn: () => Promise<void>, needles: string[]): Promise<void> {
-    try {
-      await fn()
-      assert.fail('expected the transaction to fail but it succeeded')
-    } catch (e: unknown) {
-      const err = e as Error
-      if (err.message && err.message.includes('expected the transaction to fail but it succeeded')) {
-        throw err
-      }
-      const msg = (err?.message ?? String(err)).toLowerCase()
-      assert.ok(
-        needles.some((n) => msg.includes(n)),
-        `expected one of [${needles.join(', ')}], got: ${err?.message ?? String(err)}`,
-      )
-    }
   }
 
   // ── update_authority (propose) ────────────────────────────────────────────

--- a/programs/sipher-vault/tests/sipher-vault/13-authority-management.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/13-authority-management.test.ts
@@ -1,0 +1,181 @@
+// tests/sipher-vault/13-authority-management.test.ts
+//
+// M1 — two-step authority transfer (update_authority / accept_authority) +
+// update_fee. These are the config-authority lifecycle instructions the mainnet
+// plan needs in order to hand control to a multisig WITHOUT redeploying a live
+// custody program, and to adjust the fee without a redeploy.
+//
+// IDL-free bankrun harness (raw instructions). Each test gets a fresh vault via
+// beforeEach so authority mutations never leak across tests.
+
+import { assert } from 'chai'
+import { Keypair, SystemProgram } from '@solana/web3.js'
+import { ProgramTestContext } from 'solana-bankrun'
+
+import {
+  ixInitialize,
+  ixUpdateAuthority,
+  ixAcceptAuthority,
+  ixUpdateFee,
+  sendIx,
+  startVault,
+  getAccountData,
+  parseVaultConfig,
+  VAULT_PROGRAM_ID,
+} from './bankrun-helpers'
+import { getVaultConfigPDA, MAX_FEE_BPS } from './setup'
+
+describe('13 · authority management (M1: two-step transfer + update_fee)', () => {
+  let ctx: ProgramTestContext
+  let authority: Keypair
+
+  const FEE_BPS = 10
+  const REFUND_TIMEOUT = 86400n
+
+  // Anchor custom errors start at 6000.
+  //   Unauthorized = 6001 (0x1771), FeeTooHigh = 6007 (0x1777).
+
+  // Fresh vault per test — authority changes in some tests, so isolation matters.
+  beforeEach(async () => {
+    ctx = await startVault()
+    authority = ctx.payer
+    await sendIx(ctx, [ixInitialize(authority.publicKey, FEE_BPS, REFUND_TIMEOUT)], [authority])
+  })
+
+  async function readConfig() {
+    const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+    return parseVaultConfig(await getAccountData(ctx, configPda))
+  }
+
+  // Fund a fresh keypair from the authority so it can pay its own tx fees.
+  async function fund(kp: Keypair, lamports: number): Promise<void> {
+    await sendIx(ctx, [
+      SystemProgram.transfer({ fromPubkey: authority.publicKey, toPubkey: kp.publicKey, lamports }),
+    ], [authority])
+  }
+
+  async function assertFails(fn: () => Promise<void>, needles: string[]): Promise<void> {
+    try {
+      await fn()
+      assert.fail('expected the transaction to fail but it succeeded')
+    } catch (e: unknown) {
+      const err = e as Error
+      if (err.message && err.message.includes('expected the transaction to fail but it succeeded')) {
+        throw err
+      }
+      const msg = (err?.message ?? String(err)).toLowerCase()
+      assert.ok(
+        needles.some((n) => msg.includes(n)),
+        `expected one of [${needles.join(', ')}], got: ${err?.message ?? String(err)}`,
+      )
+    }
+  }
+
+  // ── update_authority (propose) ────────────────────────────────────────────
+
+  it('update_authority → records pending_authority; current authority unchanged', async () => {
+    const newAuth = Keypair.generate()
+    await sendIx(ctx, [ixUpdateAuthority(authority.publicKey, newAuth.publicKey)], [authority])
+
+    const cfg = await readConfig()
+    assert.ok(cfg.pendingAuthority?.equals(newAuth.publicKey), 'pending_authority should be the proposed key')
+    assert.ok(cfg.authority.equals(authority.publicKey), 'authority must NOT change until accept')
+  })
+
+  it('update_authority → a second proposal overwrites the pending authority', async () => {
+    const first = Keypair.generate()
+    const second = Keypair.generate()
+    await sendIx(ctx, [ixUpdateAuthority(authority.publicKey, first.publicKey)], [authority])
+    await sendIx(ctx, [ixUpdateAuthority(authority.publicKey, second.publicKey)], [authority])
+
+    const cfg = await readConfig()
+    assert.ok(cfg.pendingAuthority?.equals(second.publicKey), 'a re-proposal must overwrite pending_authority')
+  })
+
+  it('update_authority → rejects a non-authority proposer (Unauthorized)', async () => {
+    const attacker = Keypair.generate()
+    await fund(attacker, 5_000_000)
+    const newAuth = Keypair.generate()
+    await assertFails(
+      () => sendIx(ctx, [ixUpdateAuthority(attacker.publicKey, newAuth.publicKey)], [attacker]),
+      ['unauthorized', '1771'],
+    )
+  })
+
+  // ── accept_authority (accept) ─────────────────────────────────────────────
+
+  it('accept_authority → promotes the pending authority and clears pending', async () => {
+    const newAuth = Keypair.generate()
+    await fund(newAuth, 5_000_000)
+    await sendIx(ctx, [ixUpdateAuthority(authority.publicKey, newAuth.publicKey)], [authority])
+    await sendIx(ctx, [ixAcceptAuthority(newAuth.publicKey)], [newAuth])
+
+    const cfg = await readConfig()
+    assert.ok(cfg.authority.equals(newAuth.publicKey), 'authority should be the promoted key')
+    assert.strictEqual(cfg.pendingAuthority, null, 'pending_authority must be cleared after accept')
+  })
+
+  it('accept_authority → rejects a key that is not the pending authority', async () => {
+    const newAuth = Keypair.generate()
+    const impostor = Keypair.generate()
+    await fund(impostor, 5_000_000)
+    await sendIx(ctx, [ixUpdateAuthority(authority.publicKey, newAuth.publicKey)], [authority])
+    await assertFails(
+      () => sendIx(ctx, [ixAcceptAuthority(impostor.publicKey)], [impostor]),
+      ['unauthorized', '1771'],
+    )
+  })
+
+  it('accept_authority → rejects when there is no pending transfer', async () => {
+    const someone = Keypair.generate()
+    await fund(someone, 5_000_000)
+    await assertFails(
+      () => sendIx(ctx, [ixAcceptAuthority(someone.publicKey)], [someone]),
+      ['unauthorized', '1771'],
+    )
+  })
+
+  // ── update_fee ────────────────────────────────────────────────────────────
+
+  it('update_fee → authority sets a new fee within the cap', async () => {
+    await sendIx(ctx, [ixUpdateFee(authority.publicKey, 50)], [authority])
+    const cfg = await readConfig()
+    assert.strictEqual(cfg.feeBps, 50, 'fee_bps should be updated')
+  })
+
+  it('update_fee → rejects a non-authority (Unauthorized)', async () => {
+    const attacker = Keypair.generate()
+    await fund(attacker, 5_000_000)
+    await assertFails(
+      () => sendIx(ctx, [ixUpdateFee(attacker.publicKey, 20)], [attacker]),
+      ['unauthorized', '1771'],
+    )
+  })
+
+  it('update_fee → rejects a fee above MAX_FEE_BPS (FeeTooHigh)', async () => {
+    await assertFails(
+      () => sendIx(ctx, [ixUpdateFee(authority.publicKey, MAX_FEE_BPS + 1)], [authority]),
+      ['feetoohigh', '1777'],
+    )
+  })
+
+  // ── end-to-end: control actually moves ──────────────────────────────────────
+
+  it('after handoff → the old authority loses control; the new authority gains it', async () => {
+    const newAuth = Keypair.generate()
+    await fund(newAuth, 5_000_000)
+    await sendIx(ctx, [ixUpdateAuthority(authority.publicKey, newAuth.publicKey)], [authority])
+    await sendIx(ctx, [ixAcceptAuthority(newAuth.publicKey)], [newAuth])
+
+    // Old authority can no longer update the fee.
+    await assertFails(
+      () => sendIx(ctx, [ixUpdateFee(authority.publicKey, 20)], [authority]),
+      ['unauthorized', '1771'],
+    )
+
+    // New authority can.
+    await sendIx(ctx, [ixUpdateFee(newAuth.publicKey, 25)], [newAuth])
+    const cfg = await readConfig()
+    assert.strictEqual(cfg.feeBps, 25, 'the promoted authority should control the fee')
+  })
+})

--- a/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
+++ b/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
@@ -34,6 +34,33 @@ import {
   getSolVaultPDA,
   getSolFeePDA,
 } from './setup'
+import { assert } from 'chai'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Assertion helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Assert that `fn` rejects and the (lowercased) error message contains one of
+ * `needles`. Re-throws if `fn` unexpectedly succeeds. Lives here so the bankrun
+ * suites share one fail-and-match helper instead of re-implementing it per file.
+ */
+export async function assertFails(fn: () => Promise<void>, needles: string[]): Promise<void> {
+  try {
+    await fn()
+    assert.fail('expected the transaction to fail but it succeeded')
+  } catch (e: unknown) {
+    const err = e as Error
+    if (err.message && err.message.includes('expected the transaction to fail but it succeeded')) {
+      throw err
+    }
+    const msg = (err?.message ?? String(err)).toLowerCase()
+    assert.ok(
+      needles.some((n) => msg.includes(n)),
+      `expected one of [${needles.join(', ')}], got: ${err?.message ?? String(err)}`,
+    )
+  }
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Program ID

--- a/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
+++ b/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
@@ -174,9 +174,10 @@ export function parseDepositRecord(d: Buffer): {
  *   fee_bps:           u16     (2)
  *   refund_timeout:    i64     (8)
  *   paused:            bool    (1)
- *   total_deposits:    u64     (8)
- *   total_depositors:  u64     (8)
- *   bump:              u8      (1)
+ *   total_deposits:    u64            (8)
+ *   total_depositors:  u64            (8)
+ *   bump:              u8             (1)
+ *   pending_authority: Option<Pubkey> (1 tag, + 32 if Some) — trailing
  */
 export function parseVaultConfig(d: Buffer): {
   authority: PublicKey
@@ -186,6 +187,7 @@ export function parseVaultConfig(d: Buffer): {
   totalDeposits: bigint
   totalDepositors: bigint
   bump: number
+  pendingAuthority: PublicKey | null
 } {
   let o = 8 // skip 8-byte Anchor discriminator
   const authority = new PublicKey(d.subarray(o, o += 32))
@@ -194,8 +196,14 @@ export function parseVaultConfig(d: Buffer): {
   const paused = d.readUInt8(o) !== 0; o += 1
   const totalDeposits = d.readBigUInt64LE(o); o += 8
   const totalDepositors = d.readBigUInt64LE(o); o += 8
-  const bump = d.readUInt8(o)
-  return { authority, feeBps, refundTimeout, paused, totalDeposits, totalDepositors, bump }
+  const bump = d.readUInt8(o); o += 1
+  // pending_authority: Option<Pubkey>, trailing. 0x00 => None; 0x01 + 32 => Some.
+  // Guarded read so a pre-M1 config layout (no trailing field) parses as null.
+  let pendingAuthority: PublicKey | null = null
+  if (o < d.length && d.readUInt8(o) === 1) {
+    pendingAuthority = new PublicKey(d.subarray(o + 1, o + 33))
+  }
+  return { authority, feeBps, refundTimeout, paused, totalDeposits, totalDepositors, bump, pendingAuthority }
 }
 
 /**
@@ -784,6 +792,74 @@ export function ixCollectFee(
       { pubkey: tokenMint, isSigner: false, isWritable: false },
       { pubkey: authority, isSigner: true, isWritable: true },
       { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+    ],
+    data,
+  })
+}
+
+/**
+ * update_authority(new_authority: Pubkey) — propose a new authority (step 1 of 2).
+ *
+ * Accounts (UpdateAuthority):
+ *   config    mut, PDA  has_one = authority
+ *   authority signer (current authority; fee payer → writable)
+ */
+export function ixUpdateAuthority(
+  authority: PublicKey,
+  newAuthority: PublicKey,
+): TransactionInstruction {
+  const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+  const data = Buffer.concat([disc('update_authority'), newAuthority.toBuffer()])
+
+  return new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: true },
+      { pubkey: authority, isSigner: true, isWritable: true },
+    ],
+    data,
+  })
+}
+
+/**
+ * accept_authority() — accept a pending authority transfer (step 2 of 2).
+ *
+ * Accounts (AcceptAuthority):
+ *   config        mut, PDA
+ *   new_authority signer (the proposed authority; fee payer → writable)
+ */
+export function ixAcceptAuthority(newAuthority: PublicKey): TransactionInstruction {
+  const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+
+  return new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: true },
+      { pubkey: newAuthority, isSigner: true, isWritable: true },
+    ],
+    data: disc('accept_authority'),
+  })
+}
+
+/**
+ * update_fee(new_fee_bps: u16) — authority-only fee update, capped at MAX_FEE_BPS.
+ *
+ * Accounts (UpdateFee):
+ *   config    mut, PDA  has_one = authority
+ *   authority signer (fee payer → writable)
+ */
+export function ixUpdateFee(
+  authority: PublicKey,
+  newFeeBps: number,
+): TransactionInstruction {
+  const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+  const data = Buffer.concat([disc('update_fee'), u16le(newFeeBps)])
+
+  return new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: true },
+      { pubkey: authority, isSigner: true, isWritable: true },
     ],
     data,
   })

--- a/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
+++ b/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
@@ -144,7 +144,6 @@ export async function getAccountData(ctx: ProgramTestContext, pk: PublicKey): Pr
  *   depositor:         Pubkey  (32)
  *   token_mint:        Pubkey  (32)
  *   balance:           u64     (8)
- *   locked_amount:     u64     (8)
  *   cumulative_volume: u64     (8)
  *   last_deposit_at:   i64     (8)
  *   bump:              u8      (1)
@@ -153,7 +152,6 @@ export function parseDepositRecord(d: Buffer): {
   depositor: PublicKey
   tokenMint: PublicKey
   balance: bigint
-  lockedAmount: bigint
   cumulativeVolume: bigint
   lastDepositAt: bigint
   bump: number
@@ -162,11 +160,10 @@ export function parseDepositRecord(d: Buffer): {
   const depositor = new PublicKey(d.subarray(o, o += 32))
   const tokenMint = new PublicKey(d.subarray(o, o += 32))
   const balance = d.readBigUInt64LE(o); o += 8
-  const lockedAmount = d.readBigUInt64LE(o); o += 8
   const cumulativeVolume = d.readBigUInt64LE(o); o += 8
   const lastDepositAt = d.readBigInt64LE(o); o += 8
   const bump = d.readUInt8(o)
-  return { depositor, tokenMint, balance, lockedAmount, cumulativeVolume, lastDepositAt, bump }
+  return { depositor, tokenMint, balance, cumulativeVolume, lastDepositAt, bump }
 }
 
 /**

--- a/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
+++ b/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
@@ -311,6 +311,7 @@ export function ixCreateVaultToken(
 export function ixCreateFeeToken(
   tokenMint: PublicKey,
   payer: PublicKey,
+  tokenProgram: PublicKey = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
   const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
   const [feeTokenPda] = getFeeTokenPDA(tokenMint, VAULT_PROGRAM_ID)
@@ -322,7 +323,7 @@ export function ixCreateFeeToken(
       { pubkey: feeTokenPda, isSigner: false, isWritable: true },
       { pubkey: tokenMint, isSigner: false, isWritable: false },
       { pubkey: payer, isSigner: true, isWritable: true },
-      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: tokenProgram, isSigner: false, isWritable: false },
       { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
     ],
     data: disc('create_fee_token'),


### PR DESCRIPTION
## B6 self-audit hardening

Implements every code-fix remediation from the committed self-audit (`programs/sipher-vault/SELF-AUDIT.md`) for the `sipher_vault` fund-custody program. The audit found **zero Critical / zero High**; this PR lands the Medium/Low/Info hardening + latent-footgun fixes. Bankrun suite **39/39**; build clean (no stack-frame warnings).

`Refs #1136`

### Findings resolved

| ID | Fix | Commit |
|----|-----|--------|
| **M6** | `Box<>` the heavy `WithdrawPrivate` token accounts. This overflow was an **active** runtime failure — an access violation aborting `withdraw_private` (and dependent fee collection) under the v1.52 build — not merely latent | `cc800a7` |
| **M2/M3** | Remove the inert `locked_amount` field + dead `BalanceLocked` error; refund zeroes `balance` directly | `d740287` |
| **L3** | Early `encrypted_amount.len() <= 64` guard (new `EncryptedAmountTooLong`, fail-fast before the debit) in both withdraw paths | `871f3e2` |
| **M1 (+L2)** | Two-step `update_authority` / `accept_authority` + `update_fee` (`pending_authority` field) — lets `config.authority` move to a Squads multisig without a redeploy | `de065b4` |
| **I1/I2/I4** | Dead `SIP_TRANSFER_RECORD_SEED` removed; `token::token_program` bound on the 6 non-init token accounts; `init_if_needed` accumulate-not-reset invariant pinned | `8a047d3` |
| **I3** | Shared `enforce_token2022_allowlist` helper, now applied to `create_fee_token` too (paths can't diverge) | `399fa33` |

Disclosure findings (M4 privacy boundary, M5 native-gasless rent pre-funding, L1 liveness coupling) are documented in the report, not code changes.

### Testing
- **39 bankrun tests** (was 26): +12 for the M1 authority lifecycle (propose / overwrite / accept / wrong-key / no-pending / fee cap / end-to-end handoff), +2 for the L3 guard (token + native), +1 for the I3 fee-token allowlist.
- TDD throughout (failing test → implement → green). M6's failing test pre-existed (the access violation).
- ⚠️ **Build/test requires platform-tools v1.52**: `cd programs/sipher-vault && cargo build-sbf --tools-version v1.52`. The blake3 1.8.5 dependabot bump (#1168) broke `anchor build` on the Anchor-0.30.1-pinned v1.51; a separate revert PR restores it.

### ⚠️ Deploy caveat — BREAKING account-layout change (read before the held devnet redeploy)
M1 (adds `VaultConfig.pending_authority`) and M2 (removes `DepositRecord.locked_amount`) change both struct layouts, and there is **no migration/`realloc` instruction**. This is **not a safe in-place upgrade**: an in-place `upgrade-devnet.ts` over the existing devnet program would brick it — every `config` load reverts `AccountDidNotDeserialize` (including the `refund` self-recovery paths), and old deposit records deserialize shifted (corrupt `bump` → unwithdrawable). Surfaced + verified against live devnet account sizes by the independent post-hardening review. **The held devnet redeploy must use fresh accounts** (new program ID + fresh `initialize`, or close/recreate). Mainnet B7 is a fresh deploy → unaffected. **This is a deploy decision for you.** Detail: `DEPLOYMENT.md` → "Devnet Upgrade".

### Independent review
Reviewed by 3 adversarial subagents (authority security · accounting/layout/error-code ripple · M6/L3/I2/I3 + holistic). Core logic confirmed correct. The review drove three follow-ups included here: monitoring events on authority/fee changes (`3b770d1`), legacy-test stale-ref cleanup (`e0a0d3e`), and the deploy caveat above (`7babb87`). The one "Critical" review flag (the layout/upgrade hazard) is a deploy caveat, not a code bug — documented rather than coded around. `AuthorityRefund` stack-frame concern cleared by the build (zero stack-offset warnings across all functions).

The `SELF-AUDIT.md` remediation table + §9 B7 gate checklist are updated with the resolving commits.

Not self-merged — over to you to review.
