### PR TITLE
chore(sip-privacy): adopt prettier 3

### DIFF
--- a/programs/sip-privacy/migrations/deploy.ts
+++ b/programs/sip-privacy/migrations/deploy.ts
@@ -2,11 +2,11 @@
 // single deploy script that's invoked from the CLI, injecting a provider
 // configured from the workspace's Anchor.toml.
 
-import * as anchor from "@coral-xyz/anchor";
+import * as anchor from '@coral-xyz/anchor'
 
 module.exports = async function (provider: anchor.AnchorProvider) {
   // Configure client to use the provider.
-  anchor.setProvider(provider);
+  anchor.setProvider(provider)
 
   // Add your deploy script here.
-};
+}

--- a/programs/sip-privacy/package.json
+++ b/programs/sip-privacy/package.json
@@ -15,7 +15,7 @@
     "@types/chai": "^4.3.0",
     "@types/mocha": "^9.0.0",
     "typescript": "^5.7.3",
-    "prettier": "^2.6.2"
+    "prettier": "^3.8.4"
   },
   "overrides": {
     "serialize-javascript": "^7.0.5",

--- a/programs/sip-privacy/scripts/initialize-mainnet.ts
+++ b/programs/sip-privacy/scripts/initialize-mainnet.ts
@@ -1,68 +1,75 @@
-import * as anchor from "@coral-xyz/anchor"
-import { Program } from "@coral-xyz/anchor"
-import { PublicKey, Keypair } from "@solana/web3.js"
-import { SipPrivacy } from "../target/types/sip_privacy"
-import * as fs from "fs"
+import * as anchor from '@coral-xyz/anchor'
+import { Program } from '@coral-xyz/anchor'
+import { PublicKey, Keypair } from '@solana/web3.js'
+import { SipPrivacy } from '../target/types/sip_privacy'
+import * as fs from 'fs'
 
 async function main() {
   // Connect to mainnet-beta
-  const connection = new anchor.web3.Connection("https://api.mainnet-beta.solana.com", "confirmed")
+  const connection = new anchor.web3.Connection(
+    'https://api.mainnet-beta.solana.com',
+    'confirmed',
+  )
 
   // Load authority keypair from secrets folder
-  const authorityPath = process.env.AUTHORITY_PATH || "/Users/rz/local-dev/sip-protocol/secrets/authority.json"
+  const authorityPath =
+    process.env.AUTHORITY_PATH ||
+    '/Users/rz/local-dev/sip-protocol/secrets/authority.json'
   const authorityKeypair = Keypair.fromSecretKey(
-    Uint8Array.from(JSON.parse(fs.readFileSync(authorityPath, "utf-8")))
+    Uint8Array.from(JSON.parse(fs.readFileSync(authorityPath, 'utf-8'))),
   )
 
   const wallet = new anchor.Wallet(authorityKeypair)
-  const provider = new anchor.AnchorProvider(connection, wallet, { commitment: "confirmed" })
+  const provider = new anchor.AnchorProvider(connection, wallet, {
+    commitment: 'confirmed',
+  })
   anchor.setProvider(provider)
 
   // Load program
-  const programId = new PublicKey("S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at")
-  const idl = JSON.parse(fs.readFileSync("./target/idl/sip_privacy.json", "utf-8"))
+  const programId = new PublicKey('S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at')
+  const idl = JSON.parse(
+    fs.readFileSync('./target/idl/sip_privacy.json', 'utf-8'),
+  )
   const program = new Program(idl, provider) as Program<SipPrivacy>
 
   // Find config PDA
   const [configPda] = PublicKey.findProgramAddressSync(
-    [Buffer.from("config")],
-    programId
+    [Buffer.from('config')],
+    programId,
   )
 
-  console.log("=== SIP Privacy Mainnet Initialization ===")
-  console.log("Program ID:", programId.toString())
-  console.log("Authority:", authorityKeypair.publicKey.toString())
-  console.log("Config PDA:", configPda.toString())
-  console.log("")
+  console.log('=== SIP Privacy Mainnet Initialization ===')
+  console.log('Program ID:', programId.toString())
+  console.log('Authority:', authorityKeypair.publicKey.toString())
+  console.log('Config PDA:', configPda.toString())
+  console.log('')
 
   // Initialize with 0.5% fee (50 basis points)
   const feeBps = 50
 
   try {
-    const tx = await program.methods
-      .initialize(feeBps)
-      .rpc()
+    const tx = await program.methods.initialize(feeBps).rpc()
 
-    console.log("✓ Initialized! Tx:", tx)
+    console.log('✓ Initialized! Tx:', tx)
     console.log(`  Explorer: https://solscan.io/tx/${tx}`)
-    console.log("")
+    console.log('')
 
     // Fetch and display config
     const config = await program.account.config.fetch(configPda)
-    console.log("Config State:")
-    console.log("  Authority:", config.authority.toString())
-    console.log("  Fee BPS:", config.feeBps)
-    console.log("  Paused:", config.paused)
-    console.log("  Total Transfers:", config.totalTransfers.toString())
+    console.log('Config State:')
+    console.log('  Authority:', config.authority.toString())
+    console.log('  Fee BPS:', config.feeBps)
+    console.log('  Paused:', config.paused)
+    console.log('  Total Transfers:', config.totalTransfers.toString())
   } catch (err: any) {
-    if (err.message?.includes("already in use")) {
-      console.log("Config already initialized, fetching current state...")
+    if (err.message?.includes('already in use')) {
+      console.log('Config already initialized, fetching current state...')
       const config = await program.account.config.fetch(configPda)
-      console.log("Config State:")
-      console.log("  Authority:", config.authority.toString())
-      console.log("  Fee BPS:", config.feeBps)
-      console.log("  Paused:", config.paused)
-      console.log("  Total Transfers:", config.totalTransfers.toString())
+      console.log('Config State:')
+      console.log('  Authority:', config.authority.toString())
+      console.log('  Fee BPS:', config.feeBps)
+      console.log('  Paused:', config.paused)
+      console.log('  Total Transfers:', config.totalTransfers.toString())
     } else {
       throw err
     }

--- a/programs/sip-privacy/scripts/initialize.ts
+++ b/programs/sip-privacy/scripts/initialize.ts
@@ -1,37 +1,44 @@
-import * as anchor from "@coral-xyz/anchor"
-import { Program } from "@coral-xyz/anchor"
-import { PublicKey, SystemProgram, Keypair } from "@solana/web3.js"
-import { SipPrivacy } from "../target/types/sip_privacy"
-import * as fs from "fs"
+import * as anchor from '@coral-xyz/anchor'
+import { Program } from '@coral-xyz/anchor'
+import { PublicKey, SystemProgram, Keypair } from '@solana/web3.js'
+import { SipPrivacy } from '../target/types/sip_privacy'
+import * as fs from 'fs'
 
 async function main() {
   // Connect to devnet
-  const connection = new anchor.web3.Connection("https://api.devnet.solana.com", "confirmed")
+  const connection = new anchor.web3.Connection(
+    'https://api.devnet.solana.com',
+    'confirmed',
+  )
 
   // Load authority keypair
-  const authorityPath = "/tmp/sip-authority.json"
+  const authorityPath = '/tmp/sip-authority.json'
   const authorityKeypair = Keypair.fromSecretKey(
-    Uint8Array.from(JSON.parse(fs.readFileSync(authorityPath, "utf-8")))
+    Uint8Array.from(JSON.parse(fs.readFileSync(authorityPath, 'utf-8'))),
   )
 
   const wallet = new anchor.Wallet(authorityKeypair)
-  const provider = new anchor.AnchorProvider(connection, wallet, { commitment: "confirmed" })
+  const provider = new anchor.AnchorProvider(connection, wallet, {
+    commitment: 'confirmed',
+  })
   anchor.setProvider(provider)
 
   // Load program
-  const programId = new PublicKey("S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at")
-  const idl = JSON.parse(fs.readFileSync("./target/idl/sip_privacy.json", "utf-8"))
+  const programId = new PublicKey('S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at')
+  const idl = JSON.parse(
+    fs.readFileSync('./target/idl/sip_privacy.json', 'utf-8'),
+  )
   const program = new Program(idl, provider) as Program<SipPrivacy>
 
   // Find config PDA
   const [configPda] = PublicKey.findProgramAddressSync(
-    [Buffer.from("config")],
-    programId
+    [Buffer.from('config')],
+    programId,
   )
 
-  console.log("Program ID:", programId.toString())
-  console.log("Authority:", authorityKeypair.publicKey.toString())
-  console.log("Config PDA:", configPda.toString())
+  console.log('Program ID:', programId.toString())
+  console.log('Authority:', authorityKeypair.publicKey.toString())
+  console.log('Config PDA:', configPda.toString())
 
   // Initialize with 0.5% fee (50 basis points)
   const feeBps = 50
@@ -46,24 +53,24 @@ async function main() {
       })
       .rpc()
 
-    console.log("✓ Initialized! Tx:", tx)
+    console.log('✓ Initialized! Tx:', tx)
 
     // Fetch and display config
     const config = await program.account.config.fetch(configPda)
-    console.log("Config:")
-    console.log("  Authority:", config.authority.toString())
-    console.log("  Fee BPS:", config.feeBps)
-    console.log("  Paused:", config.paused)
-    console.log("  Total Transfers:", config.totalTransfers.toString())
+    console.log('Config:')
+    console.log('  Authority:', config.authority.toString())
+    console.log('  Fee BPS:', config.feeBps)
+    console.log('  Paused:', config.paused)
+    console.log('  Total Transfers:', config.totalTransfers.toString())
   } catch (err: any) {
-    if (err.message?.includes("already in use")) {
-      console.log("Config already initialized, fetching current state...")
+    if (err.message?.includes('already in use')) {
+      console.log('Config already initialized, fetching current state...')
       const config = await program.account.config.fetch(configPda)
-      console.log("Config:")
-      console.log("  Authority:", config.authority.toString())
-      console.log("  Fee BPS:", config.feeBps)
-      console.log("  Paused:", config.paused)
-      console.log("  Total Transfers:", config.totalTransfers.toString())
+      console.log('Config:')
+      console.log('  Authority:', config.authority.toString())
+      console.log('  Fee BPS:', config.feeBps)
+      console.log('  Paused:', config.paused)
+      console.log('  Total Transfers:', config.totalTransfers.toString())
     } else {
       throw err
     }

--- a/programs/sip-privacy/tests/sip-privacy.ts
+++ b/programs/sip-privacy/tests/sip-privacy.ts
@@ -1,10 +1,15 @@
-import * as anchor from "@coral-xyz/anchor"
-import { Program, AnchorError } from "@coral-xyz/anchor"
-import { Keypair, PublicKey, SystemProgram, LAMPORTS_PER_SOL } from "@solana/web3.js"
-import { expect } from "chai"
-import { SipPrivacy } from "../target/types/sip_privacy"
+import * as anchor from '@coral-xyz/anchor'
+import { Program, AnchorError } from '@coral-xyz/anchor'
+import {
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js'
+import { expect } from 'chai'
+import { SipPrivacy } from '../target/types/sip_privacy'
 
-describe("sip-privacy", () => {
+describe('sip-privacy', () => {
   const provider = anchor.AnchorProvider.env()
   anchor.setProvider(provider)
 
@@ -86,8 +91,8 @@ describe("sip-privacy", () => {
   before(async () => {
     // Find config PDA
     ;[configPda, configBump] = PublicKey.findProgramAddressSync(
-      [Buffer.from("config")],
-      program.programId
+      [Buffer.from('config')],
+      program.programId,
     )
 
     // Airdrop to test accounts
@@ -95,15 +100,21 @@ describe("sip-privacy", () => {
 
     await provider.connection.requestAirdrop(sender.publicKey, airdropAmount)
     await provider.connection.requestAirdrop(recipient.publicKey, airdropAmount)
-    await provider.connection.requestAirdrop(stealthKeypair.publicKey, airdropAmount)
-    await provider.connection.requestAirdrop(feeCollector.publicKey, airdropAmount)
+    await provider.connection.requestAirdrop(
+      stealthKeypair.publicKey,
+      airdropAmount,
+    )
+    await provider.connection.requestAirdrop(
+      feeCollector.publicKey,
+      airdropAmount,
+    )
 
     // Wait for airdrops to confirm
-    await new Promise(resolve => setTimeout(resolve, 1000))
+    await new Promise((resolve) => setTimeout(resolve, 1000))
   })
 
-  describe("initialize", () => {
-    it("initializes the program config", async () => {
+  describe('initialize', () => {
+    it('initializes the program config', async () => {
       const tx = await program.methods
         .initialize(TEST_FEE_BPS)
         .accounts({
@@ -115,16 +126,18 @@ describe("sip-privacy", () => {
 
       const config = await program.account.config.fetch(configPda)
 
-      expect(config.authority.toString()).to.equal(authority.publicKey.toString())
+      expect(config.authority.toString()).to.equal(
+        authority.publicKey.toString(),
+      )
       expect(config.feeBps).to.equal(TEST_FEE_BPS)
       expect(config.paused).to.equal(false)
       expect(config.totalTransfers.toNumber()).to.equal(0)
       expect(config.bump).to.equal(configBump)
 
-      console.log("Initialize tx:", tx)
+      console.log('Initialize tx:', tx)
     })
 
-    it("fails to reinitialize", async () => {
+    it('fails to reinitialize', async () => {
       try {
         await program.methods
           .initialize(100)
@@ -134,7 +147,7 @@ describe("sip-privacy", () => {
             systemProgram: SystemProgram.programId,
           })
           .rpc()
-        expect.fail("Should have thrown")
+        expect.fail('Should have thrown')
       } catch (err) {
         // Expected - account already initialized
         expect(err).to.be.instanceOf(Error)
@@ -142,8 +155,8 @@ describe("sip-privacy", () => {
     })
   })
 
-  describe("admin actions", () => {
-    it("updates fee", async () => {
+  describe('admin actions', () => {
+    it('updates fee', async () => {
       const newFee = 100 // 1%
 
       await program.methods
@@ -158,7 +171,7 @@ describe("sip-privacy", () => {
       expect(config.feeBps).to.equal(newFee)
     })
 
-    it("fails to set fee above 10%", async () => {
+    it('fails to set fee above 10%', async () => {
       try {
         await program.methods
           .updateFee(1001) // 10.01%
@@ -167,14 +180,14 @@ describe("sip-privacy", () => {
             authority: authority.publicKey,
           })
           .rpc()
-        expect.fail("Should have thrown")
+        expect.fail('Should have thrown')
       } catch (err) {
         expect(err).to.be.instanceOf(AnchorError)
-        expect((err as AnchorError).error.errorCode.code).to.equal("FeeTooHigh")
+        expect((err as AnchorError).error.errorCode.code).to.equal('FeeTooHigh')
       }
     })
 
-    it("pauses and unpauses program", async () => {
+    it('pauses and unpauses program', async () => {
       // Pause
       await program.methods
         .setPaused(true)
@@ -200,7 +213,7 @@ describe("sip-privacy", () => {
       expect(config.paused).to.equal(false)
     })
 
-    it("fails admin action with wrong authority", async () => {
+    it('fails admin action with wrong authority', async () => {
       const wrongAuthority = Keypair.generate()
 
       try {
@@ -212,16 +225,18 @@ describe("sip-privacy", () => {
           })
           .signers([wrongAuthority])
           .rpc()
-        expect.fail("Should have thrown")
+        expect.fail('Should have thrown')
       } catch (err) {
         expect(err).to.be.instanceOf(AnchorError)
-        expect((err as AnchorError).error.errorCode.code).to.equal("Unauthorized")
+        expect((err as AnchorError).error.errorCode.code).to.equal(
+          'Unauthorized',
+        )
       }
     })
   })
 
-  describe("shielded_transfer", () => {
-    it("executes a shielded SOL transfer", async () => {
+  describe('shielded_transfer', () => {
+    it('executes a shielded SOL transfer', async () => {
       // Reset fee for this test
       await program.methods
         .updateFee(0)
@@ -237,11 +252,11 @@ describe("sip-privacy", () => {
       // Find transfer record PDA
       const [transferRecordPda] = PublicKey.findProgramAddressSync(
         [
-          Buffer.from("transfer_record"),
+          Buffer.from('transfer_record'),
           sender.publicKey.toBuffer(),
-          new anchor.BN(transferCount).toArrayLike(Buffer, "le", 8),
+          new anchor.BN(transferCount).toArrayLike(Buffer, 'le', 8),
         ],
-        program.programId
+        program.programId,
       )
 
       const commitment = createMockCommitment()
@@ -251,8 +266,12 @@ describe("sip-privacy", () => {
       const proof = createMockProof()
       const actualAmount = new anchor.BN(0.1 * LAMPORTS_PER_SOL)
 
-      const senderBalanceBefore = await provider.connection.getBalance(sender.publicKey)
-      const stealthBalanceBefore = await provider.connection.getBalance(stealthKeypair.publicKey)
+      const senderBalanceBefore = await provider.connection.getBalance(
+        sender.publicKey,
+      )
+      const stealthBalanceBefore = await provider.connection.getBalance(
+        stealthKeypair.publicKey,
+      )
 
       const tx = await program.methods
         .shieldedTransfer(
@@ -262,7 +281,7 @@ describe("sip-privacy", () => {
           viewingKeyHash,
           encryptedAmount,
           proof,
-          actualAmount
+          actualAmount,
         )
         .accounts({
           config: configPda,
@@ -275,27 +294,40 @@ describe("sip-privacy", () => {
         .signers([sender])
         .rpc()
 
-      console.log("Shielded transfer tx:", tx)
+      console.log('Shielded transfer tx:', tx)
 
       // Verify transfer record
-      const transferRecord = await program.account.transferRecord.fetch(transferRecordPda)
-      expect(transferRecord.sender.toString()).to.equal(sender.publicKey.toString())
-      expect(transferRecord.stealthRecipient.toString()).to.equal(stealthKeypair.publicKey.toString())
+      const transferRecord =
+        await program.account.transferRecord.fetch(transferRecordPda)
+      expect(transferRecord.sender.toString()).to.equal(
+        sender.publicKey.toString(),
+      )
+      expect(transferRecord.stealthRecipient.toString()).to.equal(
+        stealthKeypair.publicKey.toString(),
+      )
       expect(transferRecord.claimed).to.equal(false)
       expect(transferRecord.tokenMint).to.equal(null)
 
       // Verify balances changed
-      const senderBalanceAfter = await provider.connection.getBalance(sender.publicKey)
-      const stealthBalanceAfter = await provider.connection.getBalance(stealthKeypair.publicKey)
+      const senderBalanceAfter = await provider.connection.getBalance(
+        sender.publicKey,
+      )
+      const stealthBalanceAfter = await provider.connection.getBalance(
+        stealthKeypair.publicKey,
+      )
 
-      expect(stealthBalanceAfter - stealthBalanceBefore).to.equal(actualAmount.toNumber())
+      expect(stealthBalanceAfter - stealthBalanceBefore).to.equal(
+        actualAmount.toNumber(),
+      )
 
       // Verify config updated
       const updatedConfig = await program.account.config.fetch(configPda)
-      expect(updatedConfig.totalTransfers.toNumber()).to.equal(transferCount + 1)
+      expect(updatedConfig.totalTransfers.toNumber()).to.equal(
+        transferCount + 1,
+      )
     })
 
-    it("fails when program is paused", async () => {
+    it('fails when program is paused', async () => {
       // Pause program
       await program.methods
         .setPaused(true)
@@ -310,11 +342,11 @@ describe("sip-privacy", () => {
 
       const [transferRecordPda] = PublicKey.findProgramAddressSync(
         [
-          Buffer.from("transfer_record"),
+          Buffer.from('transfer_record'),
           sender.publicKey.toBuffer(),
-          new anchor.BN(transferCount).toArrayLike(Buffer, "le", 8),
+          new anchor.BN(transferCount).toArrayLike(Buffer, 'le', 8),
         ],
-        program.programId
+        program.programId,
       )
 
       try {
@@ -326,7 +358,7 @@ describe("sip-privacy", () => {
             createMockViewingKeyHash(),
             createMockEncryptedAmount(),
             createMockProof(),
-            new anchor.BN(0.1 * LAMPORTS_PER_SOL)
+            new anchor.BN(0.1 * LAMPORTS_PER_SOL),
           )
           .accounts({
             config: configPda,
@@ -338,10 +370,12 @@ describe("sip-privacy", () => {
           })
           .signers([sender])
           .rpc()
-        expect.fail("Should have thrown")
+        expect.fail('Should have thrown')
       } catch (err) {
         expect(err).to.be.instanceOf(AnchorError)
-        expect((err as AnchorError).error.errorCode.code).to.equal("ProgramPaused")
+        expect((err as AnchorError).error.errorCode.code).to.equal(
+          'ProgramPaused',
+        )
       }
 
       // Unpause for subsequent tests
@@ -354,17 +388,17 @@ describe("sip-privacy", () => {
         .rpc()
     })
 
-    it("fails with invalid commitment format", async () => {
+    it('fails with invalid commitment format', async () => {
       const config = await program.account.config.fetch(configPda)
       const transferCount = config.totalTransfers.toNumber()
 
       const [transferRecordPda] = PublicKey.findProgramAddressSync(
         [
-          Buffer.from("transfer_record"),
+          Buffer.from('transfer_record'),
           sender.publicKey.toBuffer(),
-          new anchor.BN(transferCount).toArrayLike(Buffer, "le", 8),
+          new anchor.BN(transferCount).toArrayLike(Buffer, 'le', 8),
         ],
-        program.programId
+        program.programId,
       )
 
       // Create invalid commitment (doesn't start with 0x02 or 0x03)
@@ -380,7 +414,7 @@ describe("sip-privacy", () => {
             createMockViewingKeyHash(),
             createMockEncryptedAmount(),
             createMockProof(),
-            new anchor.BN(0.1 * LAMPORTS_PER_SOL)
+            new anchor.BN(0.1 * LAMPORTS_PER_SOL),
           )
           .accounts({
             config: configPda,
@@ -392,16 +426,18 @@ describe("sip-privacy", () => {
           })
           .signers([sender])
           .rpc()
-        expect.fail("Should have thrown")
+        expect.fail('Should have thrown')
       } catch (err) {
         expect(err).to.be.instanceOf(AnchorError)
-        expect((err as AnchorError).error.errorCode.code).to.equal("InvalidCommitment")
+        expect((err as AnchorError).error.errorCode.code).to.equal(
+          'InvalidCommitment',
+        )
       }
     })
   })
 
-  describe("verify_commitment", () => {
-    it("verifies valid commitment format", async () => {
+  describe('verify_commitment', () => {
+    it('verifies valid commitment format', async () => {
       const commitment = createMockCommitment()
       const value = new anchor.BN(1000)
       const blinding = new Array(32).fill(1)
@@ -413,30 +449,36 @@ describe("sip-privacy", () => {
         })
         .rpc()
 
-      console.log("Verify commitment tx:", tx)
+      console.log('Verify commitment tx:', tx)
     })
 
-    it("fails on invalid commitment prefix", async () => {
+    it('fails on invalid commitment prefix', async () => {
       const invalidCommitment = new Array(33).fill(0)
       invalidCommitment[0] = 0x00 // Invalid
 
       try {
         await program.methods
-          .verifyCommitment(invalidCommitment, new anchor.BN(1000), new Array(32).fill(1))
+          .verifyCommitment(
+            invalidCommitment,
+            new anchor.BN(1000),
+            new Array(32).fill(1),
+          )
           .accounts({
             payer: authority.publicKey,
           })
           .rpc()
-        expect.fail("Should have thrown")
+        expect.fail('Should have thrown')
       } catch (err) {
         expect(err).to.be.instanceOf(AnchorError)
-        expect((err as AnchorError).error.errorCode.code).to.equal("InvalidCommitment")
+        expect((err as AnchorError).error.errorCode.code).to.equal(
+          'InvalidCommitment',
+        )
       }
     })
   })
 
-  describe("verify_zk_proof", () => {
-    it("verifies valid funding proof format", async () => {
+  describe('verify_zk_proof', () => {
+    it('verifies valid funding proof format', async () => {
       // Build proof data following the expected format:
       // [proof_type(1)] [num_inputs(4)] [inputs(n*32)] [proof_len(4)] [proof]
       const proofData = Buffer.alloc(1 + 4 + 3 * 32 + 4 + 100)
@@ -473,10 +515,10 @@ describe("sip-privacy", () => {
         })
         .rpc()
 
-      console.log("Verify ZK proof tx:", tx)
+      console.log('Verify ZK proof tx:', tx)
     })
 
-    it("fails on unsupported proof type", async () => {
+    it('fails on unsupported proof type', async () => {
       const proofData = Buffer.alloc(10)
       proofData.writeUInt8(99, 0) // Invalid proof type
 
@@ -487,14 +529,16 @@ describe("sip-privacy", () => {
             payer: authority.publicKey,
           })
           .rpc()
-        expect.fail("Should have thrown")
+        expect.fail('Should have thrown')
       } catch (err) {
         expect(err).to.be.instanceOf(AnchorError)
-        expect((err as AnchorError).error.errorCode.code).to.equal("UnsupportedProofType")
+        expect((err as AnchorError).error.errorCode.code).to.equal(
+          'UnsupportedProofType',
+        )
       }
     })
 
-    it("fails on missing public inputs", async () => {
+    it('fails on missing public inputs', async () => {
       const proofData = Buffer.alloc(1 + 4 + 1 * 32 + 4 + 100)
       let offset = 0
 
@@ -520,15 +564,17 @@ describe("sip-privacy", () => {
             payer: authority.publicKey,
           })
           .rpc()
-        expect.fail("Should have thrown")
+        expect.fail('Should have thrown')
       } catch (err) {
         expect(err).to.be.instanceOf(AnchorError)
-        expect((err as AnchorError).error.errorCode.code).to.equal("InvalidPublicInputs")
+        expect((err as AnchorError).error.errorCode.code).to.equal(
+          'InvalidPublicInputs',
+        )
       }
     })
   })
 
-  describe("claim_transfer", () => {
+  describe('claim_transfer', () => {
     let transferRecordPda: PublicKey
 
     before(async () => {
@@ -538,17 +584,20 @@ describe("sip-privacy", () => {
 
       ;[transferRecordPda] = PublicKey.findProgramAddressSync(
         [
-          Buffer.from("transfer_record"),
+          Buffer.from('transfer_record'),
           sender.publicKey.toBuffer(),
-          new anchor.BN(transferCount).toArrayLike(Buffer, "le", 8),
+          new anchor.BN(transferCount).toArrayLike(Buffer, 'le', 8),
         ],
-        program.programId
+        program.programId,
       )
 
       // Create new stealth keypair for this test
       const claimStealthKeypair = Keypair.generate()
-      await provider.connection.requestAirdrop(claimStealthKeypair.publicKey, LAMPORTS_PER_SOL)
-      await new Promise(resolve => setTimeout(resolve, 500))
+      await provider.connection.requestAirdrop(
+        claimStealthKeypair.publicKey,
+        LAMPORTS_PER_SOL,
+      )
+      await new Promise((resolve) => setTimeout(resolve, 500))
 
       await program.methods
         .shieldedTransfer(
@@ -558,7 +607,7 @@ describe("sip-privacy", () => {
           createMockViewingKeyHash(),
           createMockEncryptedAmount(),
           createMockProof(),
-          new anchor.BN(0.05 * LAMPORTS_PER_SOL)
+          new anchor.BN(0.05 * LAMPORTS_PER_SOL),
         )
         .accounts({
           config: configPda,
@@ -572,7 +621,7 @@ describe("sip-privacy", () => {
         .rpc()
     })
 
-    it("fails double-claim (nullifier reuse)", async () => {
+    it('fails double-claim (nullifier reuse)', async () => {
       // This test would need a full claim first, then attempt second claim
       // For now we just verify the AlreadyClaimed error exists
 
@@ -586,8 +635,8 @@ describe("sip-privacy", () => {
         if (transfer.account.claimed) {
           const nullifier = createMockNullifier()
           const [nullifierPda] = PublicKey.findProgramAddressSync(
-            [Buffer.from("nullifier"), Buffer.from(nullifier)],
-            program.programId
+            [Buffer.from('nullifier'), Buffer.from(nullifier)],
+            program.programId,
           )
 
           try {
@@ -603,33 +652,38 @@ describe("sip-privacy", () => {
               })
               .signers([recipient])
               .rpc()
-            expect.fail("Should have thrown")
+            expect.fail('Should have thrown')
           } catch (err) {
             expect(err).to.be.instanceOf(AnchorError)
-            expect((err as AnchorError).error.errorCode.code).to.equal("AlreadyClaimed")
+            expect((err as AnchorError).error.errorCode.code).to.equal(
+              'AlreadyClaimed',
+            )
           }
         }
       }
     })
   })
 
-  describe("events", () => {
-    it("emits ShieldedTransferEvent on transfer", async () => {
+  describe('events', () => {
+    it('emits ShieldedTransferEvent on transfer', async () => {
       const config = await program.account.config.fetch(configPda)
       const transferCount = config.totalTransfers.toNumber()
 
       const [transferRecordPda] = PublicKey.findProgramAddressSync(
         [
-          Buffer.from("transfer_record"),
+          Buffer.from('transfer_record'),
           sender.publicKey.toBuffer(),
-          new anchor.BN(transferCount).toArrayLike(Buffer, "le", 8),
+          new anchor.BN(transferCount).toArrayLike(Buffer, 'le', 8),
         ],
-        program.programId
+        program.programId,
       )
 
       const newStealthKeypair = Keypair.generate()
-      await provider.connection.requestAirdrop(newStealthKeypair.publicKey, LAMPORTS_PER_SOL)
-      await new Promise(resolve => setTimeout(resolve, 500))
+      await provider.connection.requestAirdrop(
+        newStealthKeypair.publicKey,
+        LAMPORTS_PER_SOL,
+      )
+      await new Promise((resolve) => setTimeout(resolve, 500))
 
       const commitment = createMockCommitment()
       const ephemeralPubkey = createMockEphemeralPubkey()
@@ -637,13 +691,19 @@ describe("sip-privacy", () => {
 
       // Subscribe to events
       const eventPromise = new Promise<any>((resolve, reject) => {
-        const timeout = setTimeout(() => reject(new Error("Event timeout")), 30000)
+        const timeout = setTimeout(
+          () => reject(new Error('Event timeout')),
+          30000,
+        )
 
-        const listener = program.addEventListener("ShieldedTransferEvent", (event) => {
-          clearTimeout(timeout)
-          program.removeEventListener(listener)
-          resolve(event)
-        })
+        const listener = program.addEventListener(
+          'ShieldedTransferEvent',
+          (event) => {
+            clearTimeout(timeout)
+            program.removeEventListener(listener)
+            resolve(event)
+          },
+        )
       })
 
       await program.methods
@@ -654,7 +714,7 @@ describe("sip-privacy", () => {
           viewingKeyHash,
           createMockEncryptedAmount(),
           createMockProof(),
-          new anchor.BN(0.01 * LAMPORTS_PER_SOL)
+          new anchor.BN(0.01 * LAMPORTS_PER_SOL),
         )
         .accounts({
           config: configPda,
@@ -670,32 +730,37 @@ describe("sip-privacy", () => {
       try {
         const event = await eventPromise
         expect(event.sender.toString()).to.equal(sender.publicKey.toString())
-        expect(event.stealthRecipient.toString()).to.equal(newStealthKeypair.publicKey.toString())
-        console.log("Received ShieldedTransferEvent:", event)
+        expect(event.stealthRecipient.toString()).to.equal(
+          newStealthKeypair.publicKey.toString(),
+        )
+        console.log('Received ShieldedTransferEvent:', event)
       } catch (e) {
         // Event listener may not work in test environment, that's ok
-        console.log("Event listener timeout (expected in test environment)")
+        console.log('Event listener timeout (expected in test environment)')
       }
     })
   })
 
-  describe("edge cases", () => {
-    it("handles maximum encrypted amount size", async () => {
+  describe('edge cases', () => {
+    it('handles maximum encrypted amount size', async () => {
       const config = await program.account.config.fetch(configPda)
       const transferCount = config.totalTransfers.toNumber()
 
       const [transferRecordPda] = PublicKey.findProgramAddressSync(
         [
-          Buffer.from("transfer_record"),
+          Buffer.from('transfer_record'),
           sender.publicKey.toBuffer(),
-          new anchor.BN(transferCount).toArrayLike(Buffer, "le", 8),
+          new anchor.BN(transferCount).toArrayLike(Buffer, 'le', 8),
         ],
-        program.programId
+        program.programId,
       )
 
       const newStealthKeypair = Keypair.generate()
-      await provider.connection.requestAirdrop(newStealthKeypair.publicKey, LAMPORTS_PER_SOL)
-      await new Promise(resolve => setTimeout(resolve, 500))
+      await provider.connection.requestAirdrop(
+        newStealthKeypair.publicKey,
+        LAMPORTS_PER_SOL,
+      )
+      await new Promise((resolve) => setTimeout(resolve, 500))
 
       // Max allowed is 64 bytes
       const maxEncryptedAmount = Buffer.alloc(64)
@@ -708,7 +773,7 @@ describe("sip-privacy", () => {
           createMockViewingKeyHash(),
           maxEncryptedAmount,
           createMockProof(),
-          new anchor.BN(0.01 * LAMPORTS_PER_SOL)
+          new anchor.BN(0.01 * LAMPORTS_PER_SOL),
         )
         .accounts({
           config: configPda,
@@ -721,25 +786,28 @@ describe("sip-privacy", () => {
         .signers([sender])
         .rpc()
 
-      console.log("Successfully transferred with max encrypted amount size")
+      console.log('Successfully transferred with max encrypted amount size')
     })
 
-    it("fails with oversized encrypted amount", async () => {
+    it('fails with oversized encrypted amount', async () => {
       const config = await program.account.config.fetch(configPda)
       const transferCount = config.totalTransfers.toNumber()
 
       const [transferRecordPda] = PublicKey.findProgramAddressSync(
         [
-          Buffer.from("transfer_record"),
+          Buffer.from('transfer_record'),
           sender.publicKey.toBuffer(),
-          new anchor.BN(transferCount).toArrayLike(Buffer, "le", 8),
+          new anchor.BN(transferCount).toArrayLike(Buffer, 'le', 8),
         ],
-        program.programId
+        program.programId,
       )
 
       const newStealthKeypair = Keypair.generate()
-      await provider.connection.requestAirdrop(newStealthKeypair.publicKey, LAMPORTS_PER_SOL)
-      await new Promise(resolve => setTimeout(resolve, 500))
+      await provider.connection.requestAirdrop(
+        newStealthKeypair.publicKey,
+        LAMPORTS_PER_SOL,
+      )
+      await new Promise((resolve) => setTimeout(resolve, 500))
 
       // Over the 64 byte limit
       const oversizedEncryptedAmount = Buffer.alloc(65)
@@ -753,7 +821,7 @@ describe("sip-privacy", () => {
             createMockViewingKeyHash(),
             oversizedEncryptedAmount,
             createMockProof(),
-            new anchor.BN(0.01 * LAMPORTS_PER_SOL)
+            new anchor.BN(0.01 * LAMPORTS_PER_SOL),
           )
           .accounts({
             config: configPda,
@@ -765,14 +833,16 @@ describe("sip-privacy", () => {
           })
           .signers([sender])
           .rpc()
-        expect.fail("Should have thrown")
+        expect.fail('Should have thrown')
       } catch (err) {
         expect(err).to.be.instanceOf(AnchorError)
-        expect((err as AnchorError).error.errorCode.code).to.equal("EncryptedAmountTooLarge")
+        expect((err as AnchorError).error.errorCode.code).to.equal(
+          'EncryptedAmountTooLarge',
+        )
       }
     })
 
-    it("calculates fee correctly", async () => {
+    it('calculates fee correctly', async () => {
       // Set fee to 1%
       await program.methods
         .updateFee(100)
@@ -787,23 +857,30 @@ describe("sip-privacy", () => {
 
       const [transferRecordPda] = PublicKey.findProgramAddressSync(
         [
-          Buffer.from("transfer_record"),
+          Buffer.from('transfer_record'),
           sender.publicKey.toBuffer(),
-          new anchor.BN(transferCount).toArrayLike(Buffer, "le", 8),
+          new anchor.BN(transferCount).toArrayLike(Buffer, 'le', 8),
         ],
-        program.programId
+        program.programId,
       )
 
       const newStealthKeypair = Keypair.generate()
-      await provider.connection.requestAirdrop(newStealthKeypair.publicKey, LAMPORTS_PER_SOL)
-      await new Promise(resolve => setTimeout(resolve, 500))
+      await provider.connection.requestAirdrop(
+        newStealthKeypair.publicKey,
+        LAMPORTS_PER_SOL,
+      )
+      await new Promise((resolve) => setTimeout(resolve, 500))
 
       const actualAmount = new anchor.BN(LAMPORTS_PER_SOL) // 1 SOL
-      const expectedFee = actualAmount.toNumber() * 100 / 10000 // 1%
+      const expectedFee = (actualAmount.toNumber() * 100) / 10000 // 1%
       const expectedTransfer = actualAmount.toNumber() - expectedFee
 
-      const stealthBalanceBefore = await provider.connection.getBalance(newStealthKeypair.publicKey)
-      const feeBalanceBefore = await provider.connection.getBalance(feeCollector.publicKey)
+      const stealthBalanceBefore = await provider.connection.getBalance(
+        newStealthKeypair.publicKey,
+      )
+      const feeBalanceBefore = await provider.connection.getBalance(
+        feeCollector.publicKey,
+      )
 
       await program.methods
         .shieldedTransfer(
@@ -813,7 +890,7 @@ describe("sip-privacy", () => {
           createMockViewingKeyHash(),
           createMockEncryptedAmount(),
           createMockProof(),
-          actualAmount
+          actualAmount,
         )
         .accounts({
           config: configPda,
@@ -826,8 +903,12 @@ describe("sip-privacy", () => {
         .signers([sender])
         .rpc()
 
-      const stealthBalanceAfter = await provider.connection.getBalance(newStealthKeypair.publicKey)
-      const feeBalanceAfter = await provider.connection.getBalance(feeCollector.publicKey)
+      const stealthBalanceAfter = await provider.connection.getBalance(
+        newStealthKeypair.publicKey,
+      )
+      const feeBalanceAfter = await provider.connection.getBalance(
+        feeCollector.publicKey,
+      )
 
       const stealthDelta = stealthBalanceAfter - stealthBalanceBefore
       const feeDelta = feeBalanceAfter - feeBalanceBefore
@@ -835,7 +916,9 @@ describe("sip-privacy", () => {
       expect(stealthDelta).to.equal(expectedTransfer)
       expect(feeDelta).to.equal(expectedFee)
 
-      console.log(`Fee calculation: ${actualAmount.toNumber()} SOL - ${expectedFee} fee = ${expectedTransfer} transferred`)
+      console.log(
+        `Fee calculation: ${actualAmount.toNumber()} SOL - ${expectedFee} fee = ${expectedTransfer} transferred`,
+      )
     })
   })
 })


### PR DESCRIPTION
Adopts prettier 3 in `programs/sip-privacy` (verify-then-adopt of Dependabot #1198).

## Change
- `prettier` `^2.6.2` → `^3.8.4`
- Reformat the 4 files prettier 3's defaults touch (`migrations/deploy.ts`, `scripts/initialize.ts`, `scripts/initialize-mainnet.ts`, `tests/sip-privacy.ts`) so the `lint` script (`prettier --check`) stays green. Formatting-only; no logic changes.

## Verification
`prettier --check` (the package's `lint` script): **All matched files use Prettier code style!**

Refs #1198