### PR TITLE
ci: adopt actions/checkout v7 across workflows

### DIFF
--- a/.github/workflows/changelog-sync.yml
+++ b/.github/workflows/changelog-sync.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sip-protocol
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checkout docs-sip
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: sip-protocol/docs-sip
           token: ${{ secrets.DOCS_SYNC_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -68,7 +68,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -12,7 +12,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -11,7 +11,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/mirror-gitlab.yml
+++ b/.github/workflows/mirror-gitlab.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6


### PR DESCRIPTION
Adopts `actions/checkout@v7` across all workflows (verify-then-adopt of Dependabot #1194).

## Change
- `actions/checkout@v6` → `@v7` — 11 occurrences across 8 workflow files.

## Why a fresh branch (not #1194)
#1194's CI failed on the stale `pnpm-lock.yaml` duplicate-key error (fixed on main via #1195), **not** on checkout v7 — its run loaded `actions/checkout@v7` successfully before the install step. Maintainer force-pushes to the `dependabot/*` branch weren't re-triggering `ci.yml`, so this branch gets a clean run.

Refs #1194