### PR TITLE
feat(sipher-vault): migrate_config instruction (B6 devnet redeploy)

### DIFF
--- a/docs/superpowers/plans/2026-06-21-sipher-vault-migrate-config-redeploy.md
+++ b/docs/superpowers/plans/2026-06-21-sipher-vault-migrate-config-redeploy.md
@@ -1,0 +1,634 @@
+# Sipher Vault `migrate_config` + B6 Devnet Redeploy — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the B6-hardened sipher-vault binary live on devnet by reusing program ID `S1Phr5…`, adding an authority-gated `migrate_config` instruction that grows the live `VaultConfig` to the new layout in place, then keeping the downstream `sipher` repo's IDL + error numbers in lockstep.
+
+**Architecture:** `migrate_config` takes the config as a raw `UncheckedAccount` (the legacy 68-byte account can't be deserialized into `VaultConfig`), verifies the PDA via `seeds`+`bump`, gates on the authority read from bytes `[8..40]`, tops up the rent delta, then `realloc`s 68→101 with zero-init — and since Borsh encodes `None` as a single `0x00` byte, the zero-fill at offset 68 *is* `pending_authority = None`. Then an in-place `BPFLoaderUpgradeable` upgrade + `migrate_config` + `create_sol_vault` on devnet, and an IDL + error-renumber PR in `sipher`.
+
+**Tech Stack:** Rust + Anchor 1.0.2, solana-bankrun (IDL-free raw-ix tests), `@solana/web3.js` + `tsx` scripts, Solana CLI 3.0.13 (Agave).
+
+## Global Constraints
+
+- Rust + TS: **2-space indent**; TS **no semicolons**.
+- Build the SBF binary with **`cargo build-sbf --tools-version v1.52`** (Agave 3.0.13 defaults to v1.51, below Anchor 1.0.2's MSRV).
+- Program ID **stays `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB`**; config PDA **stays `CpL4qy…`**. No new IDs.
+- Commits **GPG-signed** (key `BF47B9DC1FA320FA`, auto via `commit.gpgsign=true`); **no AI attribution** in commits/PRs/docs.
+- **Do not self-merge** substantive PRs — RECTOR approves the merge.
+- New error variants are **append-only** (never reorder — it renumbers codes).
+- Branch: `feat/sipher-vault-migrate-config` (already created; the spec is committed there).
+- **Deploy gate (Task 2):** the on-chain steps touch shared devnet + the devnet wallet. Confirm with RECTOR at execution time whether CIPHER runs them or hands off a runbook. Nothing is irreversible (program ID reused, not closed).
+
+---
+
+## Task 1: `migrate_config` instruction (TDD)
+
+**Files:**
+- Modify: `programs/sipher-vault/programs/sipher-vault/src/constants.rs` (add `LEGACY_VAULT_CONFIG_LEN`)
+- Modify: `programs/sipher-vault/programs/sipher-vault/src/errors.rs` (append `InvalidConfigAccount`)
+- Modify: `programs/sipher-vault/programs/sipher-vault/src/lib.rs` (handler + `MigrateConfig` accounts + `VaultConfigMigratedEvent`)
+- Modify: `programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts` (add `ixMigrateConfig`)
+- Modify: `programs/sipher-vault/package.json` (add `14` to the test glob)
+- Create: `programs/sipher-vault/tests/sipher-vault/14-migrate-config.test.ts`
+
+**Interfaces:**
+- Consumes: `VaultConfig` (`state.rs`), `VAULT_CONFIG_SEED` + `LEGACY_VAULT_CONFIG_LEN` (`constants.rs`), `VaultError` (`errors.rs`), existing bankrun helpers (`disc`, `sendIx`, `startVault`, `getAccountData`, `parseVaultConfig`, `assertFails`, `ixInitialize`, `ixUpdateFee`, `VAULT_PROGRAM_ID`, `getVaultConfigPDA`).
+- Produces: instruction `migrate_config` (no args; accounts `config` UncheckedAccount mut PDA, `authority` Signer mut, `system_program`); discriminator `sha256("global:migrate_config")[..8]`; error `InvalidConfigAccount` = **6014** (`0x177E`); event `VaultConfigMigratedEvent { authority, new_len, timestamp }`; helper `ixMigrateConfig(authority: PublicKey)`.
+
+---
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `programs/sipher-vault/tests/sipher-vault/14-migrate-config.test.ts`:
+
+```typescript
+// tests/sipher-vault/14-migrate-config.test.ts
+//
+// migrate_config — grows a legacy (pre-M1, 68-byte) VaultConfig to the current
+// 101-byte layout by appending pending_authority = None. Authority-gated,
+// idempotent. IDL-free bankrun harness (raw instructions).
+
+import { assert } from 'chai'
+import { Keypair, PublicKey, SystemProgram } from '@solana/web3.js'
+import { ProgramTestContext } from 'solana-bankrun'
+
+import {
+  ixInitialize,
+  ixMigrateConfig,
+  ixUpdateFee,
+  sendIx,
+  startVault,
+  getAccountData,
+  parseVaultConfig,
+  assertFails,
+  VAULT_PROGRAM_ID,
+} from './bankrun-helpers'
+import { getVaultConfigPDA } from './setup'
+
+const LEGACY_LEN = 68
+const NEW_LEN = 101
+
+describe('14 · migrate_config (B6 VaultConfig layout migration)', () => {
+  let ctx: ProgramTestContext
+  let authority: Keypair
+  let configPda: PublicKey
+  let bump: number
+  // Real VaultConfig account discriminator, derived empirically from a live
+  // initialize so synthetic legacy accounts carry the exact discriminator the
+  // typed handlers (e.g. update_fee) check.
+  let configDisc: Buffer
+
+  before(async () => {
+    const tmp = await startVault()
+    const [pda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+    await sendIx(tmp, [ixInitialize(tmp.payer.publicKey, 10, 86400n)], [tmp.payer])
+    configDisc = Buffer.from((await getAccountData(tmp, pda)).subarray(0, 8))
+  })
+
+  beforeEach(async () => {
+    ctx = await startVault()
+    authority = ctx.payer
+    ;[configPda, bump] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+  })
+
+  async function plantLegacy(opts: {
+    authority: PublicKey
+    feeBps: number
+    refundTimeout: bigint
+    paused: boolean
+    totalDeposits: bigint
+    totalDepositors: bigint
+  }): Promise<void> {
+    const d = Buffer.alloc(LEGACY_LEN)
+    configDisc.copy(d, 0)
+    opts.authority.toBuffer().copy(d, 8)
+    d.writeUInt16LE(opts.feeBps, 40)
+    d.writeBigInt64LE(opts.refundTimeout, 42)
+    d.writeUInt8(opts.paused ? 1 : 0, 50)
+    d.writeBigUInt64LE(opts.totalDeposits, 51)
+    d.writeBigUInt64LE(opts.totalDepositors, 59)
+    d.writeUInt8(bump, 67)
+    const rent = await ctx.banksClient.getRent()
+    ctx.setAccount(configPda, {
+      lamports: Number(rent.minimumBalance(BigInt(LEGACY_LEN))),
+      data: d,
+      owner: VAULT_PROGRAM_ID,
+      executable: false,
+      rentEpoch: 0,
+    })
+  }
+
+  async function plantNew(pendingAuthority: PublicKey | null): Promise<void> {
+    const d = Buffer.alloc(NEW_LEN)
+    configDisc.copy(d, 0)
+    authority.publicKey.toBuffer().copy(d, 8)
+    d.writeUInt16LE(10, 40)
+    d.writeBigInt64LE(86400n, 42)
+    d.writeUInt8(0, 50)
+    d.writeBigUInt64LE(0n, 51)
+    d.writeBigUInt64LE(0n, 59)
+    d.writeUInt8(bump, 67)
+    if (pendingAuthority) {
+      d.writeUInt8(1, 68)
+      pendingAuthority.toBuffer().copy(d, 69)
+    }
+    const rent = await ctx.banksClient.getRent()
+    ctx.setAccount(configPda, {
+      lamports: Number(rent.minimumBalance(BigInt(NEW_LEN))),
+      data: d,
+      owner: VAULT_PROGRAM_ID,
+      executable: false,
+      rentEpoch: 0,
+    })
+  }
+
+  it('migrates a legacy 68-byte config → 101 bytes, fields preserved, pending=None', async () => {
+    await plantLegacy({ authority: authority.publicKey, feeBps: 10, refundTimeout: 86400n, paused: false, totalDeposits: 5n, totalDepositors: 3n })
+    await sendIx(ctx, [ixMigrateConfig(authority.publicKey)], [authority])
+
+    const data = await getAccountData(ctx, configPda)
+    assert.strictEqual(data.length, NEW_LEN, 'account grew to new layout length')
+    const cfg = parseVaultConfig(data)
+    assert.ok(cfg.authority.equals(authority.publicKey))
+    assert.strictEqual(cfg.feeBps, 10)
+    assert.strictEqual(cfg.refundTimeout, 86400n)
+    assert.strictEqual(cfg.paused, false)
+    assert.strictEqual(cfg.totalDeposits, 5n)
+    assert.strictEqual(cfg.totalDepositors, 3n)
+    assert.strictEqual(cfg.bump, bump)
+    assert.strictEqual(cfg.pendingAuthority, null, 'pending_authority appended as None')
+    const rent = await ctx.banksClient.getRent()
+    const acct = await ctx.banksClient.getAccount(configPda)
+    assert.ok(BigInt(acct!.lamports) >= rent.minimumBalance(BigInt(NEW_LEN)), 'rent-exempt at new size')
+  })
+
+  it('is idempotent: re-running on an already-migrated config is a no-op', async () => {
+    await plantLegacy({ authority: authority.publicKey, feeBps: 10, refundTimeout: 86400n, paused: false, totalDeposits: 1n, totalDepositors: 1n })
+    await sendIx(ctx, [ixMigrateConfig(authority.publicKey)], [authority])
+    await sendIx(ctx, [ixMigrateConfig(authority.publicKey)], [authority])
+    const cfg = parseVaultConfig(await getAccountData(ctx, configPda))
+    assert.strictEqual(cfg.pendingAuthority, null)
+    assert.strictEqual(cfg.totalDeposits, 1n)
+  })
+
+  it('never clobbers a live pending_authority on an already-migrated config', async () => {
+    const pending = Keypair.generate().publicKey
+    await plantNew(pending)
+    await sendIx(ctx, [ixMigrateConfig(authority.publicKey)], [authority])
+    const cfg = parseVaultConfig(await getAccountData(ctx, configPda))
+    assert.ok(cfg.pendingAuthority?.equals(pending), 'pending_authority preserved (no-op path)')
+  })
+
+  it('rejects a non-authority signer (Unauthorized 6001/0x1771)', async () => {
+    await plantLegacy({ authority: authority.publicKey, feeBps: 10, refundTimeout: 86400n, paused: false, totalDeposits: 0n, totalDepositors: 0n })
+    const attacker = Keypair.generate()
+    await sendIx(ctx, [SystemProgram.transfer({ fromPubkey: authority.publicKey, toPubkey: attacker.publicKey, lamports: 5_000_000 })], [authority])
+    await assertFails(
+      () => sendIx(ctx, [ixMigrateConfig(attacker.publicKey)], [attacker]),
+      ['unauthorized', '1771'],
+    )
+  })
+
+  it('rejects a malformed (wrong-size) config account (InvalidConfigAccount 6014/0x177e)', async () => {
+    const d = Buffer.alloc(40)
+    configDisc.copy(d, 0)
+    authority.publicKey.toBuffer().copy(d, 8)
+    const rent = await ctx.banksClient.getRent()
+    ctx.setAccount(configPda, { lamports: Number(rent.minimumBalance(40n)), data: d, owner: VAULT_PROGRAM_ID, executable: false, rentEpoch: 0 })
+    await assertFails(
+      () => sendIx(ctx, [ixMigrateConfig(authority.publicKey)], [authority]),
+      ['invalidconfigaccount', '177e'],
+    )
+  })
+
+  it('migrated config is fully usable: update_fee succeeds afterward', async () => {
+    await plantLegacy({ authority: authority.publicKey, feeBps: 10, refundTimeout: 86400n, paused: false, totalDeposits: 0n, totalDepositors: 0n })
+    await sendIx(ctx, [ixMigrateConfig(authority.publicKey)], [authority])
+    await sendIx(ctx, [ixUpdateFee(authority.publicKey, 25)], [authority])
+    const cfg = parseVaultConfig(await getAccountData(ctx, configPda))
+    assert.strictEqual(cfg.feeBps, 25, 'typed handlers accept the migrated account')
+  })
+})
+```
+
+- [ ] **Step 2: Add the `ixMigrateConfig` helper**
+
+In `programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts`, after `ixUpdateFee` (~line 884), add:
+
+```typescript
+/**
+ * migrate_config() — no args
+ *
+ * Accounts (MigrateConfig):
+ *   config         mut, PDA (UncheckedAccount — legacy layout)
+ *   authority      mut, signer
+ *   system_program
+ */
+export function ixMigrateConfig(authority: PublicKey): TransactionInstruction {
+  const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+  return new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: true },
+      { pubkey: authority, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data: disc('migrate_config'),
+  })
+}
+```
+
+(`getVaultConfigPDA` is already imported from `./setup` in this file; `SystemProgram`, `TransactionInstruction`, `PublicKey` are already imported.)
+
+- [ ] **Step 3: Add `14` to the bankrun test glob**
+
+In `programs/sipher-vault/package.json`, change the `test` script glob from `{10,11,12,13}` to `{10,11,12,13,14}`:
+
+```json
+    "test": "ts-mocha -p ./tsconfig.json -t 1000000 \"tests/sipher-vault/{10,11,12,13,14}-*.ts\""
+```
+
+- [ ] **Step 4: Build the fixture + program, run the new test — verify it FAILS**
+
+```bash
+cd programs/sipher-vault
+# sip_privacy.so fixture (present already, rebuild to be safe):
+( cd ../sip-privacy && cargo build-sbf --tools-version v1.52 && cp target/deploy/sip_privacy.so ../sipher-vault/tests/fixtures/sip_privacy.so )
+# build the (still-unmodified) vault program:
+cargo build-sbf --tools-version v1.52
+pnpm install --ignore-workspace
+pnpm exec ts-mocha -p tsconfig.json -t 60000 'tests/sipher-vault/14-*.ts'
+```
+
+Expected: FAIL — `migrate_config` discriminator hits no handler, so `sendIx` rejects (e.g. "invalid instruction"/"InstructionFallbackNotFound"). The malformed/unauthorized tests may surface different errors. All 6 fail or error.
+
+- [ ] **Step 5: Add `LEGACY_VAULT_CONFIG_LEN` to `constants.rs`**
+
+Append to `programs/sipher-vault/programs/sipher-vault/src/constants.rs`:
+
+```rust
+/// Byte length of the legacy (pre-M1) VaultConfig account: 8-byte discriminator
+/// plus the fixed fields, WITHOUT the trailing `pending_authority: Option<Pubkey>`
+/// added by the B6 M1 hardening. `migrate_config` grows accounts of exactly this
+/// size to the current `8 + VaultConfig::INIT_SPACE` (101 bytes).
+pub const LEGACY_VAULT_CONFIG_LEN: usize = 8 + 32 + 2 + 8 + 1 + 8 + 8 + 1; // = 68
+```
+
+- [ ] **Step 6: Append `InvalidConfigAccount` to `errors.rs`**
+
+In `programs/sipher-vault/programs/sipher-vault/src/errors.rs`, add as the **last** variant (after `EncryptedAmountTooLong`):
+
+```rust
+  #[msg("Config account is not a migratable legacy layout")]
+  InvalidConfigAccount,
+```
+
+- [ ] **Step 7: Add the event + handler + accounts struct to `lib.rs`**
+
+7a. Inside `pub mod sipher_vault { … }`, after `update_fee` (just before the module's closing `}` at ~line 749), add the handler:
+
+```rust
+  /// Grow a legacy (pre-M1, 68-byte) VaultConfig to the current 101-byte layout
+  /// by appending `pending_authority = None`. Authority-gated, idempotent.
+  /// Reusable for any future trailing-field layout migration.
+  ///
+  /// The legacy account cannot be deserialized into `VaultConfig` (the trailing
+  /// Option is absent → AccountDidNotDeserialize) and a renamed struct would fail
+  /// the discriminator check, so `config` is a raw UncheckedAccount: the PDA is
+  /// verified by seeds+bump and the authority is read manually from bytes [8..40].
+  pub fn migrate_config(ctx: Context<MigrateConfig>) -> Result<()> {
+    let config = ctx.accounts.config.to_account_info();
+    let new_len = 8 + VaultConfig::INIT_SPACE;
+
+    // Idempotent: already current → no-op. This branch fires before any write,
+    // so a live `pending_authority` on a migrated config can never be clobbered.
+    if config.data_len() >= new_len {
+      msg!("VaultConfig already current ({} bytes); no-op", config.data_len());
+      return Ok(());
+    }
+    require!(config.data_len() == LEGACY_VAULT_CONFIG_LEN, VaultError::InvalidConfigAccount);
+
+    // Authority gate — read the authority from the legacy layout (offset 8..40).
+    {
+      let data = config.try_borrow_data()?;
+      let stored_authority =
+        Pubkey::new_from_array(data[8..40].try_into().expect("len checked == 68 above"));
+      require_keys_eq!(stored_authority, ctx.accounts.authority.key(), VaultError::Unauthorized);
+    }
+
+    // Top up the rent delta so the grown account stays rent-exempt.
+    let need = Rent::get()?
+      .minimum_balance(new_len)
+      .saturating_sub(config.lamports());
+    if need > 0 {
+      let cpi = CpiContext::new(
+        ctx.accounts.system_program.key(),
+        anchor_lang::system_program::Transfer {
+          from: ctx.accounts.authority.to_account_info(),
+          to: config.clone(),
+        },
+      );
+      anchor_lang::system_program::transfer(cpi, need)?;
+    }
+
+    // Grow + zero-fill: the new byte at offset 68 becomes 0x00 = Option::None.
+    config.realloc(new_len, true)?;
+
+    emit!(VaultConfigMigratedEvent {
+      authority: ctx.accounts.authority.key(),
+      new_len: new_len as u64,
+      timestamp: Clock::get()?.unix_timestamp,
+    });
+    Ok(())
+  }
+```
+
+7b. Add the accounts struct after `UpdateFee` (~line 1469):
+
+```rust
+#[derive(Accounts)]
+pub struct MigrateConfig<'info> {
+  /// CHECK: legacy-layout config is not deserializable into VaultConfig; the PDA
+  /// is verified by seeds+bump and the authority is verified manually in the
+  /// handler (bytes [8..40]). Owned by this program, so realloc is permitted.
+  #[account(mut, seeds = [VAULT_CONFIG_SEED], bump)]
+  pub config: UncheckedAccount<'info>,
+
+  #[account(mut)]
+  pub authority: Signer<'info>,
+
+  pub system_program: Program<'info, System>,
+}
+```
+
+7c. Add the event after `FeeUpdatedEvent` (~line 1522, end of file):
+
+```rust
+/// Emitted when `migrate_config` grows a legacy VaultConfig to the current
+/// layout. Lets off-chain tooling confirm the one-time migration on-chain.
+#[event]
+pub struct VaultConfigMigratedEvent {
+  pub authority: Pubkey,
+  pub new_len: u64,
+  pub timestamp: i64,
+}
+```
+
+- [ ] **Step 8: Rebuild + run the new test — verify it PASSES**
+
+```bash
+cd programs/sipher-vault
+cargo build-sbf --tools-version v1.52
+pnpm exec ts-mocha -p tsconfig.json -t 60000 'tests/sipher-vault/14-*.ts'
+```
+
+Expected: **6 passing**. If the `update_fee`-after-migrate test fails with a discriminator mismatch, the empirically-derived `configDisc` is being applied correctly — investigate the realloc/offset logic, not the disc.
+
+- [ ] **Step 9: Run the full bankrun suite — verify no regressions**
+
+```bash
+cd programs/sipher-vault
+pnpm test
+```
+
+Expected: **45 passing**, 0 failing (39 existing + 6 new).
+
+- [ ] **Step 10: Commit + push + open PR**
+
+```bash
+cd /Users/rector/local-dev/sip-protocol
+git add programs/sipher-vault/programs/sipher-vault/src/constants.rs \
+        programs/sipher-vault/programs/sipher-vault/src/errors.rs \
+        programs/sipher-vault/programs/sipher-vault/src/lib.rs \
+        programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts \
+        programs/sipher-vault/tests/sipher-vault/14-migrate-config.test.ts \
+        programs/sipher-vault/package.json
+git commit -m "feat(sipher-vault): add migrate_config layout-migration instruction"
+git push -u origin feat/sipher-vault-migrate-config
+gh pr create --title "feat(sipher-vault): migrate_config instruction (B6 devnet redeploy)" \
+  --body "Adds the authority-gated, idempotent \`migrate_config\` instruction that grows a legacy (pre-M1, 68-byte) VaultConfig to the current 101-byte layout in place, enabling an in-place B6 upgrade of the devnet program (\`S1Phr5…\`) without abandoning the program ID. 45/45 bankrun passing. Refs #1136. Per spec docs/superpowers/specs/2026-06-21-sipher-vault-migrate-config-redeploy-design.md."
+```
+
+**STOP — review gate.** RECTOR reviews the code (optionally `/code-review --fix`) and approves the deploy before Task 2. Do not self-merge.
+
+---
+
+## Task 2: Devnet in-place upgrade + migrate + SOL vault (operational — deploy-gated)
+
+> Runbook. Execute only after RECTOR approves the deploy (see Global Constraints → Deploy gate). Each on-chain action prints a signature/slot to paste into DEPLOYMENT.md. The configured Solana CLI keypair is already the devnet wallet (`FGSkt8…`).
+
+**Files:**
+- Create: `programs/sipher-vault/scripts/migrate-config-devnet.ts`
+- Modify: `programs/sipher-vault/DEPLOYMENT.md` (fill the "Universal-Asset Upgrade (PENDING)" section)
+
+- [ ] **Step 1: Build the deployable binary + note its size**
+
+```bash
+cd programs/sipher-vault
+cargo build-sbf --tools-version v1.52
+ls -l target/deploy/sipher_vault.so   # note SIZE (bytes)
+```
+
+- [ ] **Step 2: Extend the programdata account to fit the larger binary**
+
+The current programdata holds 383,189 bytes (45-byte header + 383,144 program region). The B6 binary (~492 KB) exceeds it, so extend first. `ADDITIONAL = (built .so size) − 383144 + 8192` (margin):
+
+```bash
+SO_SIZE=$(stat -f%z target/deploy/sipher_vault.so)
+ADD=$(( SO_SIZE - 383144 + 8192 ))
+echo "extending by $ADD bytes"
+solana program extend S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB "$ADD" --url devnet
+```
+
+Expected: success (~0.8 SOL spent; wallet has 4.27). Verify: `solana program show S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB --url devnet`.
+
+- [ ] **Step 3: In-place upgrade (BPFLoaderUpgradeable)**
+
+```bash
+solana program deploy target/deploy/sipher_vault.so \
+  --program-id S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB \
+  --upgrade-authority ~/Documents/secret/solana-devnet.json \
+  --url devnet \
+  --with-compute-unit-price 10000
+```
+
+Note the **new deployed slot** from the output (and the deploy TX if shown).
+
+- [ ] **Step 4: Write `scripts/migrate-config-devnet.ts`**
+
+Create `programs/sipher-vault/scripts/migrate-config-devnet.ts`:
+
+```typescript
+// Run the one-time migrate_config on devnet to grow the live VaultConfig
+// (CpL4qy…) from the legacy 68-byte layout to the current 101-byte layout.
+// Idempotent — safe to re-run.
+//
+//   ANCHOR_WALLET=~/Documents/secret/solana-devnet.json \
+//   ANCHOR_PROVIDER_URL=https://api.devnet.solana.com \
+//   pnpm exec tsx scripts/migrate-config-devnet.ts
+
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+} from '@solana/web3.js'
+import { createHash } from 'crypto'
+import * as fs from 'fs'
+import * as os from 'os'
+
+const PROGRAM_ID = new PublicKey('S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB')
+const VAULT_CONFIG_SEED = Buffer.from('vault_config')
+
+function disc(name: string): Buffer {
+  return createHash('sha256').update(`global:${name}`).digest().subarray(0, 8)
+}
+
+async function main() {
+  const url = process.env.ANCHOR_PROVIDER_URL ?? 'https://api.devnet.solana.com'
+  const walletPath = (process.env.ANCHOR_WALLET ?? '~/Documents/secret/solana-devnet.json')
+    .replace(/^~/, os.homedir())
+  const authority = Keypair.fromSecretKey(
+    new Uint8Array(JSON.parse(fs.readFileSync(walletPath, 'utf8'))),
+  )
+  const connection = new Connection(url, 'confirmed')
+  const [configPda] = PublicKey.findProgramAddressSync([VAULT_CONFIG_SEED], PROGRAM_ID)
+
+  const before = await connection.getAccountInfo(configPda)
+  console.log('config before:', configPda.toBase58(), 'len=', before?.data.length)
+
+  const ix = new TransactionInstruction({
+    programId: PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: true },
+      { pubkey: authority.publicKey, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data: disc('migrate_config'),
+  })
+
+  const sig = await connection.sendTransaction(new Transaction().add(ix), [authority])
+  await connection.confirmTransaction(sig, 'confirmed')
+  console.log('migrate_config TX:', sig)
+
+  const after = await connection.getAccountInfo(configPda)
+  console.log('config after: len=', after?.data.length, '(expected 101)')
+  if (after?.data.length !== 101) throw new Error('migration did not reach 101 bytes')
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1) })
+```
+
+- [ ] **Step 5: Run the migration**
+
+```bash
+cd programs/sipher-vault
+ANCHOR_WALLET=~/Documents/secret/solana-devnet.json \
+ANCHOR_PROVIDER_URL=https://api.devnet.solana.com \
+pnpm exec tsx scripts/migrate-config-devnet.ts
+```
+
+Expected: prints `config before: … len= 68`, a `migrate_config TX`, then `config after: len= 101`. Note the TX.
+
+- [ ] **Step 6: Create the native-SOL vault PDAs**
+
+```bash
+cd programs/sipher-vault
+ANCHOR_WALLET=~/Documents/secret/solana-devnet.json \
+ANCHOR_PROVIDER_URL=https://api.devnet.solana.com \
+pnpm exec tsx scripts/create-sol-vault.ts
+```
+
+Note the `SolVault` + `SolFee` PDAs and the TX from the output.
+
+- [ ] **Step 7: Verify on-chain state**
+
+```bash
+solana account CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u --url devnet   # Length: 101
+solana program show S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB --url devnet
+```
+
+Confirm the config is 101 bytes and the program's last-deployed slot is the new one.
+
+- [ ] **Step 8: Fill DEPLOYMENT.md + commit**
+
+Replace the `[TODO …]` placeholders in the "Devnet — Universal-Asset Upgrade (PENDING …)" section of `programs/sipher-vault/DEPLOYMENT.md` with the upgrade TX, new slot, `migrate_config` TX, `SolVault`/`SolFee` PDAs, and built binary size. Add a one-line note that `migrate_config` was run to convert `CpL4qy…` 68→101. Then:
+
+```bash
+cd /Users/rector/local-dev/sip-protocol
+git add programs/sipher-vault/DEPLOYMENT.md programs/sipher-vault/scripts/migrate-config-devnet.ts
+git commit -m "chore(sipher-vault): record B6 devnet upgrade + migrate_config run"
+git push
+```
+
+**STOP — RECTOR merges the PR** (code + deploy record).
+
+---
+
+## Task 3: Downstream `sipher` cascade (separate repo + PR)
+
+> Repo: `~/local-dev/sipher`. Run after the devnet upgrade so the regenerated IDL reflects the live program. The B6 enum renumber already lives in the on-chain program — `sipher` is catching up.
+
+**Files (verify exact paths at execution):**
+- Modify: `~/local-dev/sipher/packages/sdk/src/idl/sipher_vault.json` (regenerated)
+- Modify: any `sipher` file with hardcoded `VaultError` numbers (e.g. `scripts/devnet-beta-gate-check.ts`)
+
+- [ ] **Step 1: Regenerate the IDL from the upgraded program**
+
+```bash
+cd /Users/rector/local-dev/sip-protocol/programs/sipher-vault
+anchor idl build   # Anchor 1.0.2 generates target/idl/sipher_vault.json on host
+ls -l target/idl/sipher_vault.json
+```
+
+- [ ] **Step 2: Locate + replace the committed IDL in `sipher`**
+
+```bash
+cd /Users/rector/local-dev/sipher
+git checkout -b chore/sipher-vault-idl-error-sync
+find . -path ./node_modules -prune -o -name 'sipher_vault*.json' -print
+# copy the regenerated IDL over the committed one (adjust path from the find output):
+cp /Users/rector/local-dev/sip-protocol/programs/sipher-vault/target/idl/sipher_vault.json \
+   packages/sdk/src/idl/sipher_vault.json
+```
+
+If the IDL lives at a different path, use the `find` result.
+
+- [ ] **Step 3: Align hardcoded error numbers**
+
+```bash
+cd /Users/rector/local-dev/sipher
+grep -rn "6012\|6013\|UnsupportedMintExtension\|RentReserveViolation\|BalanceLocked" \
+  packages/ scripts/ src/ 2>/dev/null
+```
+
+For each hit that maps a `VaultError`: `UnsupportedMintExtension` 6012→6011, `RentReserveViolation` 6013→6012; remove any `BalanceLocked` mapping. Treat the grep as the source of truth (don't assume only `devnet-beta-gate-check.ts`).
+
+- [ ] **Step 4: Build + typecheck + commit**
+
+```bash
+cd /Users/rector/local-dev/sipher
+pnpm install
+pnpm build && pnpm typecheck
+# run any test suite the IDL/error change touches, e.g.:
+pnpm test -- --run
+git add -A
+git commit -m "chore(sdk): sync sipher_vault IDL + VaultError codes to B6 devnet redeploy"
+git push -u origin chore/sipher-vault-idl-error-sync
+gh pr create --repo sip-protocol/sipher --title "chore(sdk): sync sipher_vault IDL + error codes (B6 redeploy)" \
+  --body "Regenerates the committed sipher_vault IDL from the upgraded devnet program (adds migrate_config + VaultConfigMigratedEvent) and aligns hardcoded VaultError numbers with the merged B6 enum (UnsupportedMintExtension 6012→6011, RentReserveViolation 6013→6012)."
+```
+
+**STOP — RECTOR merges the `sipher` PR.**
+
+---
+
+## Self-Review
+
+**Spec coverage:** §3 instruction → Task 1 (steps 5–7); §4 testing → Task 1 (steps 1, 8, 9); §5 redeploy → Task 2; §6 `sipher` cascade → Task 3; §9 verification → Task 2 step 7 + Task 3 step 4. All covered.
+
+**Placeholder scan:** Task 2/3 contain runtime values (TX sigs, slots, IDL path) that are inherently execution-time; each has an explicit capture/verify step. No code placeholders.
+
+**Type consistency:** `migrate_config` (no args) / `MigrateConfig` accounts / `ixMigrateConfig(authority)` / disc `sha256("global:migrate_config")[..8]` / error `InvalidConfigAccount` 6014 / event `VaultConfigMigratedEvent` are consistent across Task 1 and Task 2's script. `LEGACY_VAULT_CONFIG_LEN = 68`, `new_len = 8 + VaultConfig::INIT_SPACE = 101` consistent with the test's `LEGACY_LEN`/`NEW_LEN`.

--- a/docs/superpowers/specs/2026-06-21-sipher-vault-migrate-config-redeploy-design.md
+++ b/docs/superpowers/specs/2026-06-21-sipher-vault-migrate-config-redeploy-design.md
@@ -1,0 +1,183 @@
+# Sipher Vault — `migrate_config` + B6 Devnet Redeploy (Design)
+
+**Date:** 2026-06-21
+**Status:** Approved — ready for implementation plan
+**Repos touched:** `sip-protocol` (program + scripts + docs), `sipher` (downstream IDL + error codes)
+**Related:** B6 audit-hardening (`#1192`, merged `152ebaa`), Octora integration Phase 2 → gates B7
+
+---
+
+## 1. Problem
+
+The B6 audit-hardening (merged to `main`) changed two on-chain account layouts:
+
+- **M1** added a trailing `pending_authority: Option<Pubkey>` to `VaultConfig` (+33 B → 68 B becomes 101 B).
+- **M2** removed the inert `BalanceLocked` error variant, which **renumbers** later `VaultError` codes: `UnsupportedMintExtension` 6012→6011, `RentReserveViolation` 6013→6012.
+
+The current devnet program (`S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB`) runs the **pre-B6** binary against a live `VaultConfig` PDA (`CpL4qy…`, 68 B, old layout). A naive in-place upgrade to the B6 binary **bricks** the vault: the new code can't deserialize the 68-byte config (`AccountDidNotDeserialize`), so *every* instruction reverts — including the `refund` self-recovery paths.
+
+We must bring the B6-hardened binary live on devnet **without** abandoning the program ID, and keep the downstream `sipher` repo's IDL + error numbers in lockstep.
+
+## 2. Decision
+
+**Reuse the existing program ID `S1Phr5…`** (in-place upgrade) and add a new **`migrate_config`** instruction that grows the live config to the new layout in place. This keeps both the program ID and the config PDA address (`CpL4qy…`) stable, shrinking the downstream cascade to just the IDL + error-code refresh.
+
+`migrate_config` is a **permanent**, authority-gated, idempotent realloc-migration primitive — reusable for any future trailing-field layout change (including future mainnet upgrades, behind the Squads multisig).
+
+### Alternatives rejected
+
+| Option | Why not |
+|--------|---------|
+| **New program ID** | Throws away the `S1Phr5…` vanity, changes the config PDA address, and forces a larger downstream cascade (program ID + config addr). Only benefit was "no code change" — not worth it once we're adding `migrate_config` anyway. |
+| **`close_config` + re-`initialize`** | Briefly empties a live config (footgun on mainnet) and discards the existing field values. |
+| **Typed `VaultConfigV1` struct to deserialize the old account** | Fails Anchor's 8-byte discriminator check — the on-chain discriminator is `VaultConfig`'s, not a renamed struct's. |
+| **In-place upgrade with no migration** | Bricks the vault (`AccountDidNotDeserialize` on every instruction). |
+
+## 3. The `migrate_config` instruction
+
+**Why a raw account:** the old 68-byte config cannot be deserialized into `VaultConfig` (the trailing `Option` is missing), and a renamed struct fails the discriminator check. So the config is taken as a **raw `UncheckedAccount`** — PDA-verified via `seeds`+`bump`, with the authority read manually from the old bytes.
+
+**Why no manual field write:** the old layout is *exactly* the new layout minus the trailing `Option<Pubkey>`. All fixed-offset fields keep their byte positions. Borsh encodes `None` as a single `0x00` byte, and `realloc(_, zero_init = true)` zero-fills the new region — so the byte at offset 68 becomes `0x00` = `None` automatically.
+
+### Handler (`programs/sipher-vault/programs/sipher-vault/src/lib.rs`)
+
+```rust
+/// Grow an old-layout VaultConfig (pre-M1, 68 B) to the current layout (101 B)
+/// by appending `pending_authority = None`. Authority-gated, idempotent.
+/// Reusable for any future trailing-field layout migration.
+pub fn migrate_config(ctx: Context<MigrateConfig>) -> Result<()> {
+  let config = ctx.accounts.config.to_account_info();
+  let new_len = 8 + VaultConfig::INIT_SPACE;                 // 101
+
+  // Idempotent: already current → no-op. Never clobbers a live pending_authority.
+  if config.data_len() >= new_len {
+    msg!("VaultConfig already current ({}B); no-op", config.data_len());
+    return Ok(());
+  }
+  require!(config.data_len() == LEGACY_VAULT_CONFIG_LEN, VaultError::InvalidConfigAccount); // == 68
+
+  // Authority gate — read authority at bytes [8..40] (old account undeserializable).
+  {
+    let d = config.try_borrow_data()?;
+    let stored = Pubkey::new_from_array(d[8..40].try_into().unwrap());
+    require_keys_eq!(stored, ctx.accounts.authority.key(), VaultError::Unauthorized);
+  }
+
+  // Fund the rent delta so the grown account stays rent-exempt (~0.00023 SOL).
+  let need = Rent::get()?
+    .minimum_balance(new_len)
+    .saturating_sub(config.lamports());
+  if need > 0 {
+    anchor_lang::system_program::transfer(
+      CpiContext::new(
+        ctx.accounts.system_program.to_account_info(),
+        anchor_lang::system_program::Transfer {
+          from: ctx.accounts.authority.to_account_info(),
+          to: config.clone(),
+        },
+      ),
+      need,
+    )?;
+  }
+
+  config.realloc(new_len, true)?;   // zero-fill → byte 68 = 0x00 = None
+  emit!(VaultConfigMigratedEvent {
+    authority: ctx.accounts.authority.key(),
+    new_len: new_len as u64,
+    timestamp: Clock::get()?.unix_timestamp,
+  });
+  Ok(())
+}
+```
+
+### Accounts struct
+
+```rust
+#[derive(Accounts)]
+pub struct MigrateConfig<'info> {
+  /// CHECK: old-layout config is undeserializable into VaultConfig; the PDA is
+  /// verified by seeds+bump and the authority is verified manually in the handler.
+  #[account(mut, seeds = [VAULT_CONFIG_SEED], bump)]
+  pub config: UncheckedAccount<'info>,
+
+  #[account(mut)]
+  pub authority: Signer<'info>,   // signs + pays the rent delta
+
+  pub system_program: Program<'info, System>,
+}
+```
+
+`bump` (no `= config.bump`) recomputes the canonical bump via `find_program_address` — correct because the config was created with the canonical bump and we can't read `config.bump` without deserializing.
+
+### Supporting additions
+
+- **`constants.rs`:** `pub const LEGACY_VAULT_CONFIG_LEN: usize = 68;` (`8 + 32 + 2 + 8 + 1 + 8 + 8 + 1`, pre-M1), with a comment tying it to the M1 migration.
+- **`errors.rs`:** append `InvalidConfigAccount` ("Config account is not a migratable legacy layout") → assigned code **6014** (append-only; does not disturb the 6011/6012 renumber).
+- **`lib.rs` events:** `VaultConfigMigratedEvent { authority: Pubkey, new_len: u64, timestamp: i64 }`, consistent with `VaultPausedEvent` / `AuthorityUpdatedEvent` / `FeeUpdatedEvent`.
+
+### Safety properties
+
+- **Authority-gated** — only the recorded authority can migrate.
+- **Idempotent** — re-running on a ≥101-byte account is a no-op; it can *never* overwrite a real `pending_authority` (the no-op branch fires before any write).
+- **Value-preserving** — every existing field keeps its value and offset; only `None` is appended.
+- **Rent-safe** — tops up the rent delta before growing.
+- **Bounded growth** — +33 B is far under `MAX_PERMITTED_DATA_INCREASE` (10 KiB).
+
+### Out of scope
+
+Old-layout **deposit records** (M2 removed `locked_amount` mid-struct → they deserialize shifted) are **not** migrated. On devnet they are orphaned-but-harmless: new test depositors derive fresh PDAs. No `migrate_deposit_record` (YAGNI).
+
+## 4. Testing (bankrun, IDL-free)
+
+New file `tests/sipher-vault/14-migrate-config.ts`. Plant a synthetic **68-byte old-layout** config via bankrun `setAccount` (discriminator = `sha256("account:VaultConfig")[..8]`, real authority, canonical bump, owner = program, rent-exempt lamports), then assert:
+
+1. **Happy path** — migrate with the correct authority → account is 101 B, deserializes as `VaultConfig`, all fields preserved, `pending_authority == None`, rent-exempt.
+2. **Idempotent** — second call → no-op `Ok`, account unchanged.
+3. **No clobber** — plant a *new-layout* config with `pending_authority = Some(X)`, call migrate → no-op, `Some(X)` preserved.
+4. **Unauthorized** — wrong signer → `Unauthorized`.
+5. **Malformed length** — wrong-size account → `InvalidConfigAccount`.
+6. **Usable after migrate** — a real instruction (`update_fee` or `set_paused`) succeeds on the migrated account.
+
+Target: existing 39 bankrun tests stay green, +6 new = **45 passing**. Build with `cargo build-sbf --tools-version v1.52` (Agave 3.0.13 defaults to v1.51, below Anchor 1.0.2's MSRV). CPI tests need the `sip_privacy.so` fixture (built the same way).
+
+## 5. Devnet redeploy sequence
+
+> The on-chain steps (5.2–5.5) touch shared devnet and the historically-held devnet wallet. **Deploy gate:** confirmed with RECTOR at execution time — either CIPHER executes, or stages the exact commands as a runbook. Nothing irreversible (the program ID is reused, not closed).
+
+1. **Merge** the `migrate_config` PR to `main` (TDD'd + reviewed; RECTOR approves — not self-merged).
+2. `solana program extend S1Phr5… <Δ>` — grow programdata for the ~492 KB B6 binary (current allocation 383,189 B has no headroom). Cost ~**0.76 SOL**; wallet (4.27 SOL) covers it. Exact Δ computed from the built `.so` size + margin.
+3. Build (`cargo build-sbf --tools-version v1.52`) → `solana program deploy --program-id S1Phr5… --upgrade-authority <devnet wallet>` (in-place `BPFLoaderUpgradeable`).
+4. New script `scripts/migrate-config-devnet.ts` → invoke `migrate_config` (authority = devnet wallet) → verify the config now deserializes as the new layout.
+5. `scripts/create-sol-vault.ts` → create the `SolVault` + `SolFee` PDAs (the native-SOL track introduced with the universal-asset feature; they don't exist yet on devnet).
+6. `anchor idl build` → fresh IDL. Fill the DEPLOYMENT.md "Universal-Asset Upgrade (PENDING)" section with the upgrade TX, new slot, migrate TX, `SolVault`/`SolFee` PDAs, and binary size.
+
+## 6. Downstream `sipher` cascade (`~/local-dev/sipher`, separate PR)
+
+The B6 enum renumber already lives in the program (merged in `#1192`); `sipher` simply has to catch up.
+
+- Regenerate `packages/sdk/src/idl/sipher_vault.json` from the new `anchor idl build` output (also picks up `migrate_config` + `VaultConfigMigratedEvent`).
+- Grep `sipher` for hardcoded `VaultError` numbers and align them with the merged enum — notably `UnsupportedMintExtension` 6012→6011 and `RentReserveViolation` 6013→6012 (check `scripts/devnet-beta-gate-check.ts` and any error-code map/table; treat the grep as the source of truth, not just these two).
+- **No program-ID or config-PDA change** — `S1Phr5…` and `CpL4qy…` are both preserved, so only the IDL + error numbers move.
+
+## 7. Risks & mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| `migrate_config` corrupts the live config | Realloc preserves bytes 0..68 verbatim; only zero-fills 68..101. Covered by tests 1 & 6 (full round-trip + real-instruction usability). |
+| Migration clobbers a real `pending_authority` | Idempotent no-op fires before any write on ≥101-byte accounts. Covered by test 3. |
+| Wrong toolchain → MSRV build failure | Explicit `cargo build-sbf --tools-version v1.52` documented in DEPLOYMENT.md. |
+| Downstream `sipher` mislabels on-chain errors | Error renumber done in the same effort, in lockstep with the redeploy. |
+| Shared devnet wallet drained | Tight extend (~0.76 SOL); deploy gate confirmed with RECTOR. |
+
+## 8. Non-goals
+
+- Mainnet deploy (B7 — fresh deploy, no migration needed; gated separately on the Squads multisig).
+- Migrating deposit records / vault-token / fee-token PDAs (devnet test data, orphaned-harmless).
+- Any change to the program ID, config PDA seed, or fee model.
+
+## 9. Verification (definition of done)
+
+- 45/45 bankrun tests pass; `cargo build-sbf --tools-version v1.52` clean; naming-check clean.
+- Devnet: `S1Phr5…` runs the B6 binary; `CpL4qy…` deserializes as the new layout with original field values + `pending_authority = None`; `SolVault`/`SolFee` exist; a smoke instruction succeeds.
+- DEPLOYMENT.md updated with real TX/slot/PDA values.
+- `sipher` IDL + error numbers regenerated; `sipher` build/typecheck green.

--- a/programs/sipher-vault/DEPLOYMENT.md
+++ b/programs/sipher-vault/DEPLOYMENT.md
@@ -126,22 +126,18 @@ emergency lever works before mainnet (PR-B1 Risk B2/B3).
 - Verified script: `programs/sipher-vault/scripts/set-paused.ts`
 - Authority signed: `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr`
 
-### Devnet — Universal-Asset Upgrade (PENDING — to be filled in by RECTOR)
+### Devnet — B6 Hardening + Universal-Asset + `migrate_config` Redeploy (2026-06-22)
 
-Universal-asset feature branch adds native SOL support (6 new instructions, 9 → 15 total).
-Binary: `492536` bytes (Δ from `383144` — ~107 KB for two new account structs + 6 instruction handlers).
+In-place `BPFLoaderUpgradeable` upgrade of the **existing** program — B6 audit-hardening (#1192) + universal-asset native-SOL track + the new `migrate_config` instruction (#1212) — followed by `migrate_config` to grow the live `VaultConfig` 68 → 101 in place, then `create_sol_vault`. **Program ID and config PDA preserved** (reuse via `migrate_config`, NOT fresh accounts — this supersedes the obsolete "fresh accounts required" note; see "Devnet Upgrade" above).
 
-> **⚠️ If the B6 audit-hardening (M1/M2) is included in this redeploy, the
-> account layouts change and an in-place upgrade is NOT safe — see the breaking-change
-> warning under "Devnet Upgrade" below. Fresh accounts (new program ID or recreate)
-> are required.**
-
-- **Upgrade TX:** `[TODO — run scripts/upgrade-devnet.ts and paste TX signature here]`
-- **New deployed slot:** `[TODO — paste slot from upgrade-devnet.ts output]`
-- **SOL vault init TX:** `[TODO — run scripts/create-sol-vault.ts after redeploy and paste TX here]`
-- **SolVault PDA:** `[TODO — paste from create-sol-vault.ts output]`
-- **SolFee PDA:** `[TODO — paste from create-sol-vault.ts output]`
-- Binary size: `492536` bytes
+- **Binary:** `513176` bytes (`.so`); programdata extended `+138224` → `521413` bytes allocated (rent ~0.963 SOL, permanent).
+- **Upgrade TX:** `2SpAab9CgbQneAiNAszxSC5AKpBuviYKETxZxD28CdqceMTX7c5ZqWaptzHKfLLiFzhWikradr1RAwMfCy9oJiUb`
+- **New deployed slot:** `471134934` (was `460376111`).
+- **`migrate_config` TX:** `2eUimGuTYRU4Biy6A8jnTjLLpL4p89ccJKddCy2KdSyYzS583onav3HiTfQRwP84iA2n4j9PHK5uZGQsopjmr1xd` — `VaultConfig` `CpL4qy…` 68 → 101; verified fields preserved (authority `FGSkt8…`, fee 10 bps, refund_timeout 86400, total_deposits 2, total_depositors 1, bump 254) with `pending_authority = None` (byte 68 = 0x00, trailing zero-filled).
+- **`create_sol_vault` TX:** `3ZW7rBK35GK1YCTQjBw9icKuS7PzUUUxJECQ9e18YYD7XwreVtKLsgKz9wkKtzJgAfiaRHDFkuoG74ytzH66jVW4`
+- **SolVault PDA:** `8ZG46epBDrRbZ2oDneuemmSuQNNG3R58LhFo8Do2p6sq` (9 bytes)
+- **SolFee PDA:** `519L2NQN16H1fnN9iPu2r2ipmjPj156yWMPQumw8PkZ4` (9 bytes)
+- **Config PDA (post-migration):** `CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u` — 101 bytes, deserializes as current `VaultConfig`.
 - Authority signed: `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr`
 
 ## Mainnet Deployments

--- a/programs/sipher-vault/DEPLOYMENT.md
+++ b/programs/sipher-vault/DEPLOYMENT.md
@@ -29,7 +29,7 @@ Deployment records and procedures for the `sipher_vault` Anchor program — a pr
 
 ## Instruction Inventory
 
-The program currently exposes **15 instructions** (9 original + 6 native-SOL track added in the universal-asset feature).
+The program currently exposes **19 instructions** (9 original + 6 native-SOL track + 3 authority-management (M1) + the `migrate_config` layout migration).
 
 ### Token-track instructions (original 9)
 
@@ -55,6 +55,15 @@ The program currently exposes **15 instructions** (9 original + 6 native-SOL tra
 | 13 | `refund_sol` | Return lamports after `refund_timeout` (depositor-signed); checked-lamport transfer from `SolVault` |
 | 14 | `authority_refund_sol` | Emergency authority-gated SOL refund |
 | 15 | `collect_fee_sol` | Sweep `SolFee` lamports to authority; preserves rent-exempt floor |
+
+### Admin & migration instructions
+
+| # | Instruction | Description |
+|---|-------------|-------------|
+| 16 | `update_authority` | Propose a new authority — step 1 of the two-step M1 transfer |
+| 17 | `accept_authority` | Accept a pending authority transfer — step 2; the proposed key must sign |
+| 18 | `update_fee` | Authority-only fee update, capped at `MAX_FEE_BPS` |
+| 19 | `migrate_config` | Authority-gated, idempotent **in-place** migration of a legacy 68-byte `VaultConfig` to the current 101-byte layout (appends `pending_authority = None`). See "Devnet Upgrade" below |
 
 > **SDK/relayer integrators:** native `withdraw_private_sol` sends lamports to a stealth system account. If
 > the stealth account is freshly created (zero balance), the receiving transaction must leave it at or above
@@ -171,7 +180,7 @@ Expected: **39 passing**, 0 failing.
 
 ### Devnet Upgrade
 
-> **⚠️ BREAKING ACCOUNT-LAYOUT CHANGE in the B6 audit-hardening — an in-place upgrade across this boundary will BRICK the existing vault.**
+> **⚠️ BREAKING ACCOUNT-LAYOUT CHANGE in the B6 audit-hardening — an in-place upgrade MUST be followed by `migrate_config` (see resolution below), or the existing vault is bricked.**
 > The hardening adds `VaultConfig.pending_authority` (M1, +33 bytes) and removes
 > `DepositRecord.locked_amount` (M2, −8 bytes mid-struct), changing both struct
 > layouts. The existing devnet `VaultConfig` PDA
@@ -185,20 +194,24 @@ Expected: **39 passing**, 0 failing.
 >   `bump = deposit_record.bump` seeds check → that depositor's funds become
 >   unwithdrawable.
 >
-> There is **no migration/`realloc` instruction**, so `upgrade-devnet.ts`
-> (in-place `BPFLoaderUpgradeable`) is unsafe here. Bring the new-layout program
-> up against **fresh** accounts — deploy to a **new program ID** + fresh
-> `initialize`, or close/recreate the config + records first. **This is RECTOR's
-> deploy decision.** (Mainnet B7 is a fresh deploy with no pre-existing accounts
-> → unaffected. Verified against live devnet account sizes by the post-hardening
-> independent review.)
+> **Resolved by `migrate_config` (PR #1212).** The `VaultConfig` brick is fixed
+> by the `migrate_config` instruction, which grows the existing config PDA in
+> place (68 → 101 bytes, appending `pending_authority = None`) — so the **program
+> ID and config PDA (`CpL4qy…`) are preserved**; no new program ID or fresh
+> `initialize` is required. The safe devnet path is: `solana program extend` (the
+> B6 binary is larger than the current allocation) → in-place
+> `BPFLoaderUpgradeable` upgrade → run `migrate_config` (authority-signed) →
+> `create_sol_vault`. Legacy `DepositRecord` accounts are **not** migrated; on
+> devnet they are orphaned-but-harmless (new depositors derive fresh PDAs).
+> Mainnet B7 is a fresh deploy with no pre-existing accounts → no migration needed.
 
 > **Downstream error-code sync (B6 M2):** removing the inert `BalanceLocked`
 > variant renumbers the later `VaultError` codes (`UnsupportedMintExtension`
 > 6012→6011, `RentReserveViolation` 6013→6012). On redeploy, regenerate the
 > consuming `sipher` repo's committed IDL (`packages/sdk/src/idl/sipher_vault.json`)
 > and update any hardcoded error numbers (e.g. `scripts/devnet-beta-gate-check.ts`)
-> in lockstep — otherwise off-chain tooling will mislabel on-chain errors.
+> in lockstep — otherwise off-chain tooling will mislabel on-chain errors. PR #1212
+> additionally appends `InvalidConfigAccount` = 6014 (append-only — existing codes unchanged).
 
 Use the atomic upgrade script (only safe for layout-compatible upgrades):
 

--- a/programs/sipher-vault/DEPLOYMENT.md
+++ b/programs/sipher-vault/DEPLOYMENT.md
@@ -161,18 +161,19 @@ cd ../sipher-vault
 Then run the suite:
 
 ```bash
-# All four test files (10 = classic SPL, 11 = Token-2022 allowlist,
-# 12 = native SOL, 13 = authority management)
-pnpm exec ts-mocha -p tsconfig.json -t 60000 'tests/sipher-vault/{10,11,12,13}-*.ts'
+# All five test files (10 = classic SPL, 11 = Token-2022 allowlist,
+# 12 = native SOL, 13 = authority management, 14 = migrate_config)
+pnpm exec ts-mocha -p tsconfig.json -t 60000 'tests/sipher-vault/{10,11,12,13,14}-*.ts'
 
 # Or individually:
 pnpm exec ts-mocha -p tsconfig.json -t 60000 'tests/sipher-vault/10-*.ts'
 pnpm exec ts-mocha -p tsconfig.json -t 60000 'tests/sipher-vault/11-*.ts'
 pnpm exec ts-mocha -p tsconfig.json -t 60000 'tests/sipher-vault/12-*.ts'
 pnpm exec ts-mocha -p tsconfig.json -t 60000 'tests/sipher-vault/13-*.ts'
+pnpm exec ts-mocha -p tsconfig.json -t 60000 'tests/sipher-vault/14-*.ts'
 ```
 
-Expected: **39 passing**, 0 failing.
+Expected: **46 passing**, 0 failing.
 
 ### Devnet Upgrade
 

--- a/programs/sipher-vault/package.json
+++ b/programs/sipher-vault/package.json
@@ -2,7 +2,7 @@
   "name": "sipher-vault-tests",
   "private": true,
   "scripts": {
-    "test": "ts-mocha -p ./tsconfig.json -t 1000000 \"tests/sipher-vault/{10,11,12,13}-*.ts\""
+    "test": "ts-mocha -p ./tsconfig.json -t 1000000 \"tests/sipher-vault/{10,11,12,13,14}-*.ts\""
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.32.1",

--- a/programs/sipher-vault/programs/sipher-vault/src/constants.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/constants.rs
@@ -13,3 +13,9 @@ pub const FEE_SOL_SEED: &[u8] = b"fee_sol";
 /// Sentinel mint representing native SOL (zero / System-Program pubkey).
 pub const NATIVE_SOL_MINT: Pubkey = Pubkey::new_from_array([0u8; 32]);
 
+/// Byte length of the legacy (pre-M1) VaultConfig account: 8-byte discriminator
+/// plus the fixed fields, WITHOUT the trailing `pending_authority: Option<Pubkey>`
+/// added by the B6 M1 hardening. `migrate_config` grows accounts of exactly this
+/// size to the current `8 + VaultConfig::INIT_SPACE` (101 bytes).
+pub const LEGACY_VAULT_CONFIG_LEN: usize = 8 + 32 + 2 + 8 + 1 + 8 + 8 + 1; // = 68
+

--- a/programs/sipher-vault/programs/sipher-vault/src/errors.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/errors.rs
@@ -30,4 +30,6 @@ pub enum VaultError {
   RentReserveViolation,
   #[msg("Encrypted amount exceeds the 64-byte maximum")]
   EncryptedAmountTooLong,
+  #[msg("Config account is not a migratable legacy layout")]
+  InvalidConfigAccount,
 }

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -748,31 +748,44 @@ pub mod sipher_vault {
   }
 
   /// Grow a legacy (pre-M1, 68-byte) VaultConfig to the current 101-byte layout
-  /// by appending `pending_authority = None`. Authority-gated, idempotent.
-  /// Reusable for any future trailing-field layout migration.
+  /// by appending `pending_authority = None`. Authority-gated on every path,
+  /// idempotent. Reusable for any future trailing-field layout migration.
   ///
   /// The legacy account cannot be deserialized into `VaultConfig` (the trailing
   /// Option is absent → AccountDidNotDeserialize) and a renamed struct would fail
   /// the discriminator check, so `config` is a raw UncheckedAccount: the PDA is
-  /// verified by seeds+bump and the authority is read manually from bytes [8..40].
+  /// verified by seeds+bump and the authority is read manually from bytes [8..40]
+  /// (the authority sits at the same offset in the legacy and current layout).
   pub fn migrate_config(ctx: Context<MigrateConfig>) -> Result<()> {
     let config = ctx.accounts.config.to_account_info();
     let new_len = 8 + VaultConfig::INIT_SPACE;
+    let len = config.data_len();
 
-    // Idempotent: already current → no-op. This branch fires before any write,
-    // so a live `pending_authority` on a migrated config can never be clobbered.
-    if config.data_len() >= new_len {
-      msg!("VaultConfig already current ({} bytes); no-op", config.data_len());
-      return Ok(());
-    }
-    require!(config.data_len() == LEGACY_VAULT_CONFIG_LEN, VaultError::InvalidConfigAccount);
+    // Accept only a legacy account (to migrate) or an already-current account
+    // (to no-op). Rejecting anything else up front also guarantees the [8..40]
+    // authority read below is in bounds (both accepted sizes are ≥ 40).
+    require!(
+      len == LEGACY_VAULT_CONFIG_LEN || len >= new_len,
+      VaultError::InvalidConfigAccount
+    );
 
-    // Authority gate — read the authority from the legacy layout (offset 8..40).
+    // Authority gate FIRST — enforced on every valid path, including the no-op,
+    // so the instruction is uniformly authority-gated. Read manually because the
+    // legacy account cannot be deserialized into `VaultConfig`.
     {
       let data = config.try_borrow_data()?;
-      let stored_authority =
-        Pubkey::new_from_array(data[8..40].try_into().expect("len checked == 68 above"));
+      let stored_authority = data
+        .get(8..40)
+        .and_then(|s| Pubkey::try_from(s).ok())
+        .ok_or(VaultError::InvalidConfigAccount)?;
       require_keys_eq!(stored_authority, ctx.accounts.authority.key(), VaultError::Unauthorized);
+    }
+
+    // Idempotent: already current → no-op. Fires after the authority gate and
+    // before any write, so a live `pending_authority` can never be clobbered.
+    if len >= new_len {
+      msg!("VaultConfig already current ({} bytes); no-op", len);
+      return Ok(());
     }
 
     // Top up the rent delta so the grown account stays rent-exempt.
@@ -790,8 +803,14 @@ pub mod sipher_vault {
       anchor_lang::system_program::transfer(cpi, need)?;
     }
 
-    // Grow + zero-fill: the new byte at offset 68 becomes 0x00 = Option::None.
+    // Grow, then explicitly zero the appended region so `pending_authority`
+    // decodes as `None` (byte 68 = 0x00) — independent of the runtime's resize
+    // zero-fill behavior; a non-zero byte 68 would decode as Some(garbage).
     config.resize(new_len)?;
+    {
+      let mut data = config.try_borrow_mut_data()?;
+      data[LEGACY_VAULT_CONFIG_LEN..new_len].fill(0);
+    }
 
     emit!(VaultConfigMigratedEvent {
       authority: ctx.accounts.authority.key(),

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -749,7 +749,11 @@ pub mod sipher_vault {
 
   /// Grow a legacy (pre-M1, 68-byte) VaultConfig to the current 101-byte layout
   /// by appending `pending_authority = None`. Authority-gated on every path,
-  /// idempotent. Reusable for any future trailing-field layout migration.
+  /// idempotent. Scoped to this one-time 68→101 migration: the accepted legacy
+  /// size is pinned to `LEGACY_VAULT_CONFIG_LEN`. The mechanism (raw realloc +
+  /// zero-fill of the appended region) would generalize to a future
+  /// trailing-field migration, but that would require bumping that constant to
+  /// the then-current size.
   ///
   /// The legacy account cannot be deserialized into `VaultConfig` (the trailing
   /// Option is absent → AccountDidNotDeserialize) and a renamed struct would fail

--- a/programs/sipher-vault/programs/sipher-vault/src/lib.rs
+++ b/programs/sipher-vault/programs/sipher-vault/src/lib.rs
@@ -746,6 +746,60 @@ pub mod sipher_vault {
     });
     Ok(())
   }
+
+  /// Grow a legacy (pre-M1, 68-byte) VaultConfig to the current 101-byte layout
+  /// by appending `pending_authority = None`. Authority-gated, idempotent.
+  /// Reusable for any future trailing-field layout migration.
+  ///
+  /// The legacy account cannot be deserialized into `VaultConfig` (the trailing
+  /// Option is absent → AccountDidNotDeserialize) and a renamed struct would fail
+  /// the discriminator check, so `config` is a raw UncheckedAccount: the PDA is
+  /// verified by seeds+bump and the authority is read manually from bytes [8..40].
+  pub fn migrate_config(ctx: Context<MigrateConfig>) -> Result<()> {
+    let config = ctx.accounts.config.to_account_info();
+    let new_len = 8 + VaultConfig::INIT_SPACE;
+
+    // Idempotent: already current → no-op. This branch fires before any write,
+    // so a live `pending_authority` on a migrated config can never be clobbered.
+    if config.data_len() >= new_len {
+      msg!("VaultConfig already current ({} bytes); no-op", config.data_len());
+      return Ok(());
+    }
+    require!(config.data_len() == LEGACY_VAULT_CONFIG_LEN, VaultError::InvalidConfigAccount);
+
+    // Authority gate — read the authority from the legacy layout (offset 8..40).
+    {
+      let data = config.try_borrow_data()?;
+      let stored_authority =
+        Pubkey::new_from_array(data[8..40].try_into().expect("len checked == 68 above"));
+      require_keys_eq!(stored_authority, ctx.accounts.authority.key(), VaultError::Unauthorized);
+    }
+
+    // Top up the rent delta so the grown account stays rent-exempt.
+    let need = Rent::get()?
+      .minimum_balance(new_len)
+      .saturating_sub(config.lamports());
+    if need > 0 {
+      let cpi = CpiContext::new(
+        ctx.accounts.system_program.key(),
+        anchor_lang::system_program::Transfer {
+          from: ctx.accounts.authority.to_account_info(),
+          to: config.clone(),
+        },
+      );
+      anchor_lang::system_program::transfer(cpi, need)?;
+    }
+
+    // Grow + zero-fill: the new byte at offset 68 becomes 0x00 = Option::None.
+    config.resize(new_len)?;
+
+    emit!(VaultConfigMigratedEvent {
+      authority: ctx.accounts.authority.key(),
+      new_len: new_len as u64,
+      timestamp: Clock::get()?.unix_timestamp,
+    });
+    Ok(())
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1468,6 +1522,20 @@ pub struct UpdateFee<'info> {
   pub authority: Signer<'info>,
 }
 
+#[derive(Accounts)]
+pub struct MigrateConfig<'info> {
+  /// CHECK: legacy-layout config is not deserializable into VaultConfig; the PDA
+  /// is verified by seeds+bump and the authority is verified manually in the
+  /// handler (bytes [8..40]). Owned by this program, so realloc is permitted.
+  #[account(mut, seeds = [VAULT_CONFIG_SEED], bump)]
+  pub config: UncheckedAccount<'info>,
+
+  #[account(mut)]
+  pub authority: Signer<'info>,
+
+  pub system_program: Program<'info, System>,
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Events
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1518,5 +1586,14 @@ pub struct FeeUpdatedEvent {
   pub authority: Pubkey,
   pub old_fee_bps: u16,
   pub new_fee_bps: u16,
+  pub timestamp: i64,
+}
+
+/// Emitted when `migrate_config` grows a legacy VaultConfig to the current
+/// layout. Lets off-chain tooling confirm the one-time migration on-chain.
+#[event]
+pub struct VaultConfigMigratedEvent {
+  pub authority: Pubkey,
+  pub new_len: u64,
   pub timestamp: i64,
 }

--- a/programs/sipher-vault/scripts/migrate-config-devnet.ts
+++ b/programs/sipher-vault/scripts/migrate-config-devnet.ts
@@ -1,0 +1,74 @@
+// Run the one-time migrate_config on devnet to grow the live VaultConfig
+// (CpL4qy…) from the legacy 68-byte layout to the current 101-byte layout.
+// Idempotent — safe to re-run (no-op once the config is already 101 bytes).
+//
+//   ANCHOR_WALLET=~/Documents/secret/solana-devnet.json \
+//   ANCHOR_PROVIDER_URL=https://api.devnet.solana.com \
+//   pnpm exec tsx scripts/migrate-config-devnet.ts
+
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+  sendAndConfirmTransaction,
+} from '@solana/web3.js'
+import { createHash } from 'crypto'
+import * as fs from 'fs'
+import * as os from 'os'
+
+const PROGRAM_ID = new PublicKey('S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB')
+const VAULT_CONFIG_SEED = Buffer.from('vault_config')
+
+// Anchor instruction discriminator: sha256("global:<name>")[..8]
+function disc(name: string): Buffer {
+  return createHash('sha256').update(`global:${name}`).digest().subarray(0, 8)
+}
+
+async function main() {
+  const url = process.env.ANCHOR_PROVIDER_URL ?? 'https://api.devnet.solana.com'
+  const walletPath = (
+    process.env.ANCHOR_WALLET ?? '~/Documents/secret/solana-devnet.json'
+  ).replace(/^~/, os.homedir())
+  const authority = Keypair.fromSecretKey(
+    new Uint8Array(JSON.parse(fs.readFileSync(walletPath, 'utf8'))),
+  )
+  const connection = new Connection(url, 'confirmed')
+  const [configPda] = PublicKey.findProgramAddressSync([VAULT_CONFIG_SEED], PROGRAM_ID)
+
+  const before = await connection.getAccountInfo(configPda)
+  console.log('config before:', configPda.toBase58(), 'len=', before?.data.length)
+  if (before?.data.length === 101) {
+    console.log('already migrated (101 bytes) — nothing to do')
+    return
+  }
+
+  const ix = new TransactionInstruction({
+    programId: PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: true },
+      { pubkey: authority.publicKey, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data: disc('migrate_config'),
+  })
+
+  const sig = await sendAndConfirmTransaction(connection, new Transaction().add(ix), [authority], {
+    commitment: 'confirmed',
+  })
+  console.log('migrate_config TX:', sig)
+
+  const after = await connection.getAccountInfo(configPda)
+  console.log('config after: len=', after?.data.length, '(expected 101)')
+  if (after?.data.length !== 101) throw new Error('migration did not reach 101 bytes')
+  console.log('OK — VaultConfig migrated 68 → 101')
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })

--- a/programs/sipher-vault/scripts/migrate-config-devnet.ts
+++ b/programs/sipher-vault/scripts/migrate-config-devnet.ts
@@ -22,6 +22,11 @@ import * as os from 'os'
 const PROGRAM_ID = new PublicKey('S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB')
 const VAULT_CONFIG_SEED = Buffer.from('vault_config')
 
+// VaultConfig account sizes (mirror the Rust program): the pre-M1 legacy layout
+// and the current layout after `migrate_config` appends `pending_authority: None`.
+const LEGACY_VAULT_CONFIG_LEN = 68
+const NEW_VAULT_CONFIG_LEN = 101
+
 // Anchor instruction discriminator: sha256("global:<name>")[..8]
 function disc(name: string): Buffer {
   return createHash('sha256').update(`global:${name}`).digest().subarray(0, 8)
@@ -36,12 +41,24 @@ async function main() {
     new Uint8Array(JSON.parse(fs.readFileSync(walletPath, 'utf8'))),
   )
   const connection = new Connection(url, 'confirmed')
+
+  // Guard: refuse to run on mainnet-beta. `migrate_config` mutates a live config
+  // account in place; on mainnet the layout migration must go through the gated
+  // mainnet deploy (self-audit → mainnet), never this devnet helper. A stray
+  // ANCHOR_PROVIDER_URL must not be able to realloc a production config.
+  const MAINNET_GENESIS = '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d'
+  const genesisHash = await connection.getGenesisHash()
+  if (genesisHash === MAINNET_GENESIS) {
+    console.error('ERROR: refusing to run against mainnet-beta — migrate_config is devnet-only here')
+    process.exit(1)
+  }
+
   const [configPda] = PublicKey.findProgramAddressSync([VAULT_CONFIG_SEED], PROGRAM_ID)
 
   const before = await connection.getAccountInfo(configPda)
   console.log('config before:', configPda.toBase58(), 'len=', before?.data.length)
-  if (before?.data.length === 101) {
-    console.log('already migrated (101 bytes) — nothing to do')
+  if (before?.data.length === NEW_VAULT_CONFIG_LEN) {
+    console.log(`already migrated (${NEW_VAULT_CONFIG_LEN} bytes) — nothing to do`)
     return
   }
 
@@ -61,9 +78,11 @@ async function main() {
   console.log('migrate_config TX:', sig)
 
   const after = await connection.getAccountInfo(configPda)
-  console.log('config after: len=', after?.data.length, '(expected 101)')
-  if (after?.data.length !== 101) throw new Error('migration did not reach 101 bytes')
-  console.log('OK — VaultConfig migrated 68 → 101')
+  console.log('config after: len=', after?.data.length, `(expected ${NEW_VAULT_CONFIG_LEN})`)
+  if (after?.data.length !== NEW_VAULT_CONFIG_LEN) {
+    throw new Error(`migration did not reach ${NEW_VAULT_CONFIG_LEN} bytes`)
+  }
+  console.log(`OK — VaultConfig migrated ${LEGACY_VAULT_CONFIG_LEN} → ${NEW_VAULT_CONFIG_LEN}`)
 }
 
 main()

--- a/programs/sipher-vault/tests/sipher-vault/14-migrate-config.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/14-migrate-config.test.ts
@@ -1,0 +1,170 @@
+// tests/sipher-vault/14-migrate-config.test.ts
+//
+// migrate_config — grows a legacy (pre-M1, 68-byte) VaultConfig to the current
+// 101-byte layout by appending pending_authority = None. Authority-gated,
+// idempotent. IDL-free bankrun harness (raw instructions).
+
+import { assert } from 'chai'
+import { Keypair, PublicKey, SystemProgram } from '@solana/web3.js'
+import { ProgramTestContext } from 'solana-bankrun'
+
+import {
+  ixInitialize,
+  ixMigrateConfig,
+  ixUpdateFee,
+  sendIx,
+  startVault,
+  getAccountData,
+  parseVaultConfig,
+  assertFails,
+  VAULT_PROGRAM_ID,
+} from './bankrun-helpers'
+import { getVaultConfigPDA } from './setup'
+
+const LEGACY_LEN = 68
+const NEW_LEN = 101
+
+describe('14 · migrate_config (B6 VaultConfig layout migration)', () => {
+  let ctx: ProgramTestContext
+  let authority: Keypair
+  let configPda: PublicKey
+  let bump: number
+  // Real VaultConfig account discriminator, derived empirically from a live
+  // initialize so synthetic legacy accounts carry the exact discriminator the
+  // typed handlers (e.g. update_fee) check.
+  let configDisc: Buffer
+
+  before(async () => {
+    const tmp = await startVault()
+    const [pda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+    await sendIx(tmp, [ixInitialize(tmp.payer.publicKey, 10, 86400n)], [tmp.payer])
+    configDisc = Buffer.from((await getAccountData(tmp, pda)).subarray(0, 8))
+  })
+
+  beforeEach(async () => {
+    ctx = await startVault()
+    authority = ctx.payer
+    ;[configPda, bump] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+  })
+
+  async function plantLegacy(opts: {
+    authority: PublicKey
+    feeBps: number
+    refundTimeout: bigint
+    paused: boolean
+    totalDeposits: bigint
+    totalDepositors: bigint
+  }): Promise<void> {
+    const d = Buffer.alloc(LEGACY_LEN)
+    configDisc.copy(d, 0)
+    opts.authority.toBuffer().copy(d, 8)
+    d.writeUInt16LE(opts.feeBps, 40)
+    d.writeBigInt64LE(opts.refundTimeout, 42)
+    d.writeUInt8(opts.paused ? 1 : 0, 50)
+    d.writeBigUInt64LE(opts.totalDeposits, 51)
+    d.writeBigUInt64LE(opts.totalDepositors, 59)
+    d.writeUInt8(bump, 67)
+    const rent = await ctx.banksClient.getRent()
+    ctx.setAccount(configPda, {
+      lamports: Number(rent.minimumBalance(BigInt(LEGACY_LEN))),
+      data: d,
+      owner: VAULT_PROGRAM_ID,
+      executable: false,
+      rentEpoch: 0,
+    })
+  }
+
+  async function plantNew(pendingAuthority: PublicKey | null): Promise<void> {
+    const d = Buffer.alloc(NEW_LEN)
+    configDisc.copy(d, 0)
+    authority.publicKey.toBuffer().copy(d, 8)
+    d.writeUInt16LE(10, 40)
+    d.writeBigInt64LE(86400n, 42)
+    d.writeUInt8(0, 50)
+    d.writeBigUInt64LE(0n, 51)
+    d.writeBigUInt64LE(0n, 59)
+    d.writeUInt8(bump, 67)
+    if (pendingAuthority) {
+      d.writeUInt8(1, 68)
+      pendingAuthority.toBuffer().copy(d, 69)
+    }
+    const rent = await ctx.banksClient.getRent()
+    ctx.setAccount(configPda, {
+      lamports: Number(rent.minimumBalance(BigInt(NEW_LEN))),
+      data: d,
+      owner: VAULT_PROGRAM_ID,
+      executable: false,
+      rentEpoch: 0,
+    })
+  }
+
+  it('migrates a legacy 68-byte config → 101 bytes, fields preserved, pending=None', async () => {
+    await plantLegacy({ authority: authority.publicKey, feeBps: 10, refundTimeout: 86400n, paused: false, totalDeposits: 5n, totalDepositors: 3n })
+    await sendIx(ctx, [ixMigrateConfig(authority.publicKey)], [authority])
+
+    const data = await getAccountData(ctx, configPda)
+    assert.strictEqual(data.length, NEW_LEN, 'account grew to new layout length')
+    const cfg = parseVaultConfig(data)
+    assert.ok(cfg.authority.equals(authority.publicKey))
+    assert.strictEqual(cfg.feeBps, 10)
+    assert.strictEqual(cfg.refundTimeout, 86400n)
+    assert.strictEqual(cfg.paused, false)
+    assert.strictEqual(cfg.totalDeposits, 5n)
+    assert.strictEqual(cfg.totalDepositors, 3n)
+    assert.strictEqual(cfg.bump, bump)
+    assert.strictEqual(cfg.pendingAuthority, null, 'pending_authority appended as None')
+    const rent = await ctx.banksClient.getRent()
+    const acct = await ctx.banksClient.getAccount(configPda)
+    assert.ok(BigInt(acct!.lamports) >= rent.minimumBalance(BigInt(NEW_LEN)), 'rent-exempt at new size')
+  })
+
+  it('is idempotent: running on an already-migrated 101-byte config is a no-op', async () => {
+    // Plant a config that is ALREADY at the new 101-byte layout (pendingAuthority=None).
+    // Calling migrate_config on it must succeed (no-op path) and must not alter any field.
+    await plantNew(null)
+    await sendIx(ctx, [ixMigrateConfig(authority.publicKey)], [authority])
+    const cfg = parseVaultConfig(await getAccountData(ctx, configPda))
+    assert.strictEqual(cfg.pendingAuthority, null, 'pending_authority still null after no-op')
+    assert.strictEqual(cfg.feeBps, 10)
+    assert.strictEqual(cfg.totalDeposits, 0n)
+    assert.strictEqual(cfg.totalDepositors, 0n)
+  })
+
+  it('never clobbers a live pending_authority on an already-migrated config', async () => {
+    const pending = Keypair.generate().publicKey
+    await plantNew(pending)
+    await sendIx(ctx, [ixMigrateConfig(authority.publicKey)], [authority])
+    const cfg = parseVaultConfig(await getAccountData(ctx, configPda))
+    assert.ok(cfg.pendingAuthority?.equals(pending), 'pending_authority preserved (no-op path)')
+  })
+
+  it('rejects a non-authority signer (Unauthorized 6001/0x1771)', async () => {
+    await plantLegacy({ authority: authority.publicKey, feeBps: 10, refundTimeout: 86400n, paused: false, totalDeposits: 0n, totalDepositors: 0n })
+    const attacker = Keypair.generate()
+    await sendIx(ctx, [SystemProgram.transfer({ fromPubkey: authority.publicKey, toPubkey: attacker.publicKey, lamports: 5_000_000 })], [authority])
+    await assertFails(
+      () => sendIx(ctx, [ixMigrateConfig(attacker.publicKey)], [attacker]),
+      ['unauthorized', '1771'],
+    )
+  })
+
+  it('rejects a malformed (wrong-size) config account (InvalidConfigAccount 6014/0x177e)', async () => {
+    const d = Buffer.alloc(40)
+    configDisc.copy(d, 0)
+    authority.publicKey.toBuffer().copy(d, 8)
+    const rent = await ctx.banksClient.getRent()
+    ctx.setAccount(configPda, { lamports: Number(rent.minimumBalance(40n)), data: d, owner: VAULT_PROGRAM_ID, executable: false, rentEpoch: 0 })
+    await assertFails(
+      () => sendIx(ctx, [ixMigrateConfig(authority.publicKey)], [authority]),
+      ['invalidconfigaccount', '177e'],
+    )
+  })
+
+  it('migrated config is fully usable: update_fee succeeds afterward', async () => {
+    await plantLegacy({ authority: authority.publicKey, feeBps: 10, refundTimeout: 86400n, paused: false, totalDeposits: 0n, totalDepositors: 0n })
+    await sendIx(ctx, [ixMigrateConfig(authority.publicKey)], [authority])
+    await sendIx(ctx, [ixUpdateFee(authority.publicKey, 25)], [authority])
+    const cfg = parseVaultConfig(await getAccountData(ctx, configPda))
+    assert.strictEqual(cfg.feeBps, 25, 'typed handlers accept the migrated account')
+  })
+})

--- a/programs/sipher-vault/tests/sipher-vault/14-migrate-config.test.ts
+++ b/programs/sipher-vault/tests/sipher-vault/14-migrate-config.test.ts
@@ -138,6 +138,16 @@ describe('14 · migrate_config (B6 VaultConfig layout migration)', () => {
     assert.ok(cfg.pendingAuthority?.equals(pending), 'pending_authority preserved (no-op path)')
   })
 
+  it('rejects a non-authority signer even on an already-migrated config (no-op path stays gated)', async () => {
+    await plantNew(null)
+    const attacker = Keypair.generate()
+    await sendIx(ctx, [SystemProgram.transfer({ fromPubkey: authority.publicKey, toPubkey: attacker.publicKey, lamports: 5_000_000 })], [authority])
+    await assertFails(
+      () => sendIx(ctx, [ixMigrateConfig(attacker.publicKey)], [attacker]),
+      ['unauthorized', '1771'],
+    )
+  })
+
   it('rejects a non-authority signer (Unauthorized 6001/0x1771)', async () => {
     await plantLegacy({ authority: authority.publicKey, feeBps: 10, refundTimeout: 86400n, paused: false, totalDeposits: 0n, totalDepositors: 0n })
     const attacker = Keypair.generate()

--- a/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
+++ b/programs/sipher-vault/tests/sipher-vault/bankrun-helpers.ts
@@ -892,3 +892,24 @@ export function ixUpdateFee(
     data,
   })
 }
+
+/**
+ * migrate_config() — no args
+ *
+ * Accounts (MigrateConfig):
+ *   config         mut, PDA (UncheckedAccount — legacy layout)
+ *   authority      mut, signer
+ *   system_program
+ */
+export function ixMigrateConfig(authority: PublicKey): TransactionInstruction {
+  const [configPda] = getVaultConfigPDA(VAULT_PROGRAM_ID)
+  return new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: configPda, isSigner: false, isWritable: true },
+      { pubkey: authority, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data: disc('migrate_config'),
+  })
+}


### PR DESCRIPTION
Adds the authority-gated, idempotent `migrate_config` instruction that grows a legacy (pre-M1, 68-byte) `VaultConfig` to the current 101-byte layout **in place** — appending `pending_authority = None` via a zero-filling `resize()`. This enables an in-place B6 upgrade of the devnet program (`S1Phr5…`) without abandoning the program ID or changing the config PDA (`CpL4qy…`).

## What
- `migrate_config` handler — raw `UncheckedAccount` (the legacy account can't deserialize into `VaultConfig`; PDA verified via seeds+bump, authority read from bytes `[8..40]` and gated; idempotent no-op on already-migrated accounts so a live `pending_authority` is never clobbered; rent-delta top-up; `resize` 68→101 zero-fills offset 68 = `None`).
- `MigrateConfig` accounts struct, `VaultConfigMigratedEvent`, `LEGACY_VAULT_CONFIG_LEN = 68`, `VaultError::InvalidConfigAccount` (appended → 6014).
- `ixMigrateConfig` bankrun helper + 6 new tests.

## Tests
**45/45 bankrun passing** (39 existing + 6 new). Built with `cargo build-sbf --tools-version v1.52`.

## Follow-ups (same branch / separate repo, gated)
- Devnet in-place upgrade → run `migrate_config` → `create_sol_vault` → fill DEPLOYMENT.md (deploy-gated; added to this branch before merge).
- Downstream `sipher` IDL regen + `VaultError` renumber (separate PR, post-deploy).

Spec: `docs/superpowers/specs/2026-06-21-sipher-vault-migrate-config-redeploy-design.md`
Plan: `docs/superpowers/plans/2026-06-21-sipher-vault-migrate-config-redeploy.md`

Refs #1136.