### PR TITLE
chore(sipher-vault): record devnet fee-precision deploy + harden upgrade script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -819,7 +819,7 @@ solana program deploy target/deploy/sip_privacy.so \
 |---------|------------|------------|------|
 | **Devnet** | `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB` | `CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u` | 2026-03-31 |
 
-**Config:** Fee 10 bps, Refund timeout 86400s (24h), Authority `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr` (devnet wallet)
+**Config:** Fee 7.5 bps (`fee_tenths_bps = 75`; tenths-of-bps unit since the 2026-06-30 re-precision, #1213), Refund timeout 86400s (24h), Authority `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr` (devnet wallet)
 
 **Instructions (9):** `initialize`, `create_vault_token`, `create_fee_token`, `deposit`, `withdraw_private`, `refund`, `authority_refund`, `collect_fee`, `set_paused`
 

--- a/programs/sipher-vault/DEPLOYMENT.md
+++ b/programs/sipher-vault/DEPLOYMENT.md
@@ -151,6 +151,8 @@ In-place `BPFLoaderUpgradeable` upgrade to the tenths-of-bps fee binary (#1213),
 - **Verified on-chain:** config PDA `CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u` (101 bytes), `fee_tenths_bps @ offset 40 = 75` (= 7.5 bps), via `scripts/update-fee.ts` + `scripts/init-devnet.ts` + direct account decode.
 - Authority signed: `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr`
 
+> **Downstream IDL/SDK sync (pending):** this deploy renamed `VaultConfig.fee_bps` → `fee_tenths_bps` (same u16, offset 40) and used `--no-idl`, so the sipher repo's hand-synced IDL (`packages/sdk/src/idl/sipher_vault.json`) and any `feeBps`-presenting client code must be regenerated/updated for the rename before the `@sipher/sdk` republish. Off-chain tooling that reads the fee by Anchor field name (not raw offset) mislabels it until then.
+
 ## Mainnet Deployments
 
 _Not deployed. Mainnet deploy is gated on the self-audit completing (B6) — out of scope for this feature branch._
@@ -231,9 +233,11 @@ ANCHOR_PROVIDER_URL=https://api.devnet.solana.com \
 pnpm exec tsx scripts/upgrade-devnet.ts
 ```
 
-The script verifies the program keypair, runs `anchor build --no-idl` (incremental —
-preserves the IDL artifact), deploys via `BPFLoaderUpgradeable`, and prints the new
-deployed slot. Idempotent — running again redeploys.
+The script verifies the program keypair and the source `declare_id!`, runs
+`anchor build --no-idl --ignore-keys` (skips IDL regen during deploy and the
+declare_id-vs-local-keypair check — see the script comment), deploys via
+`BPFLoaderUpgradeable`, and prints the new deployed slot. Idempotent — running again
+redeploys.
 
 ### Initialize Native SOL Vault on Devnet
 

--- a/programs/sipher-vault/DEPLOYMENT.md
+++ b/programs/sipher-vault/DEPLOYMENT.md
@@ -140,6 +140,17 @@ In-place `BPFLoaderUpgradeable` upgrade of the **existing** program — B6 audit
 - **Config PDA (post-migration):** `CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u` — 101 bytes, deserializes as current `VaultConfig`.
 - Authority signed: `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr`
 
+### Devnet — Fee Re-Precision Upgrade (2026-06-30)
+
+In-place `BPFLoaderUpgradeable` upgrade to the tenths-of-bps fee binary (#1213), then `update_fee(75)` to reset the live fee 10 → 75 (7.5 bps) — run back-to-back to close the semantic-reset window. **Program ID and config PDA preserved.**
+
+- **Binary:** deployed via `scripts/upgrade-devnet.ts`; programdata `521368` bytes (within the `521413` allocated on 2026-06-22 — no extend needed).
+- **Upgrade TX:** `3STyKUKErpNLaDtFVs1mnKtYpa8bAhTHF17kwkd6eKhKKRY2DHXC4UomRFmsiDF6FvdeHX1poqiaHEoXVFv9kri9`
+- **New deployed slot:** `472907461` (was `471134934`).
+- **`update_fee(75)` TX:** `4vPtP4W8B8KFKeXHnWjWoux8NhdnF1ohJVu5DGWBdyEiajnUhNoS73UPQRRCEKHnb4SvooUKgqvWwDkeonFuxb78` — `fee_tenths_bps` 10 → 75.
+- **Verified on-chain:** config PDA `CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u` (101 bytes), `fee_tenths_bps @ offset 40 = 75` (= 7.5 bps), via `scripts/update-fee.ts` + `scripts/init-devnet.ts` + direct account decode.
+- Authority signed: `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr`
+
 ## Mainnet Deployments
 
 _Not deployed. Mainnet deploy is gated on the self-audit completing (B6) — out of scope for this feature branch._

--- a/programs/sipher-vault/scripts/upgrade-devnet.ts
+++ b/programs/sipher-vault/scripts/upgrade-devnet.ts
@@ -46,18 +46,15 @@ async function main() {
   }
 
   // 2. Build
-  // Note: `--no-idl` is required because anchor 0.30.1's IDL generator
-  // depends on `proc_macro2::Span::source_file()`, a nightly-only proc-macro
-  // API that has been removed from current host rustc (1.94+). The on-chain
-  // SBF binary builds correctly via Solana's pinned platform-tools toolchain;
-  // only the host-side IDL generation is affected.
-  //
-  // We deliberately skip `anchor clean` here: clean would wipe `target/idl/sipher_vault.json`
-  // (which downstream consumers like the agent SDK and UI depend on), and the `--no-idl`
-  // flag means we cannot regenerate it from this script. `anchor build` is incremental
-  // and reliable; a stale `.so` is not a realistic risk on a deploy script that already
-  // verifies the artifact's existence afterward.
-  run('anchor build --no-idl')
+  // `--no-idl`: skip IDL regeneration during deploy so the committed
+  // `target/idl/sipher_vault.json` (downstream consumers — the agent SDK, UI —
+  // depend on it) stays stable; regenerate it intentionally via `anchor build` /
+  // `anchor test` when the interface changes, not as a side effect of deploying.
+  // `--ignore-keys`: skip Anchor's declare_id-vs-`target/deploy/<name>-keypair.json`
+  // check. On a fresh checkout or a git worktree that keypair is auto-generated and
+  // won't match `declare_id!`, aborting the build; the deploy pins the program ID via
+  // `--program-id` below, so the source `declare_id!` is the authoritative ID.
+  run('anchor build --no-idl --ignore-keys')
 
   if (!existsSync(SO_FILE)) {
     throw new Error(`Build artifact missing: ${SO_FILE}`)

--- a/programs/sipher-vault/scripts/upgrade-devnet.ts
+++ b/programs/sipher-vault/scripts/upgrade-devnet.ts
@@ -6,7 +6,7 @@
 //
 // Usage: cd programs/sipher-vault && pnpm exec tsx scripts/upgrade-devnet.ts
 import { execSync } from 'child_process'
-import { existsSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
 import { homedir } from 'os'
 
 const PROGRAM_ID = 'S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB'
@@ -45,15 +45,27 @@ async function main() {
     throw new Error(`Program keypair ID ${idFromKey} != expected ${PROGRAM_ID}`)
   }
 
+  // 1b. Sanity: the source declare_id! matches the deploy target. --ignore-keys
+  // (below) skips Anchor's keypair-vs-declare_id check, so this is the guard that the
+  // built .so's baked-in program ID is S1Phr5 — a wrong declare_id! (bad merge/typo)
+  // would otherwise build a binary that deploys "successfully" but is bricked.
+  const libSrc = readFileSync('programs/sipher-vault/src/lib.rs', 'utf-8')
+  const declaredId = libSrc.match(/declare_id!\("([^"]+)"\)/)?.[1]
+  if (declaredId !== PROGRAM_ID) {
+    throw new Error(`Source declare_id! ${declaredId ?? '(not found)'} != expected ${PROGRAM_ID}`)
+  }
+
   // 2. Build
-  // `--no-idl`: skip IDL regeneration during deploy so the committed
-  // `target/idl/sipher_vault.json` (downstream consumers — the agent SDK, UI —
-  // depend on it) stays stable; regenerate it intentionally via `anchor build` /
-  // `anchor test` when the interface changes, not as a side effect of deploying.
+  // `--no-idl`: skip IDL generation during deploy. `target/idl/` is gitignored (the
+  // SDK consumes a hand-synced copy in the sipher repo), so the deploy only needs the
+  // `.so`; regenerate the IDL on demand via `anchor build` / `anchor idl build` and
+  // re-sync downstream when the interface changes. Under Anchor 1.0.2 this is a speed
+  // choice, not the 0.30.1-era necessity (see DEPLOYMENT.md "Build note").
   // `--ignore-keys`: skip Anchor's declare_id-vs-`target/deploy/<name>-keypair.json`
   // check. On a fresh checkout or a git worktree that keypair is auto-generated and
   // won't match `declare_id!`, aborting the build; the deploy pins the program ID via
-  // `--program-id` below, so the source `declare_id!` is the authoritative ID.
+  // `--program-id` below and we assert the source `declare_id!` matches it above, so the
+  // program ID is authoritative regardless of the local keypair.
   run('anchor build --no-idl --ignore-keys')
 
   if (!existsSync(SO_FILE)) {


### PR DESCRIPTION
Closes out the devnet fee-precision deploy (2026-06-30):

- DEPLOYMENT.md: adds the Fee Re-Precision Upgrade (2026-06-30) devnet record -- upgrade TX, update_fee(75) TX, new slot 472907461, and on-chain-verified fee_tenths_bps = 75 (= 7.5 bps).
- scripts/upgrade-devnet.ts: adds --ignore-keys to anchor build so a fresh checkout or git worktree (auto-generated target/deploy keypair that does not match declare_id) no longer aborts the build. The deploy pins the program ID via --program-id, so declare_id is authoritative. Also refreshes the stale --no-idl comment (it cited anchor 0.30.1; we are on 1.0.2).

Follow-up to #1213. Devnet vault now charges 7.5 bps (was 10), verified on-chain. Docs + deploy-script only -- no program/code changes.